### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Validate Pull Requests
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -1,4 +1,6 @@
 name: Algolia Search
+permissions:
+  contents: read
 
 on:
   # Allow to run manually

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -188,9 +188,8 @@ const config: Config = {
     },
     prism: { theme: prismThemes.github, darkTheme: prismThemes.dracula, additionalLanguages: ['solidity'] },
     algolia: {
-      // Search only api key
-      apiKey: process.env.ALGOLIA_API_KEY || '',
-      appId: process.env.ALGOLIA_APP_ID || '',
+      appId: process.env.ALGOLIA_APP_ID || 'QHFGNYFTED',
+      apiKey: process.env.ALGOLIA_API_KEY || 'a279745db091a62dd51ec3212d11a5d0', // SEARCH ONLY api key
       indexName: 'docs',
     },
     mermaid: { theme: { light: 'forest', dark: 'dark' } },

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -189,9 +189,9 @@ const config: Config = {
     prism: { theme: prismThemes.github, darkTheme: prismThemes.dracula, additionalLanguages: ['solidity'] },
     algolia: {
       // Search only api key
-      apiKey: '2c367ae53326c8a85e805323aee56a75',
+      apiKey: process.env.ALGOLIA_API_KEY || '',
+      appId: process.env.ALGOLIA_APP_ID || '',
       indexName: 'docs',
-      appId: 'R1BEZXQES6',
     },
     mermaid: { theme: { light: 'forest', dark: 'dark' } },
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
Potential fix for [https://github.com/NiftyLeague/nifty-fe-monorepo/security/code-scanning/8](https://github.com/NiftyLeague/nifty-fe-monorepo/security/code-scanning/8)

To address this issue, add a `permissions` block restricting the GITHUB_TOKEN scope as much as possible. Since the workflow only checks out repository content and does not appear to write to issues, pull requests, or other resources, the minimal permission `contents: read` should be set. This can be added either at the root level (applying to all jobs in the workflow) or specifically under the `jobs.search` job if only that job exists. For clarity and future extensibility, the best fix is to add at the root level after the workflow name and before `on:`.

Required changes:
- Add a `permissions:` block with `contents: read` after the workflow name (line 1 or 2).

No other imports, methods, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
