### PR TITLE
test: increase coverage and raise regression floors

### DIFF
--- a/apps/app/src/utils/file.test.ts
+++ b/apps/app/src/utils/file.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { saveAsMock } = vi.hoisted(() => ({ saveAsMock: vi.fn() }));
+
+vi.mock('save-as', () => ({ saveAs: saveAsMock }));
+vi.mock('@/constants/url', () => ({ DEGEN_ASSETS_DOWNLOAD_URL: 'https://assets.example/degen' }));
+
+import { downloadDegenAsZip } from './file';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('downloadDegenAsZip', () => {
+  it('downloads base64 data and saves it as a ZIP blob', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ text: vi.fn().mockResolvedValue('UEs=') });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await downloadDegenAsZip('auth-token', 42);
+
+    expect(fetchMock).toHaveBeenCalledWith('https://assets.example/degen?id=42', {
+      headers: { authorizationToken: 'auth-token' },
+    });
+    const [blob, filename] = saveAsMock.mock.calls[0] as [Blob, string];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/zip');
+    expect(blob.size).toBe(2);
+    expect(filename).toBe('degen_42.zip');
+  });
+
+  it('rejects when invoked without a browser window', async () => {
+    const currentWindow = window;
+    vi.stubGlobal('window', undefined);
+
+    await expect(downloadDegenAsZip('token', 1)).rejects.toThrow('Window undefined');
+    vi.stubGlobal('window', currentWindow);
+  });
+});

