### PR TITLE
fix: prettier-canonical dependabot ignore quotes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       # code-foundry.yml). Dependabot must never bump them; a stale
       # github-actions group PR branched before a sync can resurrect
       # legacy caller files when merged.
-      - dependency-name: "0xPlayerOne/code-foundry*"
+      - dependency-name: '0xPlayerOne/code-foundry*'
     groups:
       github-actions:
         applies-to: version-updates


### PR DESCRIPTION
Single-quote the code-foundry ignore block per prettier canonical.