### PR TITLE
ci(release): stop forwarding broken automation token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,15 @@ jobs:
       runtime-repository: 0xPlayerOne/code-foundry
       runtime-ref: v0.35.0
     secrets:
-      CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
-      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      # NOTE: CODE_FOUNDRY_TOKEN / RELEASE_PLEASE_TOKEN are intentionally NOT
+      # forwarded. The org-level automation token passes the runtime's
+      # read-only credential check but fails release-please's tree write
+      # (Error adding to tree), breaking every release since 2026-08-04.
+      # Without a forwarded token the runtime falls back to the short-lived
+      # workflow token (github.token), which has repo write access and is the
+      # path that produced the last successful release (PR #356, 2026-08-03).
+      # Release PRs are created in draft and merged manually. If a properly
+      # scoped automation token is configured later (classic PAT with repo
+      # scope), forward it here to re-enable guarded auto-merge.
       STAGING_DEPLOY_KEY: ${{ secrets.STAGING_DEPLOY_KEY }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- The org-level `CODE_FOUNDRY_TOKEN` / `RELEASE_PLEASE_TOKEN` passes the runtime's **read-only** credential validation but fails release-please's **git tree write**, breaking every release run since 2026-08-04 with `Error adding to tree: <sha>`.
- Stop forwarding the token to the reusable release workflow so the runtime falls back to the short-lived **workflow token** (`github.token`) — the exact path that produced the last successful release (PR #356, 2026-08-03).
- Release PRs are created in draft and merged manually (no auto-merge without a properly scoped automation token).

## Validation
- Verified the reusable workflow declares all four secrets `required: false`.
- Verified the fallback path creates release PRs successfully (08-03 run).
- The tree write API call succeeds with a properly scoped token; it only fails with the current org token.

Fixes release workflow for main (was failing since 2026-08-04).