--- a/apps/app/src/utils/transactions.test.ts
+++ b/apps/app/src/utils/transactions.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { calculateGasMarginMock, loadGasPriceMock, toastError, toastInfo, toastSuccess } = vi.hoisted(() => ({
+  calculateGasMarginMock: vi.fn(() => 123n),
+  loadGasPriceMock: vi.fn().mockResolvedValue(25n),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('react-toastify', () => ({ toast: { error: toastError, info: toastInfo, success: toastSuccess } }));
+vi.mock('eth-rpc-errors', () => ({
+  serializeError: (error: unknown) => ({ message: `serialized: ${String(error)}` }),
+}));
+vi.mock('@/constants/index', () => ({ DEBUG: false }));
+vi.mock('@/constants/networks', () => ({ TARGET_NETWORK: { label: 'Local', gasPrice: undefined } }));
+vi.mock('@/utils/gas', () => ({ calculateGasMargin: calculateGasMarginMock, loadGasPrice: loadGasPriceMock }));
+
+import { handleError, handleLocalNotify, sendTransaction, submitTxWithGasEstimate } from './bnc-notify';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+describe('handleError', () => {
+  it('uses direct and serialized error messages', () => {
+    handleError({ message: 'rejected' });
+    handleError({ code: -1 } as never);
+
+    expect(toastError).toHaveBeenCalledTimes(2);
+    expect(toastError.mock.calls[0]?.[1]).toMatchObject({ data: 'rejected', theme: 'dark' });
+    expect(toastError.mock.calls[1]?.[1].data).toContain('serialized:');
+  });
+
+  it.each(['There was a WebSocket error', 'Configuration with scope local failed'])(
+    'suppresses non-actionable transport errors: %s',
+    message => {
+      handleError({ message });
+      expect(toastError).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('submitTxWithGasEstimate', () => {
+  it('estimates gas, applies the margin, and submits the contract result', async () => {
+    const contractFn = Object.assign(vi.fn().mockReturnValue('contract-call'), {
+      estimateGas: vi.fn().mockResolvedValue(100n),
+    });
+    const tx = vi.fn().mockResolvedValue({ hash: '0xsubmitted' });
+    const callback = vi.fn();
+
+    await expect(
+      submitTxWithGasEstimate(tx, { mint: contractFn } as never, 'mint', [7], { value: 2n }, 80n, callback),
+    ).resolves.toEqual({ hash: '0xsubmitted' });
+    expect(calculateGasMarginMock).toHaveBeenCalledWith(100n, 80n);
+    expect(contractFn).toHaveBeenCalledWith(7, { value: 2n, gasLimit: 123n });
+    expect(tx).toHaveBeenCalledWith('contract-call', callback);
+  });
+
+  it('reports estimate failures and validates the requested method', async () => {
+    const contractFn = Object.assign(vi.fn(), {
+      estimateGas: vi.fn().mockRejectedValue({ error: { message: 'estimate failed' } }),
+    });
+
+    await expect(submitTxWithGasEstimate(vi.fn(), { mint: contractFn } as never, 'mint', [])).resolves.toBeUndefined();
+    expect(toastError.mock.calls[0]?.[1]).toMatchObject({ data: 'estimate failed' });
+    expect(() => submitTxWithGasEstimate(vi.fn(), {} as never, 'missing', [])).toThrow(
+      'Function missing is not available',
+    );
+
+    const withoutEstimate = vi.fn();
+    expect(() => submitTxWithGasEstimate(vi.fn(), { mint: withoutEstimate } as never, 'mint', [])).toThrow(
+      'Function Estimate Gas is not available on mint',
+    );
+  });
+});
+
+describe('sendTransaction', () => {
+  it('awaits an already-created transaction', async () => {
+    const result = { hash: '0xpromise' };
+    await expect(sendTransaction({} as never, Promise.resolve(result) as never)).resolves.toBe(result);
+  });
+
+  it('fills default gas fields before asking the signer to send', async () => {
+    const result = { hash: '0xsent' };
+    const sendTransactionMock = vi.fn().mockResolvedValue(result);
+
+    await expect(
+      sendTransaction({ sendTransaction: sendTransactionMock } as never, { to: '0xabc' } as never),
+    ).resolves.toBe(result);
+    expect(loadGasPriceMock).toHaveBeenCalled();
+    expect(sendTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: '0xabc', gasPrice: 25n, gasLimit: '0x01d4c0' }),
+    );
+  });
+});
+
+describe('handleLocalNotify', () => {
+  it('waits for confirmation, emits notifications, and calls back with the receipt', async () => {
+    const receipt = { status: 1 };
+    const callback = vi.fn();
+    const result = { hash: '0xconfirmed', wait: vi.fn().mockResolvedValue(receipt) };
+    const signer = { provider: { getTransactionReceipt: vi.fn().mockResolvedValue(receipt) } };
+
+    await handleLocalNotify(signer as never, result as never, callback);
+
+    expect(result.wait).toHaveBeenCalled();
+    expect(toastInfo).toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(receipt);
+  });
+
+  it('does not request a receipt when no callback is supplied', async () => {
+    const getTransactionReceipt = vi.fn();
+    await handleLocalNotify(
+      { provider: { getTransactionReceipt } } as never,
+      { hash: '0xconfirmed', wait: vi.fn().mockResolvedValue(undefined) } as never,
+    );
+
+    expect(getTransactionReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/visibility.test.tsx
+++ b/packages/ui/src/hooks/visibility.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOnScreen } from './useOnScreen';
+import { useParallax } from './useParallax';
+
+describe('useOnScreen', () => {
+  let intersectionCallback: IntersectionObserverCallback;
+  const observe = vi.fn();
+  const unobserve = vi.fn();
+
+  beforeEach(() => {
+    observe.mockReset();
+    unobserve.mockReset();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe = observe;
+        unobserve = unobserve;
+      },
+    );
+  });
+
+  it('observes the referenced element, updates visibility, and cleans up', () => {
+    const element = document.createElement('div');
+    const ref = { current: element };
+    const { result, unmount } = renderHook(() => useOnScreen(ref, '20px'));
+
+    expect(observe).toHaveBeenCalledWith(element);
+    act(() => intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never));
+    expect(result.current).toBe(true);
+    unmount();
+    expect(unobserve).toHaveBeenCalledWith(element);
+  });
+
+  it('stays false when no element is mounted', () => {
+    expect(renderHook(() => useOnScreen({ current: null })).result.current).toBe(false);
+    expect(observe).not.toHaveBeenCalled();
+  });
+});
+
+describe('useParallax', () => {
+  function elementWithTop(top: number, withChild = true) {
+    const element = document.createElement('div');
+    if (withChild) {
+      const child = document.createElement('span');
+      child.className = 'parallax-child';
+      element.append(child);
+    }
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({ top } as DOMRect);
+    return element;
+  }
+
+  it('applies vertical movement to the child and removes its scroll listener', () => {
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+    const element = elementWithTop(100);
+    const { unmount } = renderHook(() =>
+      useParallax({ current: element }, { enabled: true, direction: 'down', intensity: 'strong' }),
+    );
+
+    expect((element.firstElementChild as HTMLElement).style.transform).toBe(
+      `translateY(${(-100 * 100 * 2) / window.innerHeight}px)`,
+    );
+    expect(window.addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+    unmount();
+    expect(window.removeEventListener).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+
+  it('supports horizontal movement and falls back to the element itself', () => {
+    const element = elementWithTop(50, false);
+    renderHook(() => useParallax({ current: element }, { enabled: true, direction: 'right', intensity: 'lite' }));
+
+    expect(element.style.transform).toBe(`translateX(${(-50 * 100 * 0.5) / window.innerHeight}px)`);
+  });
+
+  it('does nothing while disabled or before the ref is mounted', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    renderHook(() => useParallax({ current: null }, { enabled: true, direction: 'up', intensity: 'normal' }));
+    renderHook(() =>
+      useParallax({ current: elementWithTop(10) }, { enabled: false, direction: 'left', intensity: 'extreme' }),
+    );
+
+    expect(addEventListener).not.toHaveBeenCalledWith('scroll', expect.any(Function), expect.anything());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
         'apps/app/src/constants/leaderboards/leaderboard-*.ts',
       ],
       excludeAfterRemap: true,
-      thresholds: coverageScope ? undefined : { branches: 25, functions: 25, lines: 25, statements: 25 },
+      thresholds: coverageScope ? undefined : { branches: 26, functions: 26, lines: 27, statements: 27 },
     },
   },
 });


### PR DESCRIPTION
## Summary

- add transaction-flow tests for gas estimation, signing, notifications, error handling, and receipts
- add browser download tests plus intersection/parallax hook coverage
- raise all enforced coverage floors to the new measured baseline

## Coverage

| Metric | Before | After | Enforced floor |
| --- | ---: | ---: | ---: |
| Statements | 26.10% | 27.57% | 27% |
| Branches | 25.01% | 26.05% | 26% |
| Functions | 25.15% | 26.14% | 26% |
| Lines | 26.30% | 27.76% | 27% |

The full suite now runs 206 tests.

## Validation

- `pnpm test:coverage`
- `pnpm format:check`
- `pnpm lint`
- app and UI package type-checks and tests
