### PR TITLE
Promote staging -> main (2026-08-02)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       github-actions:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: npm
     directory: /
@@ -19,6 +20,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       npm-dependencies:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: cargo
     directory: /
@@ -29,6 +31,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       cargo-dependencies:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: pip
     directory: /
@@ -39,4 +42,5 @@ updates:
     open-pull-requests-limit: 99
     groups:
       python-dependencies:
+        applies-to: version-updates
         patterns: ['*']


### PR DESCRIPTION
## Summary

Promote the validated staging branch into main.

This promotion includes the Code Foundry v0.34.9 upgrade and repository workflow/configuration updates already validated on staging.

## Merge policy

- Preserve the linear staging-to-main promotion history.
- Do not squash this environment promotion.