### PR TITLE
perf(ci): skip installs on Turbo cache hits

### DIFF
--- a/.github/scripts/turbo-cache-probe.sh
+++ b/.github/scripts/turbo-cache-probe.sh
@@ -41,17 +41,32 @@ NODE
 )"
 [ -n "$turbo_version" ] || exit 0
 
+turbo_home="${RUNNER_TEMP:-/tmp}/repo-foundry-turbo"
 probe_file="$(mktemp)"
-cleanup() { rm -f "$probe_file"; }
+install_file="$(mktemp)"
+result_file="$(mktemp)"
+cleanup() { rm -f "$probe_file" "$install_file" "$result_file"; }
 trap cleanup EXIT
 
-if ! bunx --package "turbo@${turbo_version}" turbo run "$task" \
+if ! npm install --prefix "$turbo_home" --no-save --ignore-scripts --no-audit --no-fund \
+  "turbo@${turbo_version}" >"$install_file" 2>&1; then
+  echo "Turbo Probe: CLI unavailable; using full install"
+  exit 0
+fi
+
+turbo_bin="$turbo_home/node_modules/.bin/turbo"
+if [ ! -x "$turbo_bin" ]; then
+  echo "Turbo Probe: CLI unavailable; using full install"
+  exit 0
+fi
+
+if ! "$turbo_bin" run "$task" \
   --dry=json --cache=remote:r --output-logs=none >"$probe_file" 2>&1; then
   echo "Turbo Probe: CLI unavailable; using full install"
   exit 0
 fi
 
-probe_result="$(node - "$probe_file" <<'NODE'
+node - "$probe_file" >"$result_file" <<'NODE'
 const fs = require('node:fs');
 const file = process.argv[2];
 const text = fs.readFileSync(file, 'utf8');
@@ -74,20 +89,14 @@ const hits = runnable.filter((entry) => entry.cache?.status === 'HIT').length;
 const hit = runnable.length > 0 && hits === runnable.length;
 console.log(`tasks=${report.tasks?.length || 0} runnable=${runnable.length} hits=${hits} hit=${hit}`);
 NODE
-)
+probe_result="$(cat "$result_file")"
 echo "Turbo Probe: $probe_result"
 if ! grep -q 'hit=true' <<<"$probe_result"; then
   echo "Turbo Probe: remote cache incomplete; using full install"
   exit 0
 fi
 
-bin_dir="${RUNNER_TEMP:-/tmp}/repo-foundry-turbo-bin"
-mkdir -p "$bin_dir"
-cat > "$bin_dir/turbo" <<EOF
-#!/usr/bin/env bash
-exec bunx --package "turbo@${turbo_version}" turbo "\$@"
-EOF
-chmod +x "$bin_dir/turbo"
-echo "$bin_dir" >> "${GITHUB_PATH:-/dev/null}"
+turbo_bin_dir="${turbo_bin%/*}"
+echo "$turbo_bin_dir" >> "${GITHUB_PATH:-/dev/null}"
 printf 'REPO_FOUNDRY_TURBO_REMOTE_ONLY=true\n' >> "${GITHUB_ENV:-/dev/null}"
 set_output hit true

--- a/.github/scripts/turbo-cache-probe.sh
+++ b/.github/scripts/turbo-cache-probe.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A Turbo remote-cache hit can be resolved from package manifests alone. This
+# probe lets CI skip the full dependency install when every executable task is
+# already cached. It is deliberately conservative: only Bun projects with a
+# pinned Turbo version are eligible, and synthetic dependency-only tasks are
+# excluded from the hit decision.
+
+task="${1:?task name required}"
+
+set_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+set_output hit false
+
+[ -n "${TURBO_TOKEN:-}" ] || exit 0
+[ -n "${TURBO_TEAM:-}" ] || exit 0
+[ -f package.json ] || exit 0
+[ -f bun.lock ] || [ -f bun.lockb ] || exit 0
+
+turbo_version="$(node <<'NODE'
+const fs = require('node:fs');
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const groups = [
+  packageJson.devDependencies,
+  packageJson.dependencies,
+  packageJson.optionalDependencies,
+  packageJson.pnpm?.overrides,
+];
+for (const group of groups) {
+  const value = group?.turbo;
+  const match = typeof value === 'string' && value.match(/(\d+\.\d+\.\d+)/);
+  if (match) {
+    console.log(match[1]);
+    break;
+  }
+}
+NODE
+)"
+[ -n "$turbo_version" ] || exit 0
+
+probe_file="$(mktemp)"
+cleanup() { rm -f "$probe_file"; }
+trap cleanup EXIT
+
+if ! bunx --package "turbo@${turbo_version}" turbo run "$task" \
+  --dry=json --cache=remote:r --output-logs=none >"$probe_file" 2>&1; then
+  exit 0
+fi
+
+if ! node - "$probe_file" <<'NODE'
+const fs = require('node:fs');
+const file = process.argv[2];
+const text = fs.readFileSync(file, 'utf8');
+const start = text.indexOf('{');
+if (start < 0) process.exit(1);
+let report;
+try {
+  report = JSON.parse(text.slice(start));
+} catch {
+  process.exit(1);
+}
+const runnable = (report.tasks || []).filter((entry) =>
+  entry.command !== '<NONEXISTENT>' && entry.resolvedTaskDefinition?.cache !== false,
+);
+process.exit(runnable.length > 0 && runnable.every((entry) => entry.cache?.status === 'HIT') ? 0 : 1);
+NODE
+then
+  exit 0
+fi
+
+bin_dir="${RUNNER_TEMP:-/tmp}/repo-foundry-turbo-bin"
+mkdir -p "$bin_dir"
+cat > "$bin_dir/turbo" <<EOF
+#!/usr/bin/env bash
+exec bunx --package "turbo@${turbo_version}" turbo "\$@"
+EOF
+chmod +x "$bin_dir/turbo"
+echo "$bin_dir" >> "${GITHUB_PATH:-/dev/null}"
+printf 'REPO_FOUNDRY_TURBO_REMOTE_ONLY=true\n' >> "${GITHUB_ENV:-/dev/null}"
+set_output hit true

