### PR TITLE
fix(api): pass only fixed upstream host to proxy

### DIFF
--- a/apps/api/src/utils/api.network.test.ts
+++ b/apps/api/src/utils/api.network.test.ts
@@ -97,7 +97,7 @@ describe('api.pipeRequest', () => {
         return this
       }),
     }
-    mockHttpsGet.mockImplementation((_url: string, cb: (s: any) => void) => {
+    mockHttpsGet.mockImplementation((_options: any, cb: (s: any) => void) => {
       cb(fakeStream)
       return { setTimeout: mock(), on: mock(), destroy: mock() }
     })
@@ -105,6 +105,14 @@ describe('api.pipeRequest', () => {
     pipeRequest('https://nifty-league.s3.amazonaws.com/x', res)
     await new Promise((r) => setTimeout(r, 5))
 
+    expect((mockHttpsGet.mock.calls[0] as [any])[0]).toEqual(
+      expect.objectContaining({
+        hostname: 'nifty-league.s3.amazonaws.com',
+        path: '/x',
+        port: 443,
+        protocol: 'https:',
+      })
+    )
     expect((res as any).setHeader).toHaveBeenCalledWith('content-type', 'application/json')
     expect((res as any).setHeader).toHaveBeenCalledWith(
       'cache-control',
@@ -133,7 +141,7 @@ describe('api.pipeRequest', () => {
         return this
       }),
     }
-    mockHttpsGet.mockImplementation((_url: string, cb: (s: any) => void) => {
+    mockHttpsGet.mockImplementation((_options: any, cb: (s: any) => void) => {
       cb(fakeStream)
       return { setTimeout: mock(), on: mock(), destroy: mock() }
     })
@@ -186,7 +194,7 @@ describe('api.pipeRequest', () => {
       end: mock(),
     } as unknown as Response
 
-    mockHttpsGet.mockImplementation((_url: string, cb: (s: any) => void) => {
+    mockHttpsGet.mockImplementation((_options: any, cb: (s: any) => void) => {
       const req = {
         setTimeout: mock(function (this: any, _ms: number, timeoutCb: () => void) {
           setImmediate(timeoutCb)

--- a/apps/api/src/utils/api.ts
+++ b/apps/api/src/utils/api.ts
@@ -31,9 +31,10 @@ const toAllowedFetchUrl = (value: string): URL | null => {
   }
 }
 
-const toAllowedUpstreamUrl = (value: string): URL | null => {
+const toAllowedUpstreamPath = (value: string): string | null => {
   const upstreamUrl = toAllowedFetchUrl(value)
-  return upstreamUrl?.origin === ALLOWED_UPSTREAM_ORIGIN ? upstreamUrl : null
+  if (upstreamUrl?.origin !== ALLOWED_UPSTREAM_ORIGIN) return null
+  return `${upstreamUrl.pathname}${upstreamUrl.search}`
 }
 
 // node-fetch v3 accepts an AbortSignal timeout option. Keeps slow/dead
@@ -69,26 +70,34 @@ export async function resolveDegenMetadata(req: Request): Promise<Metadata | nul
 // handling that returns the app's standard { errors: [...] } 502 shape, and
 // guaranteed response termination on both success and failure.
 export const pipeRequest = (url: string, res: Response) => {
-  const upstreamUrl = toAllowedUpstreamUrl(url)
-  if (!upstreamUrl) {
+  const upstreamPath = toAllowedUpstreamPath(url)
+  if (!upstreamPath) {
     res.status(400).json({ errors: [{ message: 'Unsupported upstream URL' }] })
     return
   }
 
-  const req = https.get(upstreamUrl, (getRes: any) => {
-    if (getRes.statusCode && getRes.statusCode >= 400) {
-      getRes.resume()
-      res
-        .status(getRes.statusCode)
-        .json({ errors: [{ message: `Upstream error: ${getRes.statusCode}` }] })
-      return
+  const req = https.get(
+    {
+      protocol: 'https:',
+      hostname: ALLOWED_S3_HOSTNAME,
+      port: 443,
+      path: upstreamPath,
+    },
+    (getRes: any) => {
+      if (getRes.statusCode && getRes.statusCode >= 400) {
+        getRes.resume()
+        res
+          .status(getRes.statusCode)
+          .json({ errors: [{ message: `Upstream error: ${getRes.statusCode}` }] })
+        return
+      }
+      const contentType = getRes.headers['content-type']
+      if (contentType) res.setHeader('content-type', contentType)
+      // S3 metadata / images are immutable — let the edge cache them.
+      res.setHeader('cache-control', 'public, max-age=86400, immutable')
+      getRes.pipe(res)
     }
-    const contentType = getRes.headers['content-type']
-    if (contentType) res.setHeader('content-type', contentType)
-    // S3 metadata / images are immutable — let the edge cache them.
-    res.setHeader('cache-control', 'public, max-age=86400, immutable')
-    getRes.pipe(res)
-  })
+  )
 
   req.setTimeout(REQUEST_TIMEOUT_MS, () => {
     req.destroy(new Error('Upstream request timed out'))


### PR DESCRIPTION
## Summary
- pass a fixed S3 hostname to `https.get` and the validated URL path separately
- preserve the existing HTTPS S3 allowlist and timeout behavior
- add a regression assertion that the proxy cannot receive a user-controlled host

## Validation
- `bun --filter api test:unit` — 19 files passed
- `bun --filter api type-check` — passed
- `bun --filter api build` — passed
- `bun --filter api test:integration` — 21 passed, 0 failed
- `bun --filter api lint` — passed with one existing warning
- `git diff --check` — passed

This is the scanner-compatible follow-up required before promoting the tested staging tree to main.