### PR TITLE
fix(api): allowlist timed upstream fetches

### DIFF
--- a/apps/api/src/utils/api.network.test.ts
+++ b/apps/api/src/utils/api.network.test.ts
@@ -27,18 +27,23 @@ describe('api.fetchMetadata', () => {
       json: async () => ({ name: 'Degen', id: 1 }),
     })
 
-    const meta = await fetchMetadata('https://example.com/1.json')
+    const meta = await fetchMetadata('https://nifty-league.s3.amazonaws.com/1.json')
     expect(meta).toEqual({ name: 'Degen', id: 1 })
   })
 
   it('returns null when the response status is >= 400', async () => {
     mockFetch.mockResolvedValue({ status: 500, json: async () => ({}) })
-    expect(await fetchMetadata('https://example.com/1.json')).toBeNull()
+    expect(await fetchMetadata('https://nifty-league.s3.amazonaws.com/1.json')).toBeNull()
   })
 
   it('returns null when the fetch throws', async () => {
     mockFetch.mockRejectedValue(new Error('network down'))
-    expect(await fetchMetadata('https://example.com/1.json')).toBeNull()
+    expect(await fetchMetadata('https://nifty-league.s3.amazonaws.com/1.json')).toBeNull()
+  })
+
+  it('fails closed for an unsupported upstream host', async () => {
+    expect(await fetchMetadata('https://example.com/internal')).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 })
 
@@ -50,8 +55,11 @@ describe('api.resolveDegenMetadata', () => {
     const meta = await resolveDegenMetadata(req)
     expect(meta).toEqual({ token_id: 7 })
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://nifty-league.s3.amazonaws.com/degens/mainnet/metadata/7.json',
+      expect.any(URL),
       expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    expect((mockFetch.mock.calls[0] as [URL])[0].href).toBe(
+      'https://nifty-league.s3.amazonaws.com/degens/mainnet/metadata/7.json'
     )
   })
 

--- a/apps/api/src/utils/api.ts
+++ b/apps/api/src/utils/api.ts
@@ -7,13 +7,19 @@ import { S3_BASE_URL } from '../constants/aws'
 
 const REQUEST_TIMEOUT_MS = 10000
 const ALLOWED_UPSTREAM_ORIGIN = new URL(S3_BASE_URL).origin
+const ALLOWED_S3_HOSTNAME = new URL(S3_BASE_URL).hostname
 
-const toAllowedUpstreamUrl = (value: string): URL | null => {
+const isAllowedFetchHostname = (hostname: string) =>
+  hostname === ALLOWED_S3_HOSTNAME ||
+  hostname === 'eth-mainnet.g.alchemy.com' ||
+  hostname === 'eth-sepolia.g.alchemy.com'
+
+const toAllowedFetchUrl = (value: string): URL | null => {
   try {
     const upstreamUrl = new URL(value)
     if (
       upstreamUrl.protocol !== 'https:' ||
-      upstreamUrl.origin !== ALLOWED_UPSTREAM_ORIGIN ||
+      !isAllowedFetchHostname(upstreamUrl.hostname) ||
       upstreamUrl.username ||
       upstreamUrl.password
     ) {
@@ -25,11 +31,19 @@ const toAllowedUpstreamUrl = (value: string): URL | null => {
   }
 }
 
+const toAllowedUpstreamUrl = (value: string): URL | null => {
+  const upstreamUrl = toAllowedFetchUrl(value)
+  return upstreamUrl?.origin === ALLOWED_UPSTREAM_ORIGIN ? upstreamUrl : null
+}
+
 // node-fetch v3 accepts an AbortSignal timeout option. Keeps slow/dead
 // upstreams from hanging the function up to maxDuration, matching the
 // timeout behaviour used in pipeRequest and degensBurned.
-export const fetchWithTimeout = (url: string, options: any = {}) =>
-  fetch(url, { ...options, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+export const fetchWithTimeout = async (url: string, options: any = {}) => {
+  const upstreamUrl = toAllowedFetchUrl(url)
+  if (!upstreamUrl) throw new Error('Unsupported upstream URL')
+  return fetch(upstreamUrl, { ...options, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
+}
 
 export async function fetchMetadata(URI: string): Promise<Metadata | null> {
   try {

--- a/apps/api/src/utils/degensBurned.test.ts
+++ b/apps/api/src/utils/degensBurned.test.ts
@@ -46,7 +46,7 @@ describe('fetchBurnedDegens', () => {
 
     await expect(fetchBurnedDegens()).resolves.toEqual([1, 2, 5, 9])
     expect(fetchMock).toHaveBeenCalledTimes(3)
-    const urls = fetchMock.mock.calls.map((c) => c[0] as string)
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
     // Both burn wallets are queried (concurrently) and pagination is followed.
     expect(urls.filter((u) => u.includes('&pageKey=next'))).toHaveLength(1)
     expect(


### PR DESCRIPTION
## Summary
- extend the existing SSRF protection to the shared timed fetch helper
- allow only HTTPS requests to the configured S3 origin and fixed Alchemy hosts
- fail closed before network access for unsupported hosts and update URL-object tests

## Validation
- `bun --filter api test:unit` — 19 files passed
- `bun --filter api type-check` — passed
- `bun --filter api build` — passed
- `bun --filter api test:integration` — 21 passed, 0 failed
- `bun --filter api lint` — passed with one existing warning
- `git diff --check` — passed

This keeps staging aligned with the CodeQL fix required before the staging-to-main promotion.