### PR TITLE
chore: promote staging tree to main (2026-08-10)

### DIFF
--- a/.github/workflows/re-align-staging.yml
+++ b/.github/workflows/re-align-staging.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 0
 
@@ -45,15 +45,11 @@ jobs:
             # A divergent tree is not necessarily drift: staging may contain
             # legitimate forward work. Preview the exact merge policy used by
             # the PR and compare its resulting tree with staging instead.
-            git checkout --detach origin/staging
-            if git merge origin/main --no-commit --no-ff -X ours \
-              -m "chore: preview main into staging"; then
-              MERGED_TREE=$(git write-tree)
-              # A successful preview can be a no-op ("Already up to date.")
-              # when main is an ancestor of staging, in which case no
-              # MERGE_HEAD is created and abort would fail. Mirror the
-              # conflict branch's guard so drift detection never crashes.
-              git merge --abort 2>/dev/null || true
+            # merge-tree computes the result without creating a commit, so
+            # detection is independent of runner Git identity configuration
+            # and handles already-up-to-date refs as a no-op.
+            if MERGED_TREE=$(git merge-tree --write-tree -X ours \
+              origin/staging origin/main); then
               if [ "$MERGED_TREE" = "$STAGING_TREE" ]; then
                 echo "Main is already represented in staging under the"
                 echo "re-alignment merge policy."
@@ -63,10 +59,9 @@ jobs:
                 echo "drifted=true" >> "$GITHUB_OUTPUT"
               fi
             else
-              git merge --abort 2>/dev/null || true
-              echo "The re-alignment merge preview has conflicts;"
+              echo "The re-alignment merge preview failed (likely a conflict);"
               echo "failing closed for review."
-              echo "drifted=true" >> "$GITHUB_OUTPUT"
+              exit 1
             fi
           fi
 

--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -1,0 +1,66 @@
+import type { ComponentProps, PropsWithChildren } from 'react'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+/* eslint-disable @next/next/no-img-element */
+
+describe('home page', () => {
+  let Home: typeof import('./page').default
+
+  beforeEach(async () => {
+    mock.module('@/components/MainLayout', () => ({
+      default: ({ children }: PropsWithChildren) => <>{children}</>,
+    }))
+    mock.module('@nl/ui/custom/animated-wrapper', () => ({
+      AnimatedWrapper: ({ children }: PropsWithChildren) => <>{children}</>,
+    }))
+    mock.module('@/components/BouncingNFTL', () => ({ default: () => null }))
+    mock.module('@/components/MintOMatic', () => ({ default: () => null }))
+    mock.module('@/components/Sponsors', () => ({ default: () => null }))
+    mock.module('@/components/ThemeBtnGroup', () => ({ default: () => null }))
+    mock.module('@nl/ui/custom/console-game', () => ({ ConsoleGame: () => null }))
+    // The home page renders the interactive DEGEN carousel through a shared
+    // wrapper; stub the heavy carousel library out for these markup-level
+    // assertions (it is unchanged by this tranche).
+    mock.module('@/components/Carousel', () => ({
+      default: ({ children }: PropsWithChildren) => <div data-testid="carousel">{children}</div>,
+    }))
+    mock.module('next/link', () => ({
+      default: ({ children, href, ...props }: PropsWithChildren<{ href: string }>) => (
+        <a href={href} {...props}>
+          {children}
+        </a>
+      ),
+    }))
+    mock.module('next/navigation', () => ({
+      usePathname: () => '/',
+    }))
+    mock.module('next/image', () => ({
+      default: ({
+        alt,
+        priority: _priority,
+        ...props
+      }: ComponentProps<'img'> & { priority?: boolean }) => <img alt={alt} {...props} />,
+    }))
+
+    const pageModule = await import('./page')
+    Home = pageModule.default
+  })
+
+  it('links the hero call-to-action to the gaming section anchor', () => {
+    render(<Home />)
+
+    const learnMore = screen.getByRole('link', { name: 'Learn more about Nifty League' })
+    expect(learnMore.getAttribute('href')).toBe('#gaming-section')
+    expect(document.getElementById('gaming-section')).not.toBeNull()
+  })
+
+  it('renders CSS-driven responsive labels for both breakpoints', () => {
+    render(<Home />)
+
+    const mobileLabel = screen.getByText('OWN YOUR AVATAR')
+    const desktopLabel = screen.getByText('COMMUNITY-GENERATED AVATARS')
+    expect(mobileLabel.className).toContain('responsive-label-mobile')
+    expect(desktopLabel.className).toContain('responsive-label-desktop')
+  })
+})

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,10 +1,5 @@
-'use client'
-
-import { useRef } from 'react'
-import type { NextPage } from 'next'
 import Image from 'next/image'
 
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { ConsoleGame } from '@nl/ui/custom/console-game'
 
