### PR TITLE
perf: server-render Smashers sections and defer media

### DIFF
--- a/apps/smashers/src/app/page.tsx
+++ b/apps/smashers/src/app/page.tsx
@@ -1,84 +1,29 @@
-'use client'
-
-import { use, useState, useEffect, Suspense } from 'react'
-import dynamic from 'next/dynamic'
-
-import Header from '@/components/Header'
+import { ConsoleGame } from '@nl/ui/custom/console-game'
 import { SocialsFooter } from '@nl/ui/custom/socials-footer'
 
-// Lazy load below-the-fold sections with loading states
-const Loading = () => (
-  <section>
-    <div
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <h3>Loading...</h3>
-    </div>
-  </section>
-)
-
-const ConsoleSection = dynamic(
-  () => import('@nl/ui/custom/console-game').then((mod) => mod.ConsoleGame),
-  {
-    loading: Loading,
-    ssr: false,
-  }
-)
-const GameSection = dynamic(() => import('@/components/GameSection'), {
-  loading: Loading,
-  ssr: false,
-})
-const DegensSection = dynamic(() => import('@/components/DegensSection'), {
-  loading: Loading,
-  ssr: false,
-})
+import HomeInteractive from '@/components/HomeInteractive'
+import DegensSection from '@/components/DegensSection'
+import GameSection from '@/components/GameSection'
 
 type NextSearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
