### PR TITLE
fix(deps): refresh audited transitive packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
     },
     "apps/app": {
       "name": "app",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "^0.21.0",
         "@cowprotocol/cow-sdk": "^9.2.6",
@@ -111,7 +111,7 @@
     },
     "apps/docs": {
       "name": "docs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/faster": "^3.10.2",
@@ -140,7 +140,7 @@
     },
     "apps/smashers": {
       "name": "smashers",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@nl/playfab": "workspace:*",
         "@nl/ui": "workspace:*",
@@ -165,7 +165,7 @@
     },
     "apps/template": {
       "name": "template",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@nl/ui": "workspace:*",
         "next": "16.2.12",
@@ -180,7 +180,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@google/model-viewer": "^4.3.1",
         "@nl/ui": "workspace:*",
@@ -203,7 +203,7 @@
     },
     "packages/eslint-config": {
       "name": "@nl/eslint-config",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
@@ -219,7 +219,7 @@
     },
     "packages/imx-passport": {
       "name": "@nl/imx-passport",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@imtbl/sdk": "^2.24.4",
       },
@@ -229,7 +229,7 @@
     },
     "packages/playfab": {
       "name": "@nl/playfab",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@nl/ui": "workspace:*",
         "ethers": "^6.17.0",
@@ -254,11 +254,11 @@
     },
     "packages/prettier-config": {
       "name": "@nl/prettier-config",
-      "version": "0.0.0",
+      "version": "1.0.0",
     },
     "packages/theme": {
       "name": "@nl/theme",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@nl/ui": "workspace:*",
         "react-intl": "^10.1.19",
@@ -282,11 +282,11 @@
     },
     "packages/typescript-config": {
       "name": "@nl/typescript-config",
-      "version": "0.0.0",
+      "version": "1.0.0",
     },
     "packages/ui": {
       "name": "@nl/ui",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.6.0",
         "@next/third-parties": "^16.2.12",
@@ -324,11 +324,12 @@
     "adm-zip": "0.5.16",
     "brace-expansion": "5.0.9",
     "crypto-es": "2.1.0",
-    "fast-uri": "4.0.1",
+    "fast-uri": "4.1.2",
+    "ip-address": "10.3.1",
     "protobufjs": "7.5.0",
     "serialize-javascript": "6.0.2",
     "tmp": "0.2.3",
-    "undici": "6.21.2",
+    "undici": "6.28.0",
     "ws": "8.18.2",
   },
   "packages": {
@@ -3394,7 +3395,7 @@
 
     "fast-stable-stringify": ["fast-stable-stringify@1.0.0", "", {}, "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="],
 
-    "fast-uri": ["fast-uri@4.0.1", "", {}, "sha512-j0VntHrljgRKiWdbjL1xECG44OQu5sb7en4b8z2CcRvtDUEG5DAvkXlllrRhvbABR+m2mUiSgYBPvDj/PzB0dg=="],
+    "fast-uri": ["fast-uri@4.1.2", "", {}, "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -5276,7 +5277,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@6.21.2", "", {}, "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g=="],
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -6552,7 +6553,7 @@
 
     "npm/init-package-json": ["init-package-json@7.0.2", "", { "dependencies": { "@npmcli/package-json": "^6.0.0", "npm-package-arg": "^12.0.0", "promzard": "^2.0.0", "read": "^4.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4", "validate-npm-package-name": "^6.0.0" }, "bundled": true }, "sha512-Qg6nAQulaOQZjvaSzVLtYRqZmuqOi7gTknqqgdhZy7LV5oO+ppvHWq15tZYzGyxJLTH5BxRTqTa+cPDx2pSD9Q=="],
 
-    "npm/ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+    "npm/ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
 
     "npm/ip-regex": ["ip-regex@5.0.0", "", {}, "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="],
 

--- a/package.json
+++ b/package.json
@@ -85,10 +85,11 @@
   },
   "overrides": {
     "adm-zip": "0.5.16",
-    "fast-uri": "4.0.1",
+    "fast-uri": "4.1.2",
     "serialize-javascript": "6.0.2",
     "ws": "8.18.2",
-    "undici": "6.21.2",
+    "undici": "6.28.0",
+    "ip-address": "10.3.1",
     "tmp": "0.2.3",
     "brace-expansion": "5.0.9",
     "crypto-es": "2.1.0",


### PR DESCRIPTION
Refreshes existing security overrides for fast-uri, undici, and ip-address. Local validation: frozen Bun install, high-severity audit with the repository allowlist, lint, type-check, and Prettier.