### PR TITLE
fix(api): restrict proxied upstream URLs

### DIFF
--- a/apps/api/src/utils/api.network.test.ts
+++ b/apps/api/src/utils/api.network.test.ts
@@ -94,7 +94,7 @@ describe('api.pipeRequest', () => {
       return { setTimeout: mock(), on: mock(), destroy: mock() }
     })
 
-    pipeRequest('https://example.com/x', res)
+    pipeRequest('https://nifty-league.s3.amazonaws.com/x', res)
     await new Promise((r) => setTimeout(r, 5))
 
     expect((res as any).setHeader).toHaveBeenCalledWith('content-type', 'application/json')
@@ -130,7 +130,7 @@ describe('api.pipeRequest', () => {
       return { setTimeout: mock(), on: mock(), destroy: mock() }
     })
 
-    pipeRequest('https://example.com/missing', res)
+    pipeRequest('https://nifty-league.s3.amazonaws.com/missing', res)
     await new Promise((r) => setTimeout(r, 5))
 
     expect((res as any).status).toHaveBeenCalledWith(404)
@@ -160,7 +160,7 @@ describe('api.pipeRequest', () => {
     }
     mockHttpsGet.mockReturnValue(fakeReq as never)
 
-    pipeRequest('https://example.com/x', res)
+    pipeRequest('https://nifty-league.s3.amazonaws.com/x', res)
     await new Promise((r) => setTimeout(r, 5))
 
     expect((res as any).status).toHaveBeenCalledWith(502)
@@ -200,7 +200,7 @@ describe('api.pipeRequest', () => {
       return req
     })
 
-    pipeRequest('https://example.com/x', res)
+    pipeRequest('https://nifty-league.s3.amazonaws.com/x', res)
     await new Promise((r) => setTimeout(r, 20))
 
     expect((res as any).status).toHaveBeenCalledWith(502)
@@ -230,11 +230,28 @@ describe('api.pipeRequest', () => {
     }
     mockHttpsGet.mockReturnValue(fakeReq as never)
 
-    pipeRequest('https://example.com/x', res)
+    pipeRequest('https://nifty-league.s3.amazonaws.com/x', res)
     await new Promise((r) => setTimeout(r, 5))
 
     expect((res as any).end).toHaveBeenCalled()
     expect((res as any).status).not.toHaveBeenCalled()
     expect((res as any).json).not.toHaveBeenCalled()
+  })
+
+  it('rejects upstream URLs outside the S3 allowlist', () => {
+    const res = {
+      status: mock(function (this: any) {
+        return this
+      }),
+      json: mock(),
+    } as unknown as Response
+
+    pipeRequest('https://example.com/internal', res)
+
+    expect((res as any).status).toHaveBeenCalledWith(400)
+    expect((res as any).json).toHaveBeenCalledWith({
+      errors: [{ message: 'Unsupported upstream URL' }],
+    })
+    expect(mockHttpsGet).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/utils/api.ts
+++ b/apps/api/src/utils/api.ts
@@ -3,7 +3,27 @@ import https from 'https'
 import type { Request, Response } from 'express'
 import type { Metadata } from '@/types'
 
+import { S3_BASE_URL } from '../constants/aws'
+
 const REQUEST_TIMEOUT_MS = 10000
+const ALLOWED_UPSTREAM_ORIGIN = new URL(S3_BASE_URL).origin
+
+const toAllowedUpstreamUrl = (value: string): URL | null => {
+  try {
+    const upstreamUrl = new URL(value)
+    if (
+      upstreamUrl.protocol !== 'https:' ||
+      upstreamUrl.origin !== ALLOWED_UPSTREAM_ORIGIN ||
+      upstreamUrl.username ||
+      upstreamUrl.password
+    ) {
+      return null
+    }
+    return upstreamUrl
+  } catch {
+    return null
+  }
+}
 
 // node-fetch v3 accepts an AbortSignal timeout option. Keeps slow/dead
 // upstreams from hanging the function up to maxDuration, matching the
@@ -35,7 +55,13 @@ export async function resolveDegenMetadata(req: Request): Promise<Metadata | nul
 // handling that returns the app's standard { errors: [...] } 502 shape, and
 // guaranteed response termination on both success and failure.
 export const pipeRequest = (url: string, res: Response) => {
-  const req = https.get(url, (getRes: any) => {
+  const upstreamUrl = toAllowedUpstreamUrl(url)
+  if (!upstreamUrl) {
+    res.status(400).json({ errors: [{ message: 'Unsupported upstream URL' }] })
+    return
+  }
+
+  const req = https.get(upstreamUrl, (getRes: any) => {
     if (getRes.statusCode && getRes.statusCode >= 400) {
       getRes.resume()
       res


### PR DESCRIPTION
Fix the critical CodeQL server-side request forgery finding in the API proxy. `pipeRequest` now accepts only HTTPS URLs on the configured Nifty League S3 origin and fails closed before opening a socket. Tests cover the allowlist rejection and existing proxy behavior.

Validation already run on the promotion worktree:
- API unit: 19 files passed
- API integration: 21 passed, 0 failed
- API type-check and build passed
- API lint and formatting passed