-type ActiveModal = 'credits' | 'play' | 'trailer' | 'unity' | null
-
-export default function Home({ searchParams }: { searchParams: NextSearchParams }) {
-  // Modal state management
-  const [activeModal, setActiveModal] = useState<ActiveModal>(null)
-  const openModal = (modal: ActiveModal) => setActiveModal(modal)
-
-  // Handle referral link
-  const { referral } = use(searchParams)
-  useEffect(() => {
-    if (referral) {
-      const id = setTimeout(() => openModal('play'), 0)
-      return () => clearTimeout(id)
-    }
-  }, [referral])
-
+export default async function Home({ searchParams }: { searchParams: NextSearchParams }) {
+  const { referral } = await searchParams
   return (
-    <>
-      <main>
-        <section id="header">
-          <Header activeModal={activeModal} />
-        </section>
-
-        <Suspense fallback={null}>
-          <section id="console-game">
-            <ConsoleSection src="/video/smashers-960p.mp4" />
-          </section>
-          <section id="game-section" className="container section relative">
-            <div className="purple-bg-orb orb-top-left" />
-            <GameSection />
-          </section>
-          <section id="degens-section" className="container section relative">
-            <div className="purple-bg-orb orb-top-right" />
-            <div className="purple-bg-orb orb-bottom-left" />
-            <DegensSection />
-          </section>
-          <SocialsFooter />
-        </Suspense>
-      </main>
-    </>
+    <HomeInteractive hasReferral={Boolean(referral)}>
+      <section id="console-game">
+        <ConsoleGame src="/video/smashers-960p.mp4" />
+      </section>
+      <section id="game-section" className="container section relative">
+        <div className="purple-bg-orb orb-top-left" />
+        <GameSection />
+      </section>
+      <section id="degens-section" className="container section relative">
+        <div className="purple-bg-orb orb-top-right" />
+        <div className="purple-bg-orb orb-bottom-left" />
+        <DegensSection />
+      </section>
+      <SocialsFooter />
+    </HomeInteractive>
   )
 }

--- a/apps/smashers/src/components/GameSection/index.tsx
+++ b/apps/smashers/src/components/GameSection/index.tsx
@@ -1,11 +1,8 @@
 import Image from 'next/image'
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 
 const GameSection = () => {
-  function playVid() {
-    const vid = document.getElementById('level-video') as HTMLVideoElement
-    vid?.play()
-  }
   return (
     <div className="flex flex-col-reverse lg:flex-col">
       <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-center">
@@ -36,23 +33,19 @@ const GameSection = () => {
           </div>
         </div>
         <div className="md:col-span-12 lg:col-span-6">
-          <div onClick={playVid}>
-            <AnimatedWrapper>
-              <div className="transition-quick-pop transition-quick-pop-start delay-lite rounded-[40px] overflow-hidden">
-                <video
-                  id="level-video"
-                  className="w-full h-auto"
-                  muted
-                  autoPlay
-                  loop
-                  playsInline
-                  data-keepplaying
-                >
-                  <source src="/video/rocket.mp4" type="video/mp4" />
-                </video>
-              </div>
-            </AnimatedWrapper>
-          </div>
+          <AnimatedWrapper>
+            <div className="transition-quick-pop transition-quick-pop-start delay-lite overflow-hidden rounded-[40px]">
+              <ViewportVideo
+                id="level-video"
+                className="h-auto w-full"
+                muted
+                loop
+                playsInline
+                data-keepplaying
+                src="/video/rocket.mp4"
+              />
+            </div>
+          </AnimatedWrapper>
         </div>
       </div>
       <AnimatedWrapper>
@@ -64,6 +57,8 @@ const GameSection = () => {
             height={556}
             className="w-full h-auto rounded-[40px]"
             unoptimized
+            loading="lazy"
+            sizes="(max-width: 768px) 100vw, 1350px"
           />
         </div>
       </AnimatedWrapper>

--- a/apps/smashers/src/components/Header/index.tsx
+++ b/apps/smashers/src/components/Header/index.tsx
@@ -1,10 +1,12 @@
+'use client'
+
 import Image from 'next/image'
 import ActionButtonsGroup from './ActionButtonsGroup'
 import Navbar from './Navbar'
 
 import styles from './index.module.css'
 
-type ActiveModal = 'credits' | 'play' | 'trailer' | 'unity' | null
+export type ActiveModal = 'credits' | 'play' | 'trailer' | 'unity' | null
 
 const Header = ({ activeModal }: { activeModal: ActiveModal }) => (
   <div className={styles.hero}>

--- a/apps/smashers/src/components/HomeInteractive/index.tsx
+++ b/apps/smashers/src/components/HomeInteractive/index.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect, useState, type PropsWithChildren } from 'react'
+
+import Header, { type ActiveModal } from '@/components/Header'
+
+type HomeInteractiveProps = PropsWithChildren<{ hasReferral: boolean }>
+
+export default function HomeInteractive({ children, hasReferral }: HomeInteractiveProps) {
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null)
+
+  useEffect(() => {
+    if (!hasReferral) return
+
+    const timeoutId = window.setTimeout(() => setActiveModal('play'), 0)
+    return () => window.clearTimeout(timeoutId)
+  }, [hasReferral])
+
+  return (
+    <main>
+      <section id="header">
+        <Header activeModal={activeModal} />
+      </section>
+      {children}
+    </main>
+  )
+}

--- a/packages/ui/src/components/custom/console-game/console-game.test.tsx
+++ b/packages/ui/src/components/custom/console-game/console-game.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+mock.module('next/image', () => ({
+  default: (props: React.ComponentProps<'img'>) => <img {...props} />,
+}))
+mock.module('@nl/ui/custom/animated-wrapper', () => ({
+  AnimatedWrapper: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+mock.module('@nl/ui/hooks/useOnScreen', () => ({
+  useOnScreen: () => true,
+}))
+
+describe('ConsoleGame', () => {
+  let ConsoleGame: typeof import('./index').ConsoleGame
+
+  beforeEach(async () => {
+    ConsoleGame = (await import('./index')).ConsoleGame
+  })
+
+  it('defers the backdrop image while the video remains viewport-aware', () => {
+    const { container } = render(<ConsoleGame src="/video/example.mp4" />)
+    const image = container.querySelector('img')
+    const video = container.querySelector('video')
+
+    expect(image?.getAttribute('loading')).toBe('lazy')
+    expect(video?.getAttribute('preload')).toBe('metadata')
+  })
+})

--- a/packages/ui/src/components/custom/console-game/index.tsx
+++ b/packages/ui/src/components/custom/console-game/index.tsx
@@ -54,11 +54,9 @@ export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
             width={1920}
             height={1080}
             src="/img/console-game/classic-gaming-reinvented-notv.webp"
-            priority
-            fetchPriority="high"
             sizes="(max-width: 1920px) 100vw, 1920px"
             style={{ width: '100%', height: 'auto', objectFit: 'contain' }}
-            loading="eager"
+            loading="lazy"
           />
           <video
             ref={videoRef}


### PR DESCRIPTION
## Summary
- server-render Smashers static sections instead of shipping the entire home page as a client component with `ssr: false` loading islands
- isolate referral/modal behavior in a small client wrapper
- reuse the shared viewport-aware video component and defer the shared ConsoleGame backdrop image
- add regression coverage for deferred ConsoleGame media

## Validation
- `bun --filter smashers build` (18 routes)
- `bun --filter web build` (16 routes)
- `bun --filter @nl/ui test` (134 passed)
- `bun --filter web test` (13 passed)
- `bun --filter smashers test` (15 passed)
- affected type-check, lint, Prettier, `git diff --check`, and `code-foundry doctor`
- production smoke: `/` returned 200, static sections were present, no loading placeholder, and videos started with `preload="none"`

Targets `staging`; no generated assets are included.