@@ -20,7 +15,14 @@ import { SPONSORS } from '@/constants/sponsors'
 
 import '@/styles/home.css'
 
-const DesktopIntro = ({ scrollToGamingSection }: { scrollToGamingSection: () => void }) => {
+const ResponsiveLabel = ({ mobile, desktop }: { mobile: string; desktop: string }) => (
+  <>
+    <span className="responsive-label-mobile">{mobile}</span>
+    <span className="responsive-label-desktop">{desktop}</span>
+  </>
+)
+
+const DesktopIntro = () => {
   return (
     <section className="desktop relative w-screen max-h-screen overflow-hidden">
       <div>
@@ -117,9 +119,10 @@ const DesktopIntro = ({ scrollToGamingSection }: { scrollToGamingSection: () => 
           </AnimatedWrapper>
         </div>
         <AnimatedWrapper>
-          <div
+          <a
+            href="#gaming-section"
+            aria-label="Learn more about Nifty League"
             className="inline-block relative flex-grow satoshi-learn-more transition-fade-slow transition-fade-start delay-long"
-            onClick={scrollToGamingSection}
           >
             <Image
               src="/img/hero/speech-bubble.webp"
@@ -130,7 +133,7 @@ const DesktopIntro = ({ scrollToGamingSection }: { scrollToGamingSection: () => 
               className="w-full h-auto"
             />
             <p className="m-0 p-0 speech-bubble-text">Learn More!</p>
-          </div>
+          </a>
         </AnimatedWrapper>
       </div>
     </section>
@@ -179,22 +182,14 @@ const MobileIntro = () => {
   )
 }
 
-const Home: NextPage = () => {
-  const isMobile = useMediaQuery('(max-width:768px)')
-  const gamingSectionRef = useRef<HTMLDivElement>(null)
-
-  const scrollToGamingSection = () => {
-    if (!gamingSectionRef.current) return
-    ;(gamingSectionRef.current as HTMLDivElement).scrollIntoView()
-  }
-
+const Home = () => {
   return (
     <MainLayout classes={{ root: 'home-pg' }}>
       <MobileIntro />
-      <DesktopIntro scrollToGamingSection={scrollToGamingSection} />
+      <DesktopIntro />
 
       {/* SMASHERS */}
-      <section className="w-screen relative text-center" ref={gamingSectionRef}>
+      <section id="gaming-section" className="w-screen relative text-center">
         <AnimatedWrapper>
           <h2 className="absolute w-full z-10 -mt-4 sm:mt-8 md:mt-16 lg:mt-22 transition-vertical-fade transition-vertical-fade-start">
             CLASSIC GAMING REINVENTED
@@ -213,11 +208,8 @@ const Home: NextPage = () => {
       {/* DEGENS */}
       <section className="section w-screen relative flex flex-col text-center sliding-nfts">
         <AnimatedWrapper>
-          <h2
-            className="my-3 lg:my-5 px-5 sm:px-8 transition-vertical-fade transition-vertical-fade-start"
-            suppressHydrationWarning
-          >
-            {isMobile ? 'OWN YOUR AVATAR' : 'COMMUNITY-GENERATED AVATARS'}
+          <h2 className="my-3 lg:my-5 px-5 sm:px-8 transition-vertical-fade transition-vertical-fade-start">
+            <ResponsiveLabel mobile="OWN YOUR AVATAR" desktop="COMMUNITY-GENERATED AVATARS" />
           </h2>
         </AnimatedWrapper>
 
@@ -276,7 +268,8 @@ const Home: NextPage = () => {
               className="md:justify-start"
               primary={{
                 href: 'https://niftysmashers.com',
-                title: isMobile ? 'BRAWL!' : "LET'S BRAWL!",
+                title: "LET'S BRAWL!",
+                responsiveTitle: { mobile: 'BRAWL!', desktop: "LET'S BRAWL!" },
                 external: true,
               }}
               secondary={{ href: '/compete-and-earn', title: 'LEARN MORE' }}
@@ -480,7 +473,8 @@ const Home: NextPage = () => {
               className="md:justify-start"
               primary={{
                 href: 'https://discord.gg/niftyleague',
-                title: isMobile ? 'DISCORD' : 'JOIN DISCORD',
+                title: 'JOIN DISCORD',
+                responsiveTitle: { mobile: 'DISCORD', desktop: 'JOIN DISCORD' },
                 external: true,
               }}
               secondary={{ href: '/community', title: 'VIEW MORE' }}
@@ -501,7 +495,8 @@ const Home: NextPage = () => {
           primary={{ href: '/careers', title: 'JOIN THE TEAM' }}
           secondary={{
             href: '/blog',
-            title: isMobile ? 'READ BLOG' : 'READ OUR BLOG',
+            title: 'READ OUR BLOG',
+            responsiveTitle: { mobile: 'READ BLOG', desktop: 'READ OUR BLOG' },
             external: true,
           }}
         />

--- a/apps/web/src/components/Carousel/index.tsx
+++ b/apps/web/src/components/Carousel/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { memo } from 'react'
 import Carousel from 'react-multi-carousel'
 import 'react-multi-carousel/lib/styles.css'

--- a/apps/web/src/components/ThemeBtnGroup/index.tsx
+++ b/apps/web/src/components/ThemeBtnGroup/index.tsx
@@ -8,6 +8,7 @@ import { ExternalIcon } from '@nl/ui/custom/external-icon'
 interface ButtonProps {
   href?: string | UrlObject
   title: string
+  responsiveTitle?: { mobile: string; desktop: string }
   className?: string
   disabled?: boolean
   external?: boolean
@@ -16,6 +17,7 @@ interface ButtonProps {
 export const ThemeBtn = ({
   href,
   title,
+  responsiveTitle,
   className = '',
   disabled = false,
   external = false,
@@ -34,7 +36,14 @@ export const ThemeBtn = ({
     )}
     suppressHydrationWarning
   >
-    {title}
+    {responsiveTitle ? (
+      <>
+        <span className="responsive-label-mobile">{responsiveTitle.mobile}</span>
+        <span className="responsive-label-desktop">{responsiveTitle.desktop}</span>
+      </>
+    ) : (
+      title
+    )}
     {external && <ExternalIcon />}
   </Link>
 )

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -12,9 +12,25 @@
   --subheader-letter-spacing: var(--special-letter-spacing);
 }
 
+.responsive-label-mobile {
+  display: inline;
+}
+
+.responsive-label-desktop {
+  display: none;
+}
+
 /* ==============================|| MEDIA QUERIES ||============================== */
 
 @media (min-width: 769px) {
+  .responsive-label-mobile {
+    display: none;
+  }
+
+  .responsive-label-desktop {
+    display: inline;
+  }
+
   .desktop {
     display: flex !important;
   }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "**": false,
-      "main": true,
-      "staging": true
-    }
+    "deploymentEnabled": true
   }
 }

--- a/packages/ui/src/hooks/useOnScreen.ts
+++ b/packages/ui/src/hooks/useOnScreen.ts
@@ -2,6 +2,44 @@
 
 import { RefObject, useState, useEffect } from 'react'
 
+type VisibilityCallback = (isIntersecting: boolean) => void
+
+type SharedObserver = {
+  observer: IntersectionObserver
+  elements: Set<Element>
+}
+
+/**
+ * Shared IntersectionObserver instances keyed by rootMargin.
+ *
+ * Consumers (e.g. every `AnimatedWrapper` on the landing page and every
+ * `DegenCardInView` in the app) previously created one native observer per
+ * mounted component. Keeping a single observer per distinct rootMargin avoids
+ * instantiating dozens of observers on pages that render many animated
+ * wrappers while preserving identical visibility semantics.
+ */
+const observersByRootMargin = new Map<string, SharedObserver>()
+const callbacksByElement = new Map<Element, Set<VisibilityCallback>>()
+
+const getSharedObserver = (rootMargin: string): SharedObserver => {
+  let sharedObserver = observersByRootMargin.get(rootMargin)
+  if (!sharedObserver) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          callbacksByElement.get(entry.target)?.forEach((callback) => {
+            callback(entry.isIntersecting)
+          })
+        }
+      },
+      { rootMargin }
+    )
+    sharedObserver = { observer, elements: new Set() }
+    observersByRootMargin.set(rootMargin, sharedObserver)
+  }
+  return sharedObserver
+}
+
 export function useOnScreen<T extends Element = HTMLDivElement>(
   ref: RefObject<T | null>,
   rootMargin: string = '0px'
@@ -9,26 +47,30 @@ export function useOnScreen<T extends Element = HTMLDivElement>(
   // State and setter for storing whether element is visible
   const [isIntersecting, setIntersecting] = useState<boolean>(false)
   useEffect(() => {
-    if (!ref || !ref.current) return
+    const element = ref.current
+    if (!element) return
 
-    const wrapperRef = ref.current
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        // Update our state when observer callback fires
-        if (entry) setIntersecting(entry.isIntersecting)
-      },
-      { rootMargin }
-    )
-    if (wrapperRef) {
-      observer.observe(wrapperRef)
-    }
+    const sharedObserver = getSharedObserver(rootMargin)
+    const callbacks = callbacksByElement.get(element) ?? new Set<VisibilityCallback>()
+    callbacks.add(setIntersecting)
+    callbacksByElement.set(element, callbacks)
+    sharedObserver.elements.add(element)
+    sharedObserver.observer.observe(element)
     return () => {
-      if (wrapperRef) {
-        observer.unobserve(wrapperRef)
+      callbacks.delete(setIntersecting)
+      if (callbacks.size === 0) {
+        callbacksByElement.delete(element)
+        sharedObserver.elements.delete(element)
+        sharedObserver.observer.unobserve(element)
+      }
+      if (sharedObserver.elements.size === 0) {
+        sharedObserver.observer.disconnect?.()
+        observersByRootMargin.delete(rootMargin)
       }
     }
+    // ref is intentionally excluded: callbacks must not re-subscribe on re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // Empty array ensures that effect is only run on mount and unmount
+  }, [rootMargin])
   return isIntersecting
 }
 

--- a/packages/ui/src/hooks/visibility.test.tsx
+++ b/packages/ui/src/hooks/visibility.test.tsx
@@ -34,7 +34,10 @@ describe('useOnScreen', () => {
 
     expect(observe).toHaveBeenCalledWith(element)
     act(() =>
-      intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never)
+      intersectionCallback(
+        [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+        {} as never
+      )
     )
     expect(result.current).toBe(true)
     unmount()
@@ -44,6 +47,94 @@ describe('useOnScreen', () => {
   it('stays false when no element is mounted', () => {
     expect(renderHook(() => useOnScreen({ current: null })).result.current).toBe(false)
     expect(observe).not.toHaveBeenCalled()
+  })
+
+  it('shares one observer across consumers that use the same rootMargin', () => {
+    const constructorCalls = mock()
+    stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor() {
+          constructorCalls()
+        }
+        observe = observe
+        unobserve = unobserve
+      }
+    )
+
+    const firstElement = document.createElement('div')
+    const secondElement = document.createElement('div')
+    renderHook(() => useOnScreen({ current: firstElement }, '10px'))
+    renderHook(() => useOnScreen({ current: secondElement }, '10px'))
+
+    expect(constructorCalls).toHaveBeenCalledTimes(1)
+    expect(observe).toHaveBeenCalledWith(firstElement)
+    expect(observe).toHaveBeenCalledWith(secondElement)
+  })
+
+  it('creates a separate observer for a distinct rootMargin', () => {
+    const constructorCalls = mock()
+    stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor() {
+          constructorCalls()
+        }
+        observe = observe
+        unobserve = unobserve
+      }
+    )
+
+    renderHook(() => useOnScreen({ current: document.createElement('div') }, '40px'))
+    renderHook(() => useOnScreen({ current: document.createElement('div') }, '50px'))
+
+    expect(constructorCalls).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps notifying remaining consumers after a sibling unmounts', () => {
+    stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+        observe = observe
+        unobserve = unobserve
+      }
+    )
+
+    const firstElement = document.createElement('div')
+    const secondElement = document.createElement('div')
+    const first = renderHook(() => useOnScreen({ current: firstElement }, '70px'))
+    const second = renderHook(() => useOnScreen({ current: secondElement }, '70px'))
+
+    first.unmount()
+    expect(unobserve).toHaveBeenCalledWith(firstElement)
+
+    act(() =>
+      intersectionCallback(
+        [{ target: secondElement, isIntersecting: true } as IntersectionObserverEntry],
+        {} as never
+      )
+    )
+    expect(second.result.current).toBe(true)
+  })
+
+  it('disconnects a shared observer after its last consumer unmounts', () => {
+    const disconnect = mock()
+    stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = observe
+        unobserve = unobserve
+        disconnect = disconnect
+      }
+    )
+
+    const hook = renderHook(() => useOnScreen({ current: document.createElement('div') }, '80px'))
+    hook.unmount()
+
+    expect(disconnect).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
Promotes the validated staging tree into main after staging re-alignment repair and homepage performance work.\n\nThis is an exact-tree promotion: the PR head tree matches origin/staging. It replaces stale promotion PR #453, which became conflicted after staging advanced.\n\nValidation already passed on the source PRs; this promotion remains subject to main's required checks.