### PR TITLE
perf(ci): bootstrap direct Prettier

### DIFF
--- a/.github/scripts/format-fast-path.sh
+++ b/.github/scripts/format-fast-path.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap only the formatter for Bun projects whose repository-owned format
+# script directly invokes Prettier. The workflow keeps a full-install fallback
+# because formatter configs may import arbitrary repository dependencies.
+
+set_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+set_output hit false
+
+[ -f package.json ] || exit 0
+[ -f bun.lock ] || [ -f bun.lockb ] || exit 0
+
+format_script="$(node <<'NODE'
+const fs = require('node:fs');
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+console.log(packageJson.scripts?.['format:check'] || packageJson.scripts?.format || '');
+NODE
+)"
+if ! grep -Eiq '(^|[[:space:];&|])prettier([[:space:]]|$)' <<<"$format_script" ||
+  grep -Eiq '(^|[[:space:];&|])turbo([[:space:]]|$)' <<<"$format_script"; then
+  exit 0
+fi
+
+prettier_version="$(node <<'NODE'
+const fs = require('node:fs');
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+for (const group of [packageJson.devDependencies, packageJson.dependencies, packageJson.optionalDependencies]) {
+  const value = group?.prettier;
+  const match = typeof value === 'string' && value.match(/(\d+\.\d+\.\d+)/);
+  if (match) {
+    console.log(match[1]);
+    break;
+  }
+}
+NODE
+)"
+[ -n "$prettier_version" ] || exit 0
+
+tool_home="${RUNNER_TEMP:-/tmp}/repo-foundry-format"
+install_log="$(mktemp)"
+cleanup() { rm -f "$install_log"; }
+trap cleanup EXIT
+
+if ! npm install --prefix "$tool_home" --no-save --ignore-scripts --no-audit --no-fund \
+  "prettier@${prettier_version}" >"$install_log" 2>&1; then
+  echo 'Format Probe: formatter bootstrap unavailable; using full install'
+  exit 0
+fi
+
+tool_bin="$tool_home/node_modules/.bin"
+if [ ! -x "$tool_bin/prettier" ]; then
+  echo 'Format Probe: formatter binary unavailable; using full install'
+  exit 0
+fi
+
+echo "$tool_bin" >> "${GITHUB_PATH:-/dev/null}"
+printf 'REPO_FOUNDRY_FORMAT_FAST=true\n' >> "${GITHUB_ENV:-/dev/null}"
+echo "Format Probe: using Prettier ${prettier_version} without project install"
+set_output hit true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,15 @@ jobs:
       - name: Detect
         id: applicability
         run: bash .github/scripts/ci.sh should_run format >> "$GITHUB_OUTPUT"
+      - name: Format Probe
+        id: format-probe
+        if: steps.applicability.outputs.applicable == 'true'
+        run: bash .github/scripts/format-fast-path.sh
       - name: Setup
         if: steps.applicability.outputs.applicable == 'true'
         uses: ./.github/actions/setup
         with:
-          install: true
+          install: ${{ steps.format-probe.outputs.hit != 'true' }}
           install-python: false
           install-rust: false
           cache-build: false
@@ -47,6 +51,28 @@ jobs:
           task: format
       - name: Format
         if: steps.applicability.outputs.applicable == 'true'
+        id: format-fast
+        continue-on-error: ${{ steps.format-probe.outputs.hit == 'true' }}
+        run: bash .github/scripts/ci.sh format
+      - name: Setup Fallback
+        if: >-
+          steps.applicability.outputs.applicable == 'true' &&
+          steps.format-probe.outputs.hit == 'true' &&
+          steps.format-fast.outcome == 'failure'
+        uses: ./.github/actions/setup
+        with:
+          install: true
+          install-python: false
+          install-rust: false
+          cache-build: false
+          cache-save: false
+          cache-format: true
+          task: format
+      - name: Format Fallback
+        if: >-
+          steps.applicability.outputs.applicable == 'true' &&
+          steps.format-probe.outputs.hit == 'true' &&
+          steps.format-fast.outcome == 'failure'
         run: bash .github/scripts/ci.sh format
 
   lint:


### PR DESCRIPTION
## Summary\n\n- bootstrap only the pinned Prettier CLI for direct Bun format scripts\n- skip the full project install when the lightweight formatter path passes\n- retry with the existing full setup automatically if the lightweight path fails\n\n## Validation\n\n- isolated worktree passed the real format:check without project node_modules\n- bash syntax checks passed