### PR TITLE
perf: test Bun global virtual store

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,7 @@
 preload = ["./test/happy-dom-setup.ts", "./test/preload.ts", "./test/setup.ts"]
 exclude = ["dist/**", "node_modules/**", "coverage/**", "**/*.test.js", "**/*.spec.js", ".next/**", ".docusaurus/**", "build/**"]
 timeout = 15000
+
+[install]
+linker = "isolated"
+globalStore = true


### PR DESCRIPTION
## Summary\n- opt this monorepo into Bun's isolated global virtual store\n- measure install/build/test behavior on GitHub-hosted runners\n\nThis is an optimization experiment; merge only if install time improves and all checks remain green.