### PR TITLE
fix: adopt 12-column degens grid on main to match staging

### DIFF
--- a/apps/app/src/components/extended/DegensFilter/utils.ts
+++ b/apps/app/src/components/extended/DegensFilter/utils.ts
@@ -169,12 +169,12 @@ export const DEGENS_PER_PAGE = 12
 export const getGridSizeClass = (isGridView: boolean, isDrawerOpen: boolean) => {
   if (isGridView) {
     return isDrawerOpen
-      ? 'col-span-24 sm:col-span-12 md:col-span-8 lg:col-span-8 xl:col-span-8'
-      : 'col-span-24 sm:col-span-12 md:col-span-8 lg:col-span-6 xl:col-span-6'
+      ? 'col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-4 xl:col-span-4'
+      : 'col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3 xl:col-span-3'
   }
   return isDrawerOpen
-    ? 'col-span-12 sm:col-span-8 md:col-span-6 lg:col-span-6 xl:col-span-6'
-    : 'col-span-12 sm:col-span-8 md:col-span-6 lg:col-span-4 xl:col-span-4'
+    ? 'col-span-6 sm:col-span-4 md:col-span-3 lg:col-span-3 xl:col-span-3'
+    : 'col-span-6 sm:col-span-4 md:col-span-3 lg:col-span-2 xl:col-span-2'
 }
 
 // TODO: remove temp fix for 7th tribes once fetch data is updated


### PR DESCRIPTION
Aligns `DegensFilter/getGridSizeClass` on main with the 12-column fix from #408 (currently staging-only). This removes the only conflict blocking the staging→main promotion PR #406, so the release can proceed.

Resolves: the `apps/app/src/components/extended/DegensFilter/utils.ts` merge conflict in #406.