### PR TITLE
chore(ci): align Code Foundry release policy

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -6,7 +6,7 @@ package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
 runtime_ref: v0.34.13
 runner: ubuntu-latest
-unit_runner: ubuntu-slim
+unit_runner: ubuntu-latest
 ci_runner: ubuntu-latest
 test_runner: ubuntu-latest
 security_runner: ubuntu-slim

--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.34.12
+runtime_ref: v0.34.13
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest
@@ -35,4 +35,4 @@ custom_workflows: preserve
 codeql_rust_shards: '["all"]'
 codeql_rust_threads: 1
 codeql_rust_max_parallel: 1
-release_merge_strategy: squash
+release_merge_strategy: rebase

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.13
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-pr:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.13
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.12
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.13
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.12
+      runtime-ref: v0.34.13
     secrets:
       CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 0xPlayerOne/code-foundry
-          ref: v0.34.12
+          ref: v0.34.13
           path: .github/.code-foundry
           sparse-checkout: |
             src/lib
@@ -64,11 +64,11 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.12
+    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.34.13
     with:
       mode: ${{ needs.mode.outputs.mode }}
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.12
+      runtime-ref: v0.34.13
       ci-runner: ubuntu-latest
       test-runner: ubuntu-latest
       unit-runner: ubuntu-slim


### PR DESCRIPTION
Align the consumer with Code Foundry v0.34.13 and the repository merge rules:

- pin generated Code Foundry workflow references to v0.34.13
- require rebase for Release Please version PRs into main

Only standard Code Foundry references and .github/code-foundry.yml are changed. Repository-owned custom workflows remain intact.