### PR TITLE
perf: sparse-checkout CodeQL detector

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,16 @@ jobs:
           # Detection only reads Git trees, paths, and small profile files;
           # defer source blob transfer until the analyzer jobs.
           filter: blob:none
+          sparse-checkout: |
+            .github
+            .mise.toml
+            mise.lock
+            package.json
+            bun.lock
+            bun.lockb
+            pnpm-lock.yaml
+            yarn.lock
+            package-lock.json
       - id: languages
         name: Detect languages
         env:


### PR DESCRIPTION
## Summary\n- sparse-checkout only the metadata and manifests needed by CodeQL detection\n- keep analyzer jobs on full checkouts\n- measure detection time on the large frontend monorepo\n\nThis is an optimization experiment; merge only if detection remains correct and materially faster.