### PR TITLE
chore(code-foundry): pin runtime v0.36.0

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.35.0
+runtime_ref: v0.36.0
 runner: ubuntu-latest
 unit_runner: ubuntu-latest
 ci_runner: ubuntu-latest

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,9 +18,10 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.35.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.36.0
     with:
       runner: ubuntu-slim
+      base: staging
     secrets:
       CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-pr:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.35.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.36.0
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,13 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.35.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.36.0
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.35.0
+      runtime-ref: v0.36.0
     secrets:
-      # NOTE: CODE_FOUNDRY_TOKEN / RELEASE_PLEASE_TOKEN are intentionally NOT
-      # forwarded. The org-level automation token passes the runtime's
-      # read-only credential check but fails release-please's tree write
-      # (Error adding to tree), breaking every release since 2026-08-04.
-      # Without a forwarded token the runtime falls back to the short-lived
-      # workflow token (github.token), which has repo write access and is the
-      # path that produced the last successful release (PR #356, 2026-08-03).
-      # Release PRs are created in draft and merged manually. If a properly
-      # scoped automation token is configured later (classic PAT with repo
-      # scope), forward it here to re-enable guarded auto-merge.
+      CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
+      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       STAGING_DEPLOY_KEY: ${{ secrets.STAGING_DEPLOY_KEY }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 0xPlayerOne/code-foundry
-          ref: v0.35.0
+          ref: v0.36.0
           path: .github/.code-foundry
           sparse-checkout: |
             src/lib
@@ -64,14 +64,14 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.35.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.36.0
     with:
       mode: ${{ needs.mode.outputs.mode }}
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.35.0
+      runtime-ref: v0.36.0
       ci-runner: ubuntu-latest
       test-runner: ubuntu-latest
-      unit-runner: ubuntu-slim
+      unit-runner: ubuntu-latest
       security-runner: ubuntu-slim
       codeql-runner: ubuntu-latest
       rust-shards: '["all"]'


### PR DESCRIPTION
Keeps the staging-release topology for the Vercel preview/staging deploys; re-renders standard callers against the released runtime.