### PR TITLE
perf: defer shared media and client boundaries

### DIFF
--- a/apps/app/src/app/(public-routes)/games/_GameList/index.tsx
+++ b/apps/app/src/app/(public-routes)/games/_GameList/index.tsx
@@ -12,7 +12,6 @@ const AppleBadge = ({ disabled = false }) => (
     alt="Apple Store Badge"
     width={120}
     height={40}
-    loading="eager"
     style={{
       width: '91%',
       maxWidth: '100%',
@@ -30,7 +29,6 @@ const GoogleBadge = ({ disabled = false }) => (
     alt="Get it on Google Play"
     width={564}
     height={169}
-    loading="eager"
     style={{ width: '100%', maxWidth: '100%', height: 'auto', opacity: disabled ? 0.25 : 1 }}
   />
 )
@@ -41,7 +39,6 @@ const SteamBadge = ({ disabled = false }) => (
     alt="Steam Store Badge"
     width={564}
     height={168}
-    loading="eager"
     style={{ width: '100%', maxWidth: '100%', height: 'auto', opacity: disabled ? 0.25 : 1 }}
   />
 )

--- a/apps/app/src/components/cards/DegenCard/DegenImage.tsx
+++ b/apps/app/src/components/cards/DegenCard/DegenImage.tsx
@@ -27,7 +27,9 @@ const DegenImage = memo(
       <img
         className="pixelated"
         src={image}
-        alt=""
+        alt={`Degen #${tokenId}`}
+        loading="lazy"
+        decoding="async"
         style={{ objectFit: 'cover', height: imageHeight, ...sx }}
         onError={handleImageError}
       />

--- a/apps/app/src/components/cards/GameCard.tsx
+++ b/apps/app/src/components/cards/GameCard.tsx
@@ -147,7 +147,13 @@ const GameCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<GameCar
         }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={image} alt={title} className="absolute top-0 left-0 h-full w-full object-cover" />
+        <img
+          src={image}
+          alt={title || 'Game artwork'}
+          loading="lazy"
+          decoding="async"
+          className="absolute top-0 left-0 h-full w-full object-cover"
+        />
       </div>
       {contents || (
         <CardGameContent

--- a/apps/app/src/components/cards/ImageCard.tsx
+++ b/apps/app/src/components/cards/ImageCard.tsx
@@ -21,6 +21,8 @@ const ImageCard = ({ image, thumbnail, title, ratio }: ImageCardProps) => {
           onLoad={handleImageOnLoad}
           src={thumbnail}
           alt={`thumbnail-${title}`}
+          loading="lazy"
+          decoding="async"
           style={{ ...styleImage.imageCommon, ...css.thumbnail }}
         />
       )}
@@ -29,6 +31,8 @@ const ImageCard = ({ image, thumbnail, title, ratio }: ImageCardProps) => {
           onLoad={handleImageOnLoad}
           src={image}
           alt={title}
+          loading="lazy"
+          decoding="async"
           style={{ height: '100%', ...styleImage.imageCommon, ...css.fullSize }}
         />
       )}

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next'
 import Image from 'next/image'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 import { cn } from '@nl/ui/utils'
 
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
@@ -15,19 +16,17 @@ const Games: NextPage = () => (
       <div className="w-1/3 md:w-1/2 md:px-2 lg:px-3">
         <AnimatedWrapper>
           <div className="animate-zoom-out transition-fade-start transition-fade delay-long">
-            <video
+            <ViewportVideo
               id="lobby"
               width="100%"
               height="100%"
               muted
-              autoPlay
               loop
               playsInline
               data-keepplaying
               className="hidden md:block"
-            >
-              <source src="/video/lobby.mp4" type="video/mp4" />
-            </video>
+              src="/video/lobby.mp4"
+            />
             <div className="block md:hidden">
               <Image
                 alt="Arcade"
@@ -135,19 +134,17 @@ const Games: NextPage = () => (
                     className={styles.video}
                   />
                 ) : (
-                  <video
+                  <ViewportVideo
                     id="console-video"
                     width="100%"
                     height="100%"
                     muted
-                    autoPlay
                     loop
                     playsInline
                     data-keepplaying
                     className={styles.video}
-                  >
-                    <source src={video} type="video/mp4" />
-                  </video>
+                    src={video}
+                  />
                 )}
               </div>
             </AnimatedWrapper>

--- a/apps/web/src/app/(main)/niftyworld/page.tsx
+++ b/apps/web/src/app/(main)/niftyworld/page.tsx
@@ -3,6 +3,7 @@ import type { NextPage } from 'next'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { ConsoleGame } from '@nl/ui/custom/console-game'
+import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 
 import { NIFTYWORLD_PROPERTIES } from '@/constants/niftyworld'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
@@ -50,9 +51,15 @@ const NiftyWorld: NextPage = () => {
           <div className="w-full md:w-1/2 lg:w-5/12">
             <AnimatedWrapper>
               <div className="relative text-right transition-fade-slow transition-fade-start delay-normal ps-0 lg:ps-5 mb-3">
-                <video width="100%" height="100%" muted autoPlay loop playsInline data-keepplaying>
-                  <source src="/video/arcade-token.mp4" type="video/mp4" />
-                </video>
+                <ViewportVideo
+                  width="100%"
+                  height="100%"
+                  muted
+                  loop
+                  playsInline
+                  data-keepplaying
+                  src="/video/arcade-token.mp4"
+                />
               </div>
             </AnimatedWrapper>
           </div>

--- a/apps/web/src/app/(main)/roadmap/satoshi-right.module.css
+++ b/apps/web/src/app/(main)/roadmap/satoshi-right.module.css
@@ -1,9 +1,4 @@
 .satoshiMove {
-  --breakpoint-sm: 615px;
-  --breakpoint-md: 850px;
-  --breakpoint-lg: 1000px;
-  --breakpoint-xl: 1170px;
-
   --mobile-position: 6000px;
   --medium-position: 9000px;
   --desktop-position: 12000px;
@@ -24,27 +19,27 @@
   animation-fill-mode: forwards;
 }
 
-@media only screen and (min-width: var(--breakpoint-sm)) {
+@media only screen and (min-width: 615px) {
   .satoshiMove {
     -webkit-animation-name: moveRightXs, moveDownMd, spin, hide;
     animation-name: moveRightXs, moveDownMd, spin, hide;
   }
 }
-@media only screen and (min-width: var(--breakpoint-md)) {
+@media only screen and (min-width: 850px) {
   .satoshiMove {
     width: 175px;
     -webkit-animation-name: moveRightSm, moveDownMd, spin, hide;
     animation-name: moveRightSm, moveDownMd, spin, hide;
   }
 }
-@media only screen and (min-width: var(--breakpoint-lg)) {
+@media only screen and (min-width: 1000px) {
   .satoshiMove {
     width: 200px;
     -webkit-animation-name: moveRightMd, moveDownMd, spin, hide;
     animation-name: moveRightMd, moveDownMd, spin, hide;
   }
 }
-@media only screen and (min-width: var(--breakpoint-xl)) {
+@media only screen and (min-width: 1170px) {
   .satoshiMove {
     width: 250px;
     -webkit-animation-name: moveRightLg, moveDownLg, spin, hide;

--- a/apps/web/src/components/Footer/index.tsx
+++ b/apps/web/src/components/Footer/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import type { UrlObject } from 'url'
 import { cn } from '@nl/ui/utils'

--- a/apps/web/src/components/RoadmapTimeline/index.module.css
+++ b/apps/web/src/components/RoadmapTimeline/index.module.css
@@ -422,9 +422,6 @@
 /* ==============================|| SATOSHI ||============================== */
 
 .satoshiStationary {
-  --breakpoint-md: 850px;
-  --breakpoint-lg: 1000px;
-  --breakpoint-xl: 1170px;
 }
 
 .satoshiStationary {
@@ -446,17 +443,17 @@
   animation-fill-mode: forwards;
 }
 
-@media only screen and (min-width: var(--breakpoint-md)) {
+@media only screen and (min-width: 850px) {
   .satoshiStationary {
     width: 175px;
   }
 }
-@media only screen and (min-width: var(--breakpoint-lg)) {
+@media only screen and (min-width: 1000px) {
   .satoshiStationary {
     width: 200px;
   }
 }
-@media only screen and (min-width: var(--breakpoint-xl)) {
+@media only screen and (min-width: 1170px) {
   .satoshiStationary {
     left: 50%;
     width: 250px;

--- a/apps/web/src/components/Sponsors.tsx
+++ b/apps/web/src/components/Sponsors.tsx
@@ -17,7 +17,6 @@ const SponsorItem = ({ image, url, width, height }: Sponsor): React.ReactNode =>
         src={image}
         width={width}
         height={height}
-        priority
         sizes="100vw"
         className="w-full h-auto"
       />

--- a/apps/web/src/constants/games.ts
+++ b/apps/web/src/constants/games.ts
@@ -73,7 +73,7 @@ export const NIFTY_GAMES: NiftyGame[] = [
   {
     name: 'CRYPTO WINTER',
     description: `The crypto market is currently going through an extended winter season, and only few will survive until the next cycle. Dodge snowballs, bombs and icicles and utilise pickups to defeat Pengweevil to achieve a seat at the ranking table. Weak hands need not apply, diamond hands only!`,
-    video: 'video/crypto-winter.mp4',
+    video: '/video/crypto-winter.mp4',
     tag: 'MINI-GAME',
     action: {
       title: 'START PLAYING!',
@@ -85,7 +85,7 @@ export const NIFTY_GAMES: NiftyGame[] = [
     name: 'MT. GAWX',
     description:
       "No DEGEN story is ever complete without a kickass lore behind it. DEGENs come here while the volcano is active to sink NFTL and watch the volcano roar, belching molten lava in response. It would be cute if it wasn't so scary.",
-    video: 'video/rugmans-peak.mp4',
+    video: '/video/rugmans-peak.mp4',
     tag: 'MINI-GAME',
     action: {
       title: 'MOUNTAIN CLOSED',

--- a/packages/ui/src/components/base/icon.tsx
+++ b/packages/ui/src/components/base/icon.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { forwardRef } from 'react'
 import {
   AlertCircle,

--- a/packages/ui/src/components/custom/external-icon/index.tsx
+++ b/packages/ui/src/components/custom/external-icon/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Icon, type IconProps } from '@nl/ui/base/icon'
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
+++ b/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { NavigationMenuLink } from '@nl/ui/base/navigation-menu'
+import { ExternalIcon } from '@nl/ui/custom/external-icon'
+
+export interface ActiveNavLinkProps extends React.ComponentProps<typeof NavigationMenuLink> {
+  description?: string
+  external?: boolean
+  href: string
+  title: string
+}
+
+export function ActiveNavLink({
+  description,
+  external,
+  href,
+  title,
+  ...props
+}: ActiveNavLinkProps) {
+  const pathname = usePathname()
+
+  return (
+    <NavigationMenuLink asChild data-active={href === pathname} {...props}>
+      <Link
+        href={href}
+        target={external ? '_blank' : undefined}
+        rel={external ? 'noreferrer' : undefined}
+      >
+        <div className="w-full leading-none">
+          {title}
+          {external && <ExternalIcon />}
+        </div>
+        {description && (
+          <p className="w-full text-xs leading-snug text-muted-foreground line-clamp-2">
+            {description}
+          </p>
+        )}
+      </Link>
+    </NavigationMenuLink>
+  )
+}

--- a/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { NavigationMenu } from '@nl/ui/base/navigation-menu'
+import { useScrollDetection } from '@nl/ui/hooks/useScrollDetection'
+import { cn } from '@nl/ui/utils'
+
+export default function NavbarScrollFrame({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenu>) {
+  const { ref: scrollSentinelRef, isIntersecting } = useScrollDetection()
+
+  return (
+    <>
+      <div ref={scrollSentinelRef} className="absolute inset-x-0 top-0 h-px" />
+      <NavigationMenu
+        viewport={false}
+        {...props}
+        className={cn(
+          'fixed inset-x-0 top-0 z-50 h-20 transition-all duration-500',
+          isIntersecting ? 'bg-transparent backdrop-blur-xs' : 'bg-background/90 backdrop-blur-sm',
+          className
+        )}
+      >
+        {children}
+      </NavigationMenu>
+    </>
+  )
+}

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -1,21 +1,14 @@
-'use client'
-
-import Link from 'next/link'
 import Image from 'next/image'
+import Link from 'next/link'
 import { Fragment } from 'react'
-import { usePathname } from 'next/navigation'
-import { useScrollDetection } from '@nl/ui/hooks/useScrollDetection'
-import { cn } from '@nl/ui/utils'
 
 import { Button } from '@nl/ui/base/button'
-import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import { Icon } from '@nl/ui/base/icon'
 import { Separator } from '@nl/ui/base/separator'
 import {
   NavigationMenu,
   NavigationMenuContent,
   NavigationMenuItem,
-  NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
@@ -29,6 +22,8 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@nl/ui/base/sheet'
+import { ActiveNavLink } from './ActiveNavLink'
+import NavbarScrollFrame from './NavbarScrollFrame'
 
 interface Page {
   title: string
@@ -54,36 +49,6 @@ interface NavbarProps {
   navItems: NavItemData[]
 }
 
-function NavLink({
-  description,
-  external,
-  href,
-  title,
-  ...props
-}: React.ComponentProps<typeof NavigationMenuLink> & Page) {
-  const pathname = usePathname()
-  const isActive = href === pathname
-  return (
-    <NavigationMenuLink asChild data-active={isActive} {...props}>
-      <Link
-        href={href}
-        target={external ? '_blank' : undefined}
-        rel={external ? 'noreferrer' : undefined}
-      >
-        <div className="w-full leading-none">
-          {title}
-          {external && <ExternalIcon />}
-        </div>
-        {description && (
-          <p className="w-full text-xs text-muted-foreground line-clamp-2 leading-snug">
-            {description}
-          </p>
-        )}
-      </Link>
-    </NavigationMenuLink>
-  )
-}
-
 /* ==============================|| DESKTOP NAV ||============================== */
 
 function ListItem({
@@ -95,7 +60,7 @@ function ListItem({
 }: React.ComponentPropsWithoutRef<'li'> & Page) {
   return (
     <li {...props}>
-      <NavLink
+      <ActiveNavLink
         className="text-base font-medium"
         description={description}
         external={external}
@@ -124,7 +89,7 @@ function DropdownMenuItem({ group, pages }: GroupedMenuItemData) {
 function SingleMenuItem({ type, ...page }: SingleMenuItemData) {
   return (
     <NavigationMenuItem value={page.title.toLowerCase()}>
-      <NavLink className={navigationMenuTriggerStyle()} {...page} />
+      <ActiveNavLink className={navigationMenuTriggerStyle()} {...page} />
     </NavigationMenuItem>
   )
 }
@@ -166,7 +131,7 @@ function MobileMenuGroup({ group, pages }: GroupedMenuItemData) {
         {pages.map((page) => (
           <li key={page.title}>
             <SheetClose asChild>
-              <NavLink className="text-base font-medium" {...page} />
+              <ActiveNavLink className="text-base font-medium" {...page} />
             </SheetClose>
           </li>
         ))}
@@ -179,7 +144,7 @@ function MobileMenuItem({ type, ...page }: SingleMenuItemData) {
   return (
     <NavigationMenuItem value={page.title.toLowerCase()} className="w-full">
       <SheetClose asChild>
-        <NavLink className="text-base font-medium" {...page} />
+        <ActiveNavLink className="text-base font-medium" {...page} />
       </SheetClose>
     </NavigationMenuItem>
   )
@@ -241,48 +206,30 @@ export function Navbar({
   navItems,
   ...props
 }: React.ComponentProps<typeof NavigationMenu> & NavbarProps) {
-  const { ref: scrollSentinelRef, isIntersecting } = useScrollDetection()
   return (
-    <>
-      {/*
-        This sentinel element is what the IntersectionObserver watches.
-        It sits at the very top of the page, so when it scrolls out of view,
-        we know the user has scrolled down.
-      */}
-      <div ref={scrollSentinelRef} className="absolute top-0 inset-x-0 h-px" />
-
-      <NavigationMenu
-        viewport={false}
-        // value="products"
-        className={cn(
-          'fixed top-0 inset-x-0 h-20 z-50 transition-all duration-500',
-          isIntersecting ? 'bg-transparent backdrop-blur-xs' : 'bg-background/90 backdrop-blur-sm'
-        )}
-        {...props}
-      >
-        <div className="w-screen h-full px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-          <Link href="/" className="flex-shrink-0">
-            <Image
-              src="/img/logos/NL/white.webp"
-              height={50}
-              width={52}
-              alt="Home"
-              className="h-12 w-auto transition-transform hover:scale-105"
-              loading="lazy"
-            />
-          </Link>
-
-          <DesktopNavMenu
-            actionButton={actionButton}
-            navItems={navItems.filter(
-              (item) => item.type === 'group' || (item.type === 'single' && item?.title !== 'Home')
-            )}
+    <NavbarScrollFrame {...props}>
+      <div className="flex h-full w-screen items-center justify-between px-4 sm:px-6 lg:px-8">
+        <Link href="/" className="flex-shrink-0">
+          <Image
+            src="/img/logos/NL/white.webp"
+            height={50}
+            width={52}
+            alt="Home"
+            className="h-12 w-auto transition-transform hover:scale-105"
+            loading="lazy"
           />
+        </Link>
 
-          <MobileNavMenu actionButton={actionButton} navItems={navItems} />
-        </div>
-      </NavigationMenu>
-    </>
+        <DesktopNavMenu
+          actionButton={actionButton}
+          navItems={navItems.filter(
+            (item) => item.type === 'group' || (item.type === 'single' && item?.title !== 'Home')
+          )}
+        />
+
+        <MobileNavMenu actionButton={actionButton} navItems={navItems} />
+      </div>
+    </NavbarScrollFrame>
   )
 }
 

--- a/packages/ui/src/components/custom/viewport-video/index.tsx
+++ b/packages/ui/src/components/custom/viewport-video/index.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { memo, useEffect, useRef, type VideoHTMLAttributes } from 'react'
+
+import useMediaQuery from '@nl/ui/hooks/useMediaQuery'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+type ViewportVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'autoPlay' | 'preload'> & {
+  rootMargin?: string
+  src: string
+}
+
+export const ViewportVideo = memo(function ViewportVideo({
+  rootMargin = '300px',
+  src,
+  ...props
+}: ViewportVideoProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const isNearViewport = useOnScreen(videoRef, rootMargin)
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+  const shouldPlay = isNearViewport && !prefersReducedMotion
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+
+    if (!shouldPlay) {
+      video.pause?.()
+      return
+    }
+
+    const playPromise = video.play?.()
+    playPromise?.catch(() => undefined)
+  }, [shouldPlay])
+
+  return (
+    <video
+      {...props}
+      ref={videoRef}
+      autoPlay={shouldPlay}
+      preload={shouldPlay ? 'metadata' : 'none'}
+    >
+      <source src={src} type="video/mp4" />
+    </video>
+  )
+})
+
+export default ViewportVideo

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const state = { nearViewport: true, reducedMotion: false }
+
+mock.module('@nl/ui/hooks/useOnScreen', () => ({
+  useOnScreen: () => state.nearViewport,
+}))
+mock.module('@nl/ui/hooks/useMediaQuery', () => ({
+  default: () => state.reducedMotion,
+}))
+
+describe('ViewportVideo', () => {
+  let ViewportVideo: typeof import('./index').ViewportVideo
+
+  beforeEach(() => {
+    state.nearViewport = true
+    state.reducedMotion = false
+  })
+
+  beforeEach(async () => {
+    ViewportVideo = (await import('./index')).ViewportVideo
+  })
+
+  it('only enables playback and metadata loading near the viewport', () => {
+    const { rerender } = render(
+      <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
+    )
+    const video = document.querySelector('[data-testid="video"]') as HTMLVideoElement
+
+    expect(video.autoplay).toBe(true)
+    expect(video.preload).toBe('metadata')
+    expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
+
+    state.nearViewport = false
+    rerender(<ViewportVideo data-testid="video" src="/video/example.mp4" />)
+    expect(video.autoplay).toBe(false)
+    expect(video.preload).toBe('none')
+  })
+
+  it('honors reduced-motion preferences even when visible', () => {
+    state.reducedMotion = true
+    const { container } = render(<ViewportVideo src="/video/example.mp4" />)
+    const video = container.querySelector('video') as HTMLVideoElement
+
+    expect(video.autoplay).toBe(false)
+    expect(video.preload).toBe('none')
+  })
+})


### PR DESCRIPTION
## Summary
- defer shared web videos until they approach the viewport and honor reduced-motion preferences
- lazy-load reusable app card media and correct two broken video URLs
- split navbar active-path and scroll behavior into small client islands while keeping the shadcn/Radix structure and theme
- remove invalid CSS variable media queries, eliminating the web build warnings

## Validation
- UI: type-check, lint, 133 tests passed
- app: type-check, lint, 155 tests passed, build passed
- web: type-check, lint, 13 tests passed, build passed with 0 CSS warnings
- smashers/docs: type-check, lint, build passed
- local app and web runtime smoke checks returned HTTP 200

Generated assets/robots.txt and assets/sitemap.xml were left untracked and untouched.