### PR TITLE
chore(ci): use Code Foundry v0.34.9

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.34.8
+runtime_ref: v0.34.9
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.8
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.9
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-pr:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.8
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.9
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.8
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.9
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.8
+      runtime-ref: v0.34.9
     secrets:
       CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 0xPlayerOne/code-foundry
-          ref: v0.34.8
+          ref: v0.34.9
           path: .github/.code-foundry
           sparse-checkout: |
             src/lib
@@ -64,11 +64,11 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.8
+    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.9
     with:
       mode: ${{ needs.mode.outputs.mode }}
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.8
+      runtime-ref: v0.34.9
       ci-runner: ubuntu-latest
       test-runner: ubuntu-latest
       unit-runner: ubuntu-slim


### PR DESCRIPTION
## Summary

Update all generated Code Foundry workflow pins and runtime metadata from v0.34.8 to v0.34.9.

This includes token-aware release promotion for organizations that reject long-lived fine-grained tokens.

## Validation

- Only five generated Code Foundry files changed
- Vercel and repository-owned workflows preserved
- Required checks must pass before staging merge