### PR TITLE
fix(ci): use Code Foundry v0.34.12 on main

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.34.11
+runtime_ref: v0.34.12
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.12
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.11
+      runtime-ref: v0.34.12
     secrets:
       CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 0xPlayerOne/code-foundry
-          ref: v0.34.11
+          ref: v0.34.12
           path: .github/.code-foundry
           sparse-checkout: |
             src/lib
@@ -64,11 +64,11 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.12
     with:
       mode: ${{ needs.mode.outputs.mode }}
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.11
+      runtime-ref: v0.34.12
       ci-runner: ubuntu-latest
       test-runner: ubuntu-latest
       unit-runner: ubuntu-slim


### PR DESCRIPTION
## Summary
- pin the generated Code Foundry callers and runtime to v0.34.12
- keep main on the same reconciliation-safe runtime as staging

## Validation
- exactly three generated files changed
- no v0.34.11 pins remain