### PR TITLE
Release: staging → main (app shadcn audit)

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -54,3 +54,6 @@ NEXT_PUBLIC_UNITY_CRYPTO_WINTER_BASE_VERSION='1.0.19'
 # =============================|| Debugging ||============================
 
 NEXT_PUBLIC_DEBUG=true
+
+# Explicitly opt in to local visual-audit fixtures; leave false for normal builds.
+NEXT_PUBLIC_AUDIT_FIXTURE=false

--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -40,6 +40,7 @@ import DegenDialog from '@/components/dialog/DegenDialog'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import DegensTopNav from '@/components/extended/DegensTopNav'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
+import { isAuditFixtureEnabled } from '@/audit/fixture'
 
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
@@ -47,9 +48,12 @@ const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_Collapsibl
 const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: false })
 
 const DashboardDegensPage = (): React.ReactNode => {
-  const { authToken } = useAuth()
+  const { authToken, isLoggedIn } = useAuth()
   const { isConnected } = useAccount()
-  const [isDrawerOpen, setIsDrawerOpen] = useState(true)
+  const hasConnectedAccount = isConnected || (isAuditFixtureEnabled && isLoggedIn)
+  // Start closed so mobile does not push the first card below the fold before the
+  // responsive drawer effect runs. The layout opens it after mount on desktop.
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [filters, setFilters] = useState<DegenFilter>(DEFAULT_STATIC_FILTER)
   const [defaultValues, setDefaultValues] = useState<DegenFilter | undefined>(DEFAULT_STATIC_FILTER)
   const [filteredData, setFilteredData] = useState<Degen[]>([])
@@ -269,6 +273,7 @@ const DashboardDegensPage = (): React.ReactNode => {
               variant="ghost"
               size="icon"
               className="cursor-pointer"
+              aria-label={isDrawerOpen ? 'Hide filters' : 'Show filters'}
               onClick={() => setIsDrawerOpen(!isDrawerOpen)}
             >
               <Icon name={isDrawerOpen ? 'chevron-left' : 'chevron-right'} size="xl" />
@@ -282,7 +287,7 @@ const DashboardDegensPage = (): React.ReactNode => {
             !degensBalances?.length ? 'h-full justify-center items-center' : ''
           }`}
         >
-          {loading || !isConnected ? (
+          {loading || !hasConnectedAccount ? (
             [...Array(8)].map(renderSkeletonItem)
           ) : dataForCurrentPage.length ? (
             dataForCurrentPage.map(renderDegen)
@@ -351,7 +356,7 @@ const DashboardDegensPage = (): React.ReactNode => {
       dataForCurrentPage,
       degensBalances?.length,
       filteredData.length,
-      isConnected,
+      hasConnectedAccount,
       isDrawerOpen,
       isMobile,
       jump,
@@ -365,7 +370,7 @@ const DashboardDegensPage = (): React.ReactNode => {
 
   return (
     <>
-      <div className="flex h-full flex-col justify-center align-top gap-4 pl-2">
+      <div className="flex h-full flex-col justify-start align-top gap-4 pl-2">
         <div className="pl-4 pr-6">
           <DegensTopNav
             searchTerm={searchTerm || ''}
@@ -389,6 +394,7 @@ const DashboardDegensPage = (): React.ReactNode => {
         isClaim={isClaimDialog}
         isRent={isRentDialog}
         isEquip={isEquipDialog}
+        setIsClaim={setIsClaimDialog}
         setIsRent={setIsRentDialog}
         onClose={() => setIsDegenModalOpen(false)}
       />

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -167,6 +167,7 @@ const MyDegens = (): React.ReactNode => {
         degen={selectedDegen}
         isClaim={isClaimDialog}
         isRent={isRentDialog}
+        setIsClaim={setIsClaimDialog}
         setIsRent={setIsRentDialog}
         onClose={() => setIsDegenModalOpen(false)}
       />

--- a/apps/app/src/app/(public-routes)/degens/page.tsx
+++ b/apps/app/src/app/(public-routes)/degens/page.tsx
@@ -42,7 +42,9 @@ const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: f
 const AllDegensPage = (): React.ReactNode => {
   const { address } = useNetworkContext()
   const [degens, setDegens] = useState<Degen[]>([])
-  const [isDrawerOpen, setIsDrawerOpen] = useState(true)
+  // Start closed so mobile does not push the first card below the fold before the
+  // responsive drawer effect runs. The layout opens it after mount on desktop.
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [filters, setFilters] = useState<DegenFilter>(DEFAULT_STATIC_FILTER)
   const [defaultValues, setDefaultValues] = useState<DegenFilter | undefined>()
   const [filteredData, setFilteredData] = useState<Degen[]>([])
@@ -190,6 +192,7 @@ const AllDegensPage = (): React.ReactNode => {
               variant="ghost"
               size="icon"
               className="cursor-pointer"
+              aria-label={isDrawerOpen ? 'Hide filters' : 'Show filters'}
               onClick={() => setIsDrawerOpen(!isDrawerOpen)}
             >
               <Icon name={isDrawerOpen ? 'chevron-left' : 'chevron-right'} size="xl" />
@@ -264,7 +267,7 @@ const AllDegensPage = (): React.ReactNode => {
 
   return (
     <>
-      <div className="flex h-full flex-col justify-center align-top gap-4 pl-2">
+      <div className="flex h-full flex-col justify-start align-top gap-4 pl-2">
         <div className="pl-4 pr-6">
           <DegensTopNav
             searchTerm={searchTerm || ''}

--- a/apps/app/src/app/(public-routes)/mint-o-matic/_CharacterCreator/index.tsx
+++ b/apps/app/src/app/(public-routes)/mint-o-matic/_CharacterCreator/index.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { memo, useCallback, useEffect, useState } from 'react'
-import Unity, { UnityContext } from 'react-unity-webgl'
+import { Unity } from 'react-unity-webgl'
 import type { IUnityConfig } from 'react-unity-webgl'
 import { useUnityContext } from '@/lib/use-unity-context'
 import { useOrientation } from '@nl/ui/hooks/useOrientation'

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_OnboardingCard/OnboardingCard.module.css
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_OnboardingCard/OnboardingCard.module.css
@@ -8,7 +8,7 @@
   background-color: var(--color-muted-foreground);
 }
 
-.borderLinearProgress :global(.MuiLinearProgress-bar) {
+.borderLinearProgress :global([data-slot='progress-indicator']) {
   border-radius: var(--radius-default);
   background-color: var(--color-purple);
 }

--- a/apps/app/src/audit/fixture.ts
+++ b/apps/app/src/audit/fixture.ts
@@ -1,0 +1,187 @@
+import type { Character } from '@/types/graph'
+import type {
+  Account,
+  Profile,
+  ProfileMiniGame,
+  ProfileNiftySmsher,
+  ProfileTotal,
+} from '@/types/account'
+import type { Degen } from '@/types/degens'
+import {
+  DEGEN_BASE_API_URL,
+  GET_GAMER_PROFILE_API,
+  MY_PROFILE_API_URL,
+  PROFILE_FAV_DEGENS_API,
+} from '@/constants/url'
+
+export const isAuditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+export const AUDIT_FIXTURE_ADDRESS = '0x0000000000000000000000000000000000000a01' as const
+export const AUDIT_FIXTURE_TOKEN = 'audit-fixture-token'
+
+export const AUDIT_FIXTURE_ACCOUNT: Account = {
+  address: AUDIT_FIXTURE_ADDRESS,
+  balance: 1250,
+  created_at: 0,
+  id: 'audit-account',
+  is_banned: false,
+  name: 'Audit Player',
+  session_key: '',
+  session_updated_at: 0,
+}
+
+const auditDegenList: Degen[] = [
+  {
+    id: '101',
+    stats: {},
+    rental_count: 1,
+    is_active: true,
+    last_rented_at: 0,
+    total_rented: 12,
+    price: 125,
+    price_daily: 18,
+    tribe: 'Ape',
+    background: 'Common',
+    traits_string: 'blue,cap',
+    multiplier: 1,
+    multipliers: { background: 1 },
+    name: 'Audit Ape',
+    owner: AUDIT_FIXTURE_ADDRESS,
+    earning_cap: 1000,
+    earning_cap_daily: 100,
+  },
+  {
+    id: '202',
+    stats: {},
+    rental_count: 0,
+    is_active: true,
+    last_rented_at: 0,
+    total_rented: 7,
+    price: 250,
+    price_daily: 35,
+    tribe: 'Alien',
+    background: 'Rare',
+    traits_string: 'green,helmet',
+    multiplier: 2,
+    multipliers: { background: 2 },
+    name: 'Audit Alien',
+    owner: AUDIT_FIXTURE_ADDRESS,
+    earning_cap: 1200,
+    earning_cap_daily: 120,
+  },
+  {
+    id: '303',
+    stats: {},
+    rental_count: 2,
+    is_active: true,
+    last_rented_at: 0,
+    total_rented: 19,
+    price: 500,
+    price_daily: 70,
+    tribe: 'Cat',
+    background: 'Meta',
+    traits_string: 'purple,visor',
+    multiplier: 3,
+    multipliers: { background: 3 },
+    name: 'Audit Cat',
+    owner: AUDIT_FIXTURE_ADDRESS,
+    earning_cap: 1500,
+    earning_cap_daily: 150,
+  },
+  {
+    id: '9999',
+    stats: {},
+    rental_count: 0,
+    is_active: true,
+    last_rented_at: 0,
+    total_rented: 3,
+    price: 900,
+    price_daily: 125,
+    tribe: 'Rugman',
+    background: 'Legendary',
+    traits_string: 'gold,crown',
+    multiplier: 4,
+    multipliers: { background: 4 },
+    name: 'Audit Rugman',
+    owner: AUDIT_FIXTURE_ADDRESS,
+    earning_cap: 2000,
+    earning_cap_daily: 200,
+  },
+]
+
+export const AUDIT_FIXTURE_DEGENS = Object.fromEntries(
+  auditDegenList.map((degen) => [degen.id, degen])
+) as Record<string, Degen>
+
+export const AUDIT_FIXTURE_CHARACTERS: Character[] = auditDegenList.slice(0, 3).map((degen) => ({
+  id: degen.id,
+  tokenId: BigInt(degen.id),
+  createdAt: 0n,
+  name: degen.name,
+  nameHistory: [],
+  owner: { address: AUDIT_FIXTURE_ADDRESS },
+  traits: {},
+}))
+
+const auditTotals: ProfileTotal = {
+  wins: 24,
+  xp: 4800,
+  rental_earnings: 320,
+  rental_royalty_earnings: 120,
+  rental_earnings_as_owner: 200,
+  rental_earnings_as_renter: 120,
+  rental_game_earnings: 40,
+  earnings: 360,
+  matches: 60,
+  time_played: 7200,
+  rank: 12,
+  rank_xp_previous: 4000,
+  rank_xp_next: 5500,
+}
+
+const auditSmashers: ProfileNiftySmsher = {
+  ...auditTotals,
+  hits: 90,
+  kills: 42,
+  suicides: 2,
+  round_wins: 28,
+  deaths: 30,
+  rounds: 60,
+}
+
+const auditMiniGame: ProfileMiniGame = {
+  dodges: 8,
+  hits: 18,
+  machine_hits: 4,
+  matches: 20,
+  misses: 3,
+  rank: 8,
+  rank_xp_next: 1200,
+  rank_xp_previous: 900,
+  score: 860,
+  time_played: 1800,
+  xp: 1050,
+}
+
+export const AUDIT_FIXTURE_PROFILE: Profile = {
+  id: 'audit-profile',
+  updated_at: 0,
+  name: 'Audit Player',
+  name_cased: 'Audit Player',
+  stats: {
+    total: auditTotals,
+    nifty_smashers: auditSmashers,
+    wen_game: auditMiniGame,
+    crypto_winter: auditMiniGame,
+  },
+}
+
+export function getAuditFixtureData(url: string): unknown {
+  if (!isAuditFixtureEnabled) return undefined
+  if (url === `${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`) return AUDIT_FIXTURE_DEGENS
+  if (url === PROFILE_FAV_DEGENS_API) return { favorites: '' }
+  if (url === GET_GAMER_PROFILE_API || url === MY_PROFILE_API_URL) return AUDIT_FIXTURE_PROFILE
+
+  // Fixture mode is an explicit visual-audit sandbox: never fall through to a real request.
+  return null
+}

--- a/apps/app/src/components/cards/DegenCard/index.tsx
+++ b/apps/app/src/components/cards/DegenCard/index.tsx
@@ -119,7 +119,7 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
           {isSelectableDegen ? (
             <Button
               variant={isSelected ? 'default' : 'outline'}
-              className="min-w-[32%] w-full"
+              className="min-w-0 flex-1"
               style={{ fontSize: buttonFontSize }}
               onClick={onClickSelect}
               disabled={isSelectionDisabled && !isSelected}
@@ -129,7 +129,7 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
           ) : (
             <Button
               variant="outline"
-              className="min-w-[32%] w-full"
+              className="min-w-0 flex-1"
               style={{ fontSize: buttonFontSize }}
               onClick={onClickDetail}
             >
@@ -140,7 +140,7 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
             <Button
               onClick={onClickClaim}
               variant="default"
-              className="min-w-[32%] w-full"
+              className="min-w-0 flex-1"
               style={{ fontSize: buttonFontSize }}
             >
               Claim

--- a/apps/app/src/components/dialog/DegenDialog/RentDegenContentDialog.module.css
+++ b/apps/app/src/components/dialog/DegenDialog/RentDegenContentDialog.module.css
@@ -36,11 +36,6 @@
   padding: 4px;
 }
 
-.inputCheck :global(.MuiSvgIcon-root) {
-  width: 0.75em;
-  height: 0.75em;
-}
-
 .inputCheckFormControl {
   margin-left: -4px;
   margin-right: 0;

--- a/apps/app/src/components/dialog/DegenDialog/TokenInfoBox.module.css
+++ b/apps/app/src/components/dialog/DegenDialog/TokenInfoBox.module.css
@@ -27,7 +27,7 @@
   font-size: 20px !important;
 }
 
-.tokenAmountInput :global(.MuiInputBase-input) {
+.tokenAmountInput {
   position: relative;
   background-color: transparent;
   border: none;
@@ -39,7 +39,7 @@
   overflow: hidden;
 }
 
-.tokenAmountInput :global(.MuiInputBase-input)::placeholder {
+.tokenAmountInput::placeholder {
   font-size: 36px;
   color: #4d4d4f;
 }

--- a/apps/app/src/components/dialog/DegenDialog/index.module.css
+++ b/apps/app/src/components/dialog/DegenDialog/index.module.css
@@ -1,11 +1,11 @@
-.customDialog :global(.MuiPaper-root) {
+.customDialog {
   overflow-x: hidden;
-  min-width: inherit;
+  min-width: 0;
 }
 
 @media (max-width: 767.95px) {
-  .customDialogRent :global(.MuiPaper-root),
-  .customDialogEquip :global(.MuiPaper-root) {
+  .customDialogRent,
+  .customDialogEquip {
     margin: 16px;
     max-width: calc(100% - 32px) !important;
     width: calc(100% - 32px) !important;
@@ -14,6 +14,8 @@
   }
 }
 
-.customDialogRent :global(.MuiPaper-root) {
-  min-width: 550px;
+@media (min-width: 768px) {
+  .customDialogRent {
+    min-width: 550px;
+  }
 }

--- a/apps/app/src/components/dialog/DegenDialog/index.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/index.tsx
@@ -141,7 +141,7 @@ const DegenDialog = ({
     }
   }, [tokenId, readContracts, open, authToken])
 
-  const displayName = name || 'No Name DEGEN'
+  const displayName = name || degen?.name || 'No Name DEGEN'
   const traits: { [traitType: string]: number } = traitList.reduce(
     (acc, trait, i) => ({ ...acc, [TRAIT_INDEXES[i] as string]: trait }),
     {}
@@ -149,6 +149,8 @@ const DegenDialog = ({
 
   const handleClose = (event?: React.MouseEvent<HTMLButtonElement>) => {
     onClose?.(event as React.MouseEvent<HTMLButtonElement>, 'backdropClick')
+    setIsClaim?.(false)
+    setIsRent?.(false)
     resetDialog()
   }
 
@@ -169,7 +171,7 @@ const DegenDialog = ({
             ? 'max-w-fit md:max-w-fit lg:max-w-fit'
             : isRent
               ? 'max-w-[444px] md:max-w-[444px] lg:max-w-[444px]'
-              : 'max-w-[600px] md:max-w-[600px] lg:max-w-[600px]',
+              : 'max-w-[900px] md:max-w-[900px] lg:max-w-[900px]',
           fullScreen &&
             'top-0 left-0 h-screen w-screen max-h-screen max-w-none translate-x-0 translate-y-0 rounded-none'
         )}
@@ -177,23 +179,14 @@ const DegenDialog = ({
         {isClaim && <ClaimDegenContentDialog degen={degen} onClose={handleClose} />}
         {isEquip && <EquipDegenContentDialog degen={degen} name={name} />}
         {isRent && <RentDegenContentDialog degen={degen} onClose={handleClose} />}
-        {!isRent && !isClaim && !isEquip && setIsRent && (
+        {!isRent && !isClaim && !isEquip && (setIsRent || setIsClaim) && (
           <ViewTraitsContentDialog
             degen={degen}
             degenDetail={degenDetail}
             traits={traits}
             displayName={displayName}
-            onRent={() => setIsRent(true)}
-            onClose={handleClose}
-          />
-        )}
-        {!isRent && !isClaim && !isEquip && setIsClaim && (
-          <ViewTraitsContentDialog
-            degen={degen}
-            degenDetail={degenDetail}
-            traits={traits}
-            displayName={displayName}
-            onClaim={() => setIsClaim(true)}
+            onRent={setIsRent ? () => setIsRent(true) : undefined}
+            onClaim={setIsClaim ? () => setIsClaim(true) : undefined}
             onClose={handleClose}
           />
         )}

--- a/apps/app/src/components/dialog/DialogContent.test.tsx
+++ b/apps/app/src/components/dialog/DialogContent.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { Dialog, DialogContent, DialogTrigger } from './index'
+
+describe('application DialogContent wrapper', () => {
+  it('forwards shared layout and accessibility props to the dialog surface', () => {
+    render(
+      <Dialog>
+        <DialogTrigger>
+          <button type="button">Open dialog</button>
+        </DialogTrigger>
+        <DialogContent
+          aria-label="Audit dialog"
+          className="max-w-[900px]"
+          dialogTitle="Dialog title"
+          sx={{ minHeight: '300px' }}
+        >
+          Dialog body
+        </DialogContent>
+      </Dialog>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }))
+    const dialog = screen.getByRole('dialog', { name: 'Dialog title' })
+    expect(dialog.getAttribute('aria-label')).toBe('Audit dialog')
+    expect(dialog.className).toContain('max-w-[900px]')
+    expect(dialog.style.minHeight).toBe('300px')
+    expect(dialog.textContent).toContain('Dialog body')
+  })
+})

--- a/apps/app/src/components/dialog/DialogContent.tsx
+++ b/apps/app/src/components/dialog/DialogContent.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 
 import {
   Dialog as DialogBase,
-  DialogContent as DialogContentBaseMui,
+  DialogContent as DialogContentPrimitive,
   DialogHeader,
   DialogTitle,
 } from '@nl/ui/base/dialog'
@@ -11,15 +11,22 @@ import { DialogContext } from '.'
 import type { DialogProps } from '@/types/dialog'
 import { CloseIconButton } from './DialogActions'
 
-const DialogContentBase = ({ children, ...props }: DialogProps) => {
+const DialogContentBase = ({
+  children,
+  sx,
+  dialogTitle,
+  dividers,
+  onClose,
+  ...props
+}: DialogProps) => {
   const [isOpen, setIsOpen] = useContext(DialogContext)
 
   if (!isOpen) return null
   return (
     <DialogBase open={isOpen} onOpenChange={(open) => !open && setIsOpen(false)}>
-      <DialogContentBaseMui showCloseButton={false} style={props.sx}>
+      <DialogContentPrimitive {...props} showCloseButton={false} style={{ ...props.style, ...sx }}>
         {children}
-      </DialogContentBaseMui>
+      </DialogContentPrimitive>
     </DialogBase>
   )
 }

--- a/apps/app/src/components/extended/Avatar.tsx
+++ b/apps/app/src/components/extended/Avatar.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { Avatar as MuiAvatar, AvatarImage, AvatarFallback } from '@nl/ui/base/avatar'
+import { Avatar as BaseAvatar, AvatarImage, AvatarFallback } from '@nl/ui/base/avatar'
 import type { LinkTarget } from '@/types'
 
 // ==============================|| AVATAR ||============================== //
@@ -50,7 +50,7 @@ const Avatar = ({ className, color, outline, size, style, ...others }: avatarPro
         : undefined
 
   return (
-    <MuiAvatar
+    <BaseAvatar
       className={`${size ? sizeClass[size] : ''} ${className || ''}`}
       style={{ ...colorStyle, ...outlineStyle, ...style }}
       {...others}
@@ -60,7 +60,7 @@ const Avatar = ({ className, color, outline, size, style, ...others }: avatarPro
       ) : (
         <AvatarFallback>{others.children}</AvatarFallback>
       )}
-    </MuiAvatar>
+    </BaseAvatar>
   )
 }
 

--- a/apps/app/src/components/extended/DegensFilter/index.module.css
+++ b/apps/app/src/components/extended/DegensFilter/index.module.css
@@ -5,17 +5,21 @@
   color: #4d4d4d;
 }
 
-.inputCheck :global(.MuiSvgIcon-root) {
-  width: 0.75em;
-  height: 0.75em;
-}
-
 .inputCheckFormControl {
-  margin-left: -8px;
+  margin-left: 0;
   margin-right: 0;
+  min-width: 0;
 }
 
-.inputCheckFormControl :global(.MuiFormControlLabel-label) {
-  font-size: 0.75rem;
-  line-height: 0.75rem;
+.filterOption {
+  min-width: 0;
+}
+
+.filterOption > div,
+.filterOption > span {
+  min-width: 0;
+}
+
+.filterOption span {
+  white-space: nowrap;
 }

--- a/apps/app/src/components/extended/DegensFilter/index.tsx
+++ b/apps/app/src/components/extended/DegensFilter/index.tsx
@@ -220,8 +220,8 @@ const DegensFilter = ({
             {tribes.map((tribe) => (
               <label
                 key={tribe.name}
-                className="flex min-w-[122px] items-center"
-                style={{ flex: '0 0 33.333333%' }}
+                className={cn('flex min-w-0 items-center', styles.filterOption)}
+                style={{ flex: '0 0 50%' }}
               >
                 <Checkbox
                   name={tribe.name}
@@ -366,7 +366,7 @@ const DegensFilter = ({
             {backgrounds.map((background) => (
               <label
                 key={background}
-                className={`${styles.inputCheckFormControl} flex items-center`}
+                className={`${styles.inputCheckFormControl} ${styles.filterOption} flex items-center`}
                 style={{ flex: '0 0 50%' }}
               >
                 <Checkbox

--- a/apps/app/src/components/extended/DegensTopNav/index.module.css
+++ b/apps/app/src/components/extended/DegensTopNav/index.module.css
@@ -3,25 +3,6 @@
   height: 32px;
 }
 
-.searchTextField :global(.MuiInputLabel-root) {
-  color: var(--color-muted-foreground);
-  top: -12px;
-}
-
-.searchTextField :global(.MuiOutlinedInput-root) {
-  height: 32px;
-}
-
-.searchTextField :global(.MuiOutlinedInput-root) input {
-  background-color: var(--color-muted);
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.searchTextField :global(.MuiOutlinedInput-root) fieldset {
-  border: none;
-}
-
 .layoutModeButtonsGroup {
   border: var(--border-default);
   border-radius: var(--radius-default);
@@ -31,14 +12,6 @@
   border: none;
   border-radius: var(--radius-default);
   padding: 5px 16px;
-}
-
-.layoutModeButton:global(.Mui-selected) {
-  background: rgba(88, 32, 214, 0.2);
-}
-
-.layoutModeButton:global(.Mui-selected):hover {
-  background: rgba(88, 32, 214, 0.2);
 }
 
 .layoutModeButton svg {

--- a/apps/app/src/components/extended/Snackbar.test.ts
+++ b/apps/app/src/components/extended/Snackbar.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getSnackbarPosition, getSnackbarTransitionClass } from './Snackbar'
+
+describe('Snackbar adapter', () => {
+  it('maps all anchor positions to Sonner positions', () => {
+    expect(getSnackbarPosition({ vertical: 'top', horizontal: 'left' })).toBe('top-left')
+    expect(getSnackbarPosition({ vertical: 'top', horizontal: 'center' })).toBe('top-center')
+    expect(getSnackbarPosition({ vertical: 'bottom', horizontal: 'right' })).toBe('bottom-right')
+  })
+
+  it('maps migrated transition names and safely falls back for unknown names', () => {
+    expect(getSnackbarTransitionClass('SlideLeft')).toContain('slide-in-from-right')
+    expect(getSnackbarTransitionClass('Fade')).toContain('fade-in-0')
+    expect(getSnackbarTransitionClass('Unknown')).toContain('fade-in-0')
+  })
+})

--- a/apps/app/src/components/extended/Snackbar.tsx
+++ b/apps/app/src/components/extended/Snackbar.tsx
@@ -1,16 +1,38 @@
 import { useEffect } from 'react'
 
 import { toast } from 'sonner'
+import type { ExternalToast } from 'sonner'
 
 import { useDispatch, useSelector } from '@/store/hooks'
 import { closeSnackbar } from '@/store/slices/snackbar'
+import type { SnackbarOrigin } from '@/types/snackbar'
 
 // ==============================|| SNACKBAR ||============================== //
+
+const snackbarPositions = {
+  top: { left: 'top-left', center: 'top-center', right: 'top-right' },
+  bottom: { left: 'bottom-left', center: 'bottom-center', right: 'bottom-right' },
+} as const
+
+const snackbarTransitions = {
+  Fade: 'animate-in fade-in-0',
+  Grow: 'animate-in zoom-in-95',
+  SlideDown: 'animate-in slide-in-from-top',
+  SlideLeft: 'animate-in slide-in-from-right',
+  SlideRight: 'animate-in slide-in-from-left',
+  SlideUp: 'animate-in slide-in-from-bottom',
+} as const
+
+export const getSnackbarPosition = ({ vertical, horizontal }: SnackbarOrigin) =>
+  snackbarPositions[vertical][horizontal]
+
+export const getSnackbarTransitionClass = (transition: string) =>
+  snackbarTransitions[transition as keyof typeof snackbarTransitions] ?? snackbarTransitions.Fade
 
 const Snackbar = () => {
   const dispatch = useDispatch()
   const snackbar = useSelector((state) => state.snackbar)
-  const { alert, close, message, open, variant } = snackbar
+  const { actionButton, alert, anchorOrigin, close, message, open, transition, variant } = snackbar
 
   useEffect(() => {
     if (!open) return
@@ -21,7 +43,20 @@ const Snackbar = () => {
           ? 'info'
           : alert.color
         : 'default'
-    const options = { duration: 6000, closeButton: close !== false }
+    const options: ExternalToast = {
+      action:
+        actionButton || variant !== 'alert'
+          ? { label: 'UNDO', onClick: () => dispatch(closeSnackbar()) }
+          : undefined,
+      className: getSnackbarTransitionClass(transition),
+      closeButton: close !== false,
+      duration: 6000,
+      position: getSnackbarPosition(anchorOrigin),
+    }
+
+    if (variant === 'alert' && alert.variant === 'outlined') {
+      options.className = `${options.className} border border-current bg-background`
+    }
     switch (type) {
       case 'success':
       case 'error':
@@ -34,7 +69,18 @@ const Snackbar = () => {
     }
 
     dispatch(closeSnackbar())
-  }, [alert.color, close, dispatch, message, open, variant])
+  }, [
+    actionButton,
+    alert.color,
+    alert.variant,
+    anchorOrigin,
+    close,
+    dispatch,
+    message,
+    open,
+    transition,
+    variant,
+  ])
 
   return null
 }

--- a/apps/app/src/components/extended/SortButton/index.test.tsx
+++ b/apps/app/src/components/extended/SortButton/index.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { Button } from '@nl/ui/base/button'
+
+import SortButton from './index'
+
+describe('SortButton', () => {
+  it('dismisses its menu on outside pointer and Escape while preserving focus', () => {
+    const handleSort = () => {}
+    render(
+      <SortButton handleSort={handleSort}>
+        <Button>Sort</Button>
+      </SortButton>
+    )
+
+    const trigger = screen.getByRole('button', { name: /sort/i })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('menu')).not.toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(trigger)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/apps/app/src/components/extended/SortButton/index.tsx
+++ b/apps/app/src/components/extended/SortButton/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Children, cloneElement, ReactElement, useCallback, useEffect, useState } from 'react'
+import { Children, cloneElement, useCallback, useEffect, useId, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
 import type { MenuItemBaseProps } from '@/types'
 import callAll, { type FunctionType } from '@/utils/callAll'
 import DegenSortOptions from '@/constants/sort'
@@ -16,6 +17,7 @@ interface Props {
 const SortButton = ({
   children,
   defaultSelectedItemValue = null,
+  label = 'Sort options',
   handleSort,
 }: Props): React.ReactNode => {
   if (!Children.only(children)) console.error('SortButton only accepts one child')
@@ -25,10 +27,10 @@ const SortButton = ({
   )
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [buttonNode, setButtonNode] = useState<HTMLElement | null>(null)
+  const menuContainerRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
   const buttonRef = useCallback((node: HTMLElement | null) => {
-    if (node !== null) {
-      setButtonNode(node)
-    }
+    setButtonNode(node)
   }, [])
   const isSortOpen = Boolean(anchorEl)
   const sortLabel = sortOptions.filter((items) => items.value === selectedSort)
@@ -45,9 +47,31 @@ const SortButton = ({
     setAnchorEl(event.currentTarget)
   }
 
-  const handleCloseSortMenu = () => {
+  const handleCloseSortMenu = useCallback(() => {
     setAnchorEl(null)
-  }
+  }, [])
+
+  useEffect(() => {
+    if (!isSortOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!menuContainerRef.current?.contains(event.target as Node)) handleCloseSortMenu()
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        handleCloseSortMenu()
+        buttonNode?.focus()
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [buttonNode, handleCloseSortMenu, isSortOpen])
 
   const handleMenuItemClick = (event: React.MouseEvent<HTMLElement>, value: string) => {
     setSelectedSort(value)
@@ -66,6 +90,9 @@ const SortButton = ({
     {
       ...(child.props || {}),
       ref: buttonRef,
+      'aria-controls': isSortOpen ? menuId : undefined,
+      'aria-expanded': isSortOpen,
+      'aria-haspopup': 'menu',
       onClick: callAll(handleOpenSortMenu as FunctionType, childOnClick as FunctionType),
     },
     <>
@@ -75,10 +102,13 @@ const SortButton = ({
   )
 
   return (
-    <div className="relative flex items-center justify-center">
+    <div ref={menuContainerRef} className="relative flex items-center justify-center">
       {Button}
       {isSortOpen && (
         <div
+          id={menuId}
+          role="menu"
+          aria-label={label}
           className="absolute top-full right-0 z-50 rounded-b-md border border-border bg-background shadow-md"
           style={{ width: buttonWidth }}
         >
@@ -86,6 +116,8 @@ const SortButton = ({
             <button
               type="button"
               key={option.value}
+              role="menuitemradio"
+              aria-checked={option.value === selectedSort}
               onClick={(event) => handleMenuItemClick(event, option.value)}
               className={`w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-accent ${
                 option.value === selectedSort ? 'font-medium text-blue' : ''

--- a/apps/app/src/components/leaderboards/index.module.css
+++ b/apps/app/src/components/leaderboards/index.module.css
@@ -1,7 +1,3 @@
 .styledListItemButton {
   padding: 2px 12px;
 }
-
-.styledListItemButton:global(.Mui-selected) {
-  background-color: transparent !important;
-}

--- a/apps/app/src/components/wrapper/GameWithAuth.tsx
+++ b/apps/app/src/components/wrapper/GameWithAuth.tsx
@@ -4,7 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useUserAgent } from '@nl/ui/hooks/useUserAgent'
-import Unity from 'react-unity-webgl'
+import { Unity } from 'react-unity-webgl'
 import type { UnityConfig } from 'react-unity-webgl'
 import { useUnityContext } from '@/lib/use-unity-context'
 import { Button } from '@nl/ui/base/button'

--- a/apps/app/src/contexts/AppContextWrapper.tsx
+++ b/apps/app/src/contexts/AppContextWrapper.tsx
@@ -6,6 +6,7 @@ import { headers } from 'next/headers'
 
 // app context
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
 import { IMXProvider } from '@/contexts/IMXContext'
 import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
@@ -18,23 +19,33 @@ import ReduxProvider from '@/store/ReduxProvider'
 const AppContextWrapper = async ({ children }: PropsWithChildren) => {
   const headersList = await headers()
   const cookies = headersList.get('cookie')
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+  const appContexts = auditFixtureEnabled ? (
+    <AuditFixtureContextWrapper>
+      <ReduxProvider>
+        <FeatureFlagProvider>{children}</FeatureFlagProvider>
+      </ReduxProvider>
+    </AuditFixtureContextWrapper>
+  ) : (
+    <NetworkProvider>
+      <IMXProvider>
+        <ReduxProvider>
+          <AuthTokenProvider>
+            <NFTsBalanceProvider>
+              <TokensBalanceProvider>
+                <FeatureFlagProvider>{children}</FeatureFlagProvider>
+              </TokensBalanceProvider>
+            </NFTsBalanceProvider>
+          </AuthTokenProvider>
+        </ReduxProvider>
+      </IMXProvider>
+    </NetworkProvider>
+  )
+
   return (
     <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>
-        <NetworkProvider>
-          <IMXProvider>
-            <ReduxProvider>
-              <AuthTokenProvider>
-                <NFTsBalanceProvider>
-                  <TokensBalanceProvider>
-                    <FeatureFlagProvider>{children}</FeatureFlagProvider>
-                  </TokensBalanceProvider>
-                </NFTsBalanceProvider>
-              </AuthTokenProvider>
-            </ReduxProvider>
-          </IMXProvider>
-        </NetworkProvider>
-      </Web3ModalProvider>
+      <Web3ModalProvider cookies={cookies}>{appContexts}</Web3ModalProvider>
     </LocalStorageProvider>
   )
 }

--- a/apps/app/src/contexts/AuditFixtureContextWrapper.tsx
+++ b/apps/app/src/contexts/AuditFixtureContextWrapper.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { PropsWithChildren } from 'react'
+import { immutableZkEvmTestnet } from 'viem/chains'
+
+import {
+  AUDIT_FIXTURE_ADDRESS,
+  AUDIT_FIXTURE_CHARACTERS,
+  AUDIT_FIXTURE_TOKEN,
+} from '@/audit/fixture'
+import { COMICS, ITEMS } from '@/constants/marketplace'
+import AuthTokenContext from '@/contexts/AuthTokenContext'
+import IMXContext from '@/contexts/IMXContext'
+import NetworkContext from '@/contexts/NetworkContext'
+import NFTsBalanceContext from '@/contexts/NFTsBalanceContext'
+import TokensBalanceContext from '@/contexts/TokensBalanceContext'
+import type { Contracts } from '@/types/web3'
+
+const auditComics = COMICS.map((comic, index) => ({ ...comic, balance: index === 0 ? 1 : 0 }))
+const auditItems = ITEMS.map((item, index) => ({ ...item, balance: index === 0 ? 1 : 0 }))
+
+const AuditFixtureContextWrapper = ({ children }: PropsWithChildren): React.ReactNode => {
+  const pathname = usePathname()
+  const isProtectedSurface = pathname?.startsWith('/dashboard') ?? false
+
+  return (
+    <AuthTokenContext.Provider
+      value={{
+        authToken: isProtectedSurface ? AUDIT_FIXTURE_TOKEN : undefined,
+        handleConnectWallet: async () => {},
+        isConnected: false,
+        isLoggedIn: isProtectedSurface,
+      }}
+    >
+      <IMXContext.Provider
+        value={{
+          address: AUDIT_FIXTURE_ADDRESS,
+          imxChainId: immutableZkEvmTestnet.id,
+          imxContracts: {} as Contracts,
+          imxSigner: undefined,
+          passportProvider: undefined,
+        }}
+      >
+        <NetworkContext.Provider
+          value={{
+            address: AUDIT_FIXTURE_ADDRESS,
+            isConnected: false,
+            publicProvider: undefined,
+            readContracts: {} as Contracts,
+            signer: undefined,
+            tx: async () => null,
+            writeContracts: {} as Contracts,
+          }}
+        >
+          <NFTsBalanceContext.Provider
+            value={{
+              comicsBalances: auditComics,
+              degenCount: AUDIT_FIXTURE_CHARACTERS.length,
+              degensBalances: AUDIT_FIXTURE_CHARACTERS,
+              degenTokenIndices: AUDIT_FIXTURE_CHARACTERS.map((degen) => Number(degen.tokenId)),
+              isDegenOwner: true,
+              itemsBalances: auditItems,
+              loadingComics: false,
+              loadingDegens: false,
+              loadingItems: false,
+              refreshComicsBalances: () => {},
+              refreshDegenBalances: () => {},
+              refreshItemsBalances: () => {},
+            }}
+          >
+            <TokensBalanceContext.Provider
+              value={{
+                loadingArcadeBal: false,
+                loadingNFTLAccrued: false,
+                loadingNFTLBal: false,
+                refetchArcadeBal: () => {},
+                refreshClaimableNFTL: () => {},
+                refreshNFTLBalance: () => {},
+                tokensBalances: { AT: 24, NFTL: { eth: 1250, imx: 875 } },
+                totalAccruedNFTL: 42,
+              }}
+            >
+              {children}
+            </TokensBalanceContext.Provider>
+          </NFTsBalanceContext.Provider>
+        </NetworkContext.Provider>
+      </IMXContext.Provider>
+    </AuthTokenContext.Provider>
+  )
+}
+
+export default AuditFixtureContextWrapper

--- a/apps/app/src/hooks/balances/useClaimableNFTL.ts
+++ b/apps/app/src/hooks/balances/useClaimableNFTL.ts
@@ -7,6 +7,7 @@ import type { Abi } from 'viem'
 import { TARGET_NETWORK } from '@/constants/networks'
 import { getDeployedContract, NFTL_CONTRACT as NFTL_CONTRACT_NAME } from '@/constants/contracts'
 import useAuth from '@/hooks/useAuth'
+import { isAuditFixtureEnabled } from '@/audit/fixture'
 
 /*
   ~ What it does? ~
@@ -37,12 +38,12 @@ export default function useClaimableNFTL(degenTokenIndices: number[]): NFTLClaim
     args: [degenTokenIndices],
     query: {
       staleTime: 10_000,
-      enabled: degenTokenIndices?.length > 0 && isLoggedIn,
+      enabled: degenTokenIndices?.length > 0 && isLoggedIn && !isAuditFixtureEnabled,
       select: (data) => parseFloat(formatEther(data as bigint)),
     },
   })
 
-  const balance = useMemo(() => data ?? 0, [data])
+  const balance = useMemo(() => (isAuditFixtureEnabled ? 12 : (data ?? 0)), [data])
 
   return { balance, error, loading: isLoading, refetch }
 }

--- a/apps/app/src/hooks/useFetch.ts
+++ b/apps/app/src/hooks/useFetch.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useEffect, useReducer, useRef } from 'react'
+import { getAuditFixtureData, isAuditFixtureEnabled } from '@/audit/fixture'
 
 interface State<T> {
   data?: T
@@ -72,6 +73,11 @@ function useFetch<T = unknown>(url?: string, options?: Options, textOnly = false
 
     const fetchData = async () => {
       dispatch({ type: 'loading' })
+
+      if (isAuditFixtureEnabled) {
+        dispatch({ type: 'fetched', payload: getAuditFixtureData(url) as T })
+        return
+      }
 
       // If a cache exists for this url, return it
       if (cache.current[url]) {

--- a/apps/app/src/hooks/useGameAccount.ts
+++ b/apps/app/src/hooks/useGameAccount.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { GAMER_ACCOUNT_API } from '@/constants/url'
 import type { Account } from '@/types/account'
 import { AUTH_Token } from '@/types/auth'
+import { AUDIT_FIXTURE_ACCOUNT, isAuditFixtureEnabled } from '@/audit/fixture'
 import useAuth from './useAuth'
 
 interface GameAccountState {
@@ -27,10 +28,15 @@ const useGameAccount = (): GameAccountState => {
   const { data, isLoading, error, refetch } = useQuery<Account>({
     queryKey: ['game-account'],
     queryFn: () => fetchGameAccount(authToken),
-    enabled: !!authToken && isLoggedIn,
+    enabled: !isAuditFixtureEnabled && !!authToken && isLoggedIn,
   })
 
-  return { account: data, accountError: error, loadingAccount: isLoading, refetchAccount: refetch }
+  return {
+    account: isAuditFixtureEnabled && isLoggedIn ? AUDIT_FIXTURE_ACCOUNT : data,
+    accountError: isAuditFixtureEnabled ? null : error,
+    loadingAccount: isAuditFixtureEnabled ? false : isLoading,
+    refetchAccount: isAuditFixtureEnabled ? () => {} : refetch,
+  }
 }
 
 export default useGameAccount

--- a/apps/app/src/types/dialog.ts
+++ b/apps/app/src/types/dialog.ts
@@ -1,4 +1,8 @@
-export interface DialogProps {
+import type { ComponentProps } from 'react'
+
+import type { DialogContent } from '@nl/ui/base/dialog'
+
+export interface DialogProps extends Omit<ComponentProps<typeof DialogContent>, 'children'> {
   dialogTitle?: React.ReactNode | string
   dividers?: boolean
   sx?: React.CSSProperties

--- a/packages/ui/src/components/base/base-components.test.tsx
+++ b/packages/ui/src/components/base/base-components.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, jest, mock } from 'bun:test'
+import { useState } from 'react'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@nl/ui/base/accordion'
 import { Alert, AlertDescription, AlertTitle } from '@nl/ui/base/alert'
 import {
@@ -236,6 +237,35 @@ describe('base overlay and navigation primitives', () => {
     expect(document.documentElement.style.overflow).toBe('hidden')
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
     expect(onOpenChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('keeps document scrolling locked until every open dialog closes', () => {
+    const ConcurrentDialogs = () => {
+      const [outerOpen, setOuterOpen] = useState(true)
+      const [innerOpen, setInnerOpen] = useState(true)
+
+      return (
+        <>
+          <Dialog open={outerOpen} onOpenChange={setOuterOpen} />
+          <Dialog open={innerOpen} onOpenChange={setInnerOpen} />
+          <button type="button" onClick={() => setInnerOpen(false)}>
+            Close inner
+          </button>
+          <button type="button" onClick={() => setOuterOpen(false)}>
+            Close outer
+          </button>
+        </>
+      )
+    }
+
+    render(<ConcurrentDialogs />)
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close inner' }))
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close outer' }))
+    expect(document.documentElement.style.overflow).toBe('')
   })
 
   it('renders alert-dialog, sheet sides, tooltip, and navigation composition', () => {

--- a/packages/ui/src/components/base/dialog.tsx
+++ b/packages/ui/src/components/base/dialog.tsx
@@ -6,10 +6,47 @@ import { XIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'
 
+const openDialogLocks = new Set<symbol>()
+let previousHtmlOverflow = ''
+
+function lockDialogScroll(lockId: symbol) {
+  if (openDialogLocks.has(lockId)) return
+
+  if (openDialogLocks.size === 0) {
+    const htmlElement = document.documentElement
+    previousHtmlOverflow = htmlElement.style.overflow
+    htmlElement.style.overflow = 'hidden'
+  }
+
+  openDialogLocks.add(lockId)
+}
+
+function unlockDialogScroll(lockId: symbol) {
+  if (!openDialogLocks.delete(lockId) || openDialogLocks.size > 0) return
+
+  document.documentElement.style.overflow = previousHtmlOverflow
+  previousHtmlOverflow = ''
+}
+
 function Dialog({ onOpenChange, ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  const lockId = React.useRef(Symbol())
+
+  React.useEffect(() => {
+    const currentLockId = lockId.current
+
+    if (props.open !== undefined) {
+      if (props.open) lockDialogScroll(currentLockId)
+      else unlockDialogScroll(currentLockId)
+    } else if (props.defaultOpen) {
+      lockDialogScroll(currentLockId)
+    }
+
+    return () => unlockDialogScroll(currentLockId)
+  }, [props.defaultOpen, props.open])
+
   const handleOpenState = (open: boolean) => {
-    const htmlElement = document.querySelector('html') as HTMLElement
-    htmlElement.style.overflow = open ? 'hidden' : ''
+    if (open) lockDialogScroll(lockId.current)
+    else unlockDialogScroll(lockId.current)
     onOpenChange?.(open)
   }
 
@@ -36,7 +73,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 z-100',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[1200] bg-black/50',
         className
       )}
       {...props}
@@ -56,7 +93,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-[calc(100%-2rem)] md:max-w-xl lg:max-w-2xl z-100',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[1201] grid max-h-[calc(100vh-2rem)] min-w-0 w-full max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-[calc(100%-2rem)] md:max-w-xl lg:max-w-2xl',
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Promote the validated `staging` tree to `main`.

This exact-tree promotion is based on `main` because the repository history contains equivalent re-alignment commits on both protected branches; the resulting tree is byte-for-byte identical to `origin/staging` and contains the validated `apps/app` audit fixes from #417.

## Validation

- Feature PR #417 merged into `staging` with squash.
- Feature CI: format, lint, type-check, build, unit tests, and gate passed.
- Responsive browser audit covered mobile, tablet, desktop, authenticated dashboard routes, public routes, and dialogs with opt-in fixtures.
- The promotion branch tree matches `origin/staging` exactly.

Promotion must use the repository-required rebase merge into `main`.