### PR TITLE
chore: remove SnarfyMcSlappy from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Managed by code-foundry. Repository owners/admins are discovered during initialization.
-* @0xPlayerOne @SnarfyMcSlappy
+* @0xPlayerOne
 # Managed by repo-foundry. Repository owners/admins are discovered during initialization.
 # Default owner for all repository files.


### PR DESCRIPTION
Restrict CODEOWNERS to active repository owner.