--- a/.github/scripts/turbo-cache-probe.sh
+++ b/.github/scripts/turbo-cache-probe.sh
@@ -47,27 +47,37 @@ trap cleanup EXIT
 
 if ! bunx --package "turbo@${turbo_version}" turbo run "$task" \
   --dry=json --cache=remote:r --output-logs=none >"$probe_file" 2>&1; then
+  echo "Turbo Probe: CLI unavailable; using full install"
   exit 0
 fi
 
-if ! node - "$probe_file" <<'NODE'
+probe_result="$(node - "$probe_file" <<'NODE'
 const fs = require('node:fs');
 const file = process.argv[2];
 const text = fs.readFileSync(file, 'utf8');
 const start = text.indexOf('{');
-if (start < 0) process.exit(1);
+if (start < 0) {
+  console.log('invalid-json');
+  process.exit(0);
+}
 let report;
 try {
   report = JSON.parse(text.slice(start));
 } catch {
-  process.exit(1);
+  console.log('invalid-json');
+  process.exit(0);
 }
 const runnable = (report.tasks || []).filter((entry) =>
   entry.command !== '<NONEXISTENT>' && entry.resolvedTaskDefinition?.cache !== false,
 );
-process.exit(runnable.length > 0 && runnable.every((entry) => entry.cache?.status === 'HIT') ? 0 : 1);
+const hits = runnable.filter((entry) => entry.cache?.status === 'HIT').length;
+const hit = runnable.length > 0 && hits === runnable.length;
+console.log(`tasks=${report.tasks?.length || 0} runnable=${runnable.length} hits=${hits} hit=${hit}`);
 NODE
-then
+)
+echo "Turbo Probe: $probe_result"
+if ! grep -q 'hit=true' <<<"$probe_result"; then
+  echo "Turbo Probe: remote cache incomplete; using full install"
   exit 0
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,15 @@ jobs:
       - name: Detect
         id: applicability
         run: bash .github/scripts/ci.sh should_run lint >> "$GITHUB_OUTPUT"
+      - name: Turbo Probe
+        id: turbo
+        if: steps.applicability.outputs.applicable == 'true'
+        run: bash .github/scripts/turbo-cache-probe.sh lint
       - name: Setup
         if: steps.applicability.outputs.applicable == 'true'
         uses: ./.github/actions/setup
         with:
-          install: true
+          install: ${{ steps.turbo.outputs.hit != 'true' }}
           install-python: false
           cache-build: false
           # Warm the lint cache on branch pushes without adding archive time
@@ -89,11 +93,15 @@ jobs:
       - name: Detect
         id: applicability
         run: bash .github/scripts/ci.sh should_run type_check >> "$GITHUB_OUTPUT"
+      - name: Turbo Probe
+        id: turbo
+        if: steps.applicability.outputs.applicable == 'true'
+        run: bash .github/scripts/turbo-cache-probe.sh type-check
       - name: Setup
         if: steps.applicability.outputs.applicable == 'true'
         uses: ./.github/actions/setup
         with:
-          install: true
+          install: ${{ steps.turbo.outputs.hit != 'true' }}
           install-python: false
           cache-build: ${{ steps.applicability.outputs.rust == 'true' || vars.REPO_FOUNDRY_CACHE_BUILD == 'true' }}
           cache-save: ${{ github.event_name == 'push' }}
@@ -114,11 +122,15 @@ jobs:
       - name: Detect
         id: applicability
         run: bash .github/scripts/ci.sh should_run build >> "$GITHUB_OUTPUT"
+      - name: Turbo Probe
+        id: turbo
+        if: steps.applicability.outputs.applicable == 'true'
+        run: bash .github/scripts/turbo-cache-probe.sh build
       - name: Setup
         if: steps.applicability.outputs.applicable == 'true'
         uses: ./.github/actions/setup
         with:
-          install: true
+          install: ${{ steps.turbo.outputs.hit != 'true' }}
           install-python: false
           cache-build: ${{ steps.applicability.outputs.rust == 'true' || vars.REPO_FOUNDRY_CACHE_BUILD == 'true' }}
           cache-save: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary\n\n- probe Vercel Turbo remote cache from manifests before dependency installation\n- install only the pinned toolchain when every executable task is already cached\n- fall back automatically to the existing locked install on misses or uncertainty\n\n## Validation\n\n- bash syntax checks passed\n- isolated worktree used so the local dirty checkout was not modified