### PR TITLE
refactor: remove dead network/alchemy constants

### DIFF
--- a/apps/app/src/constants/index.ts
+++ b/apps/app/src/constants/index.ts
@@ -1,16 +1,3 @@
-import { mainnet, sepolia } from 'viem/chains'
-
-enum ChainId {
-  MAINNET = mainnet.id,
-  SEPOLIA = sepolia.id,
-}
-
-// MY ALCHEMY_ID, SWAP IN YOURS FROM https://dashboard.alchemyapi.io/
-export const ALCHEMY_ID: { [key in ChainId]?: string } = {
-  [mainnet.id]: process.env.NEXT_PUBLIC_ALCHEMY_MAINNET_API as string,
-  [sepolia.id]: process.env.NEXT_PUBLIC_ALCHEMY_SEPOLIA_API as string,
-}
-
 export const SUBGRAPH_URI = `https://gateway.thegraph.com/api/subgraphs/id/${process.env.NEXT_PUBLIC_GRAPH_ID}`
 
 export const SUBGRAPH_DEV_URI =
@@ -22,4 +9,3 @@ export const DEBUG =
 // Request polling intervals
 
 export const REMOVED_TRAITS_INTERVAL = DEBUG ? 20000 : 60000
-export const BALANCE_INTERVAL = DEBUG ? 300000 : 10000

--- a/apps/app/src/constants/networks.ts
+++ b/apps/app/src/constants/networks.ts
@@ -10,14 +10,6 @@ export const LOCAL_CHAIN_ID = hardhat.id
 export const IMX_ID = immutableZkEvm.id
 export const IMX_TESTNET_ID = immutableZkEvmTestnet.id
 
-export const NETWORK_ICON = {
-  [MAINNET_ID]: '/img/logos/networks/mainnet-network.webp',
-  [SEPOLIA_ID]: '/img/logos/networks/sepolia-network.webp',
-  [LOCAL_CHAIN_ID]: '/img/logos/networks/sepolia-network.webp',
-  [IMX_ID]: '/img/logos/networks/imx_zkEVM.webp',
-  [IMX_TESTNET_ID]: '/img/logos/networks/imx_zkEVM.webp',
-}
-
 export const NETWORK_LABEL = {
   [MAINNET_ID]: mainnet.name,
   [SEPOLIA_ID]: sepolia.name,
@@ -80,24 +72,8 @@ export const NETWORKS: Record<NetworkName, Network> = {
   },
 }
 
-export const NETWORK = (chainId: number): Network =>
-  Object.values(NETWORKS).find((n) => n.chainId === chainId) || {
-    blockExplorer: '',
-    chainId: 1,
-    label: '',
-    rpcUrl: '',
-  }
-
 export const TARGET_NETWORK: Network = NETWORKS[
   process.env.NEXT_PUBLIC_NETWORK as NetworkName
 ] as Network
-
-export const SUPPORTED_CHAIN_IDS: number[] = [
-  MAINNET_ID,
-  SEPOLIA_ID,
-  LOCAL_CHAIN_ID,
-  IMX_ID,
-  IMX_TESTNET_ID,
-]
 
 export const VALID_NOTIFY_NETWORKS: number[] = [MAINNET_ID, SEPOLIA_ID]


### PR DESCRIPTION
## Ticket Summary
Removes 5 exported constants from `apps/app/src/constants/` that are never imported anywhere in the monorepo.

## Changes Implemented
- `networks.ts`: removed `NETWORK_ICON`, the `NETWORK()` lookup helper, and `SUPPORTED_CHAIN_IDS` (-28 lines)
- `index.ts`: removed `ALCHEMY_ID` + its `ChainId` enum (and the now-unused `viem/chains` import), and `BALANCE_INTERVAL` (-10 lines)

Net reduction: **38 lines** of dead code.

## Risk Assessment
**LOW.** Verified zero references to each constant across all `apps/` and `packages/` (including namespace/alias import patterns). App type-check passes; full app test suite passes (158 tests, 0 failures).