### PR TITLE
perf: cache Next.js build state in Turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,7 @@
     "app#build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_RUNTIME", "NEXT_PUBLIC_*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**"]
     },
     "docs#build": {
       "cache": false,
@@ -39,12 +39,12 @@
     "smashers#build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_RUNTIME", "NEXT_PUBLIC_*", "NEXTAUTH_SECRET"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**"]
     },
     "web#build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_RUNTIME", "NEXT_PUBLIC_*", "EDGE_CONFIG"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**"]
     },
     "clean": { "cache": false },
     "transit": { "dependsOn": ["^transit"] },


### PR DESCRIPTION
## Summary\n- include Next.js build cache in Turbo outputs\n- measure whether remote Turbo caching improves subsequent builds\n\nThis is an optimization experiment; merge only if the Build check and cache behavior improve.