### PR TITLE
perf(app): defer Passport and server-render game sections

### DIFF
--- a/apps/app/src/app/(public-routes)/games/InstallerAction.tsx
+++ b/apps/app/src/app/(public-routes)/games/InstallerAction.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Link from 'next/link'
+import { Button } from '@nl/ui/base/button'
+
+import useVersion from '@/hooks/useVersion'
+
+const InstallerAction = () => {
+  const { isWindows, isMacOs, downloadURL, version, message } = useVersion()
+  const installerDisabled = isMacOs || !version
+
+  if (installerDisabled) {
+    return (
+      <Button variant="outline" disabled>
+        {!version && isWindows ? 'Fetching installer version...' : message}
+      </Button>
+    )
+  }
+
+  return (
+    <Button asChild variant="outline">
+      <Link href={downloadURL}>{message}</Link>
+    </Button>
+  )
+}
+
+export default InstallerAction

--- a/apps/app/src/app/(public-routes)/games/_GameList/index.tsx
+++ b/apps/app/src/app/(public-routes)/games/_GameList/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import Image from 'next/image'
 import GameCard from '@/components/cards/GameCard'

--- a/apps/app/src/app/(public-routes)/games/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/page.tsx
@@ -1,42 +1,21 @@
-'use client'
-
-import Link from 'next/link'
-import { Button } from '@nl/ui/base/button'
-import SectionSlider from '@/components/sections/SectionSlider'
-import useVersion from '@/hooks/useVersion'
 import GameList from './_GameList'
 import Web3GameList from './_Web3GameList'
+import InstallerAction from './InstallerAction'
+import StaticSection from '@/components/sections/StaticSection'
 
 const GamesPage = () => {
-  const { isWindows, isMacOs, downloadURL, version, message } = useVersion()
-  const installerDisabled = isMacOs || !version
   return (
     <>
-      <SectionSlider firstSection title="Free-2-Play Games" isSlider={false}>
+      <StaticSection firstSection title="Free-2-Play Games">
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
           <GameList />
         </div>
-      </SectionSlider>
-      <SectionSlider
-        firstSection
-        title="Web3 Games"
-        isSlider={false}
-        actions={
-          installerDisabled ? (
-            <Button variant="outline" disabled>
-              {!version && isWindows ? 'Fetching installer version...' : message}
-            </Button>
-          ) : (
-            <Button asChild variant="outline">
-              <Link href={downloadURL}>{message}</Link>
-            </Button>
-          )
-        }
-      >
+      </StaticSection>
+      <StaticSection firstSection title="Web3 Games" actions={<InstallerAction />}>
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
           <Web3GameList />
         </div>
-      </SectionSlider>
+      </StaticSection>
     </>
   )
 }

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,31 +1,20 @@
-'use client'
-
-import SectionSlider from '@/components/sections/SectionSlider'
 import GameList from '@/app/(public-routes)/games/_GameList'
 import Web3GameList from '@/app/(public-routes)/games/_Web3GameList'
+import StaticSection from '@/components/sections/StaticSection'
 
 const Home = () => {
   return (
     <>
-      <SectionSlider firstSection title="Free-2-Play Games" isSlider={false}>
+      <StaticSection firstSection title="Free-2-Play Games">
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
           <GameList />
         </div>
-      </SectionSlider>
-      <SectionSlider
-        firstSection
-        title="Web3 Games"
-        isSlider={false}
-        // actions={
-        //   <Link href="/games">
-        //     <Button variant="outlined">View All Games</Button>
-        //   </Link>
-        // }
-      >
+      </StaticSection>
+      <StaticSection firstSection title="Web3 Games">
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
           <Web3GameList />
         </div>
-      </SectionSlider>
+      </StaticSection>
     </>
   )
 }

--- a/apps/app/src/components/sections/StaticSection.test.tsx
+++ b/apps/app/src/components/sections/StaticSection.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import StaticSection from './StaticSection'
+
+describe('StaticSection', () => {
+  it('renders the shared section title, actions, and server-compatible content slot', () => {
+    render(
+      <StaticSection firstSection title="Free-2-Play Games" actions={<button>Install</button>}>
+        <p>Game cards</p>
+      </StaticSection>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Free-2-Play Games' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Install' })).not.toBeNull()
+    expect(screen.getByText('Game cards')).not.toBeNull()
+  })
+})

--- a/apps/app/src/components/sections/StaticSection.tsx
+++ b/apps/app/src/components/sections/StaticSection.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren, ReactNode } from 'react'
+
+import type { SxProps, Theme } from '@/types'
+import SectionTitle from './SectionTitle'
+
+const sectionSpacing = 2 // 16px
+
+interface StaticSectionProps {
+  title: string | ReactNode
+  firstSection?: boolean
+  actions?: ReactNode
+  children?: ReactNode
+  variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  styles?: { root?: SxProps<Theme>; headerRow?: SxProps<Theme>; mainRow?: SxProps<Theme> }
+}
+
+const StaticSection = ({
+  title,
+  firstSection,
+  children,
+  actions,
+  variant = 'h2',
+  styles,
+}: PropsWithChildren<StaticSectionProps>) => (
+  <div
+    className="flex flex-col"
+    style={{ gap: sectionSpacing * 8, ...(styles?.root as React.CSSProperties) }}
+  >
+    <div style={styles?.headerRow as React.CSSProperties}>
+      <SectionTitle firstSection={firstSection} variant={variant} actions={actions}>
+        {title}
+      </SectionTitle>
+    </div>
+    <div style={styles?.mainRow as React.CSSProperties}>{children}</div>
+  </div>
+)
+
+export default StaticSection

--- a/apps/app/src/hooks/useImxProvider.test.tsx
+++ b/apps/app/src/hooks/useImxProvider.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+let isConnected = false
+const connectEvm = mock(async () => ({ request: async () => [] }))
+
+mock.module('wagmi', () => ({
+  useAccount: () => ({ isConnected }),
+  useConnectorClient: () => ({ data: undefined }),
+}))
+mock.module('@nl/imx-passport', () => ({
+  default: { connectEvm },
+}))
+
+describe('useImxProvider', () => {
+  let useImxProvider: typeof import('./useImxProvider').useImxProvider
+
+  beforeEach(async () => {
+    isConnected = false
+    connectEvm.mockClear()
+    useImxProvider = (await import('./useImxProvider')).useImxProvider
+  })
+
+  it('does not initialize Passport until a wallet is connected', async () => {
+    const { result, rerender } = renderHook(() => useImxProvider())
+
+    expect(result.current).toBeUndefined()
+    expect(connectEvm).not.toHaveBeenCalled()
+
+    isConnected = true
+    rerender()
+    await waitFor(() => expect(connectEvm).toHaveBeenCalledTimes(1))
+  })
+})

--- a/apps/app/src/hooks/useImxProvider.ts
+++ b/apps/app/src/hooks/useImxProvider.ts
@@ -6,10 +6,18 @@ import { type Chain, immutableZkEvm, immutableZkEvmTestnet } from 'viem/chains'
 import { useAccount } from 'wagmi'
 
 import useEthersSigner, { type Signer } from '@/hooks/useEthersSigner'
-import passport, { passportEnv } from '@nl/imx-passport'
-import { config } from '@nl/imx-passport/types'
+
+type PassportModule = typeof import('@nl/imx-passport')
+
+let passportModulePromise: Promise<PassportModule> | undefined
+
+const loadPassport = () => {
+  passportModulePromise ??= import('@nl/imx-passport')
+  return passportModulePromise
+}
 
 async function clientToProvider(): Promise<BrowserProvider> {
+  const { default: passport } = await loadPassport()
   const passportProvider = await passport.connectEvm()
   return new BrowserProvider(passportProvider)
 }
@@ -21,7 +29,9 @@ async function getPassportSigner(): Promise<JsonRpcSigner> {
 }
 
 export function getNetwork(): Chain {
-  return passportEnv === config.Environment.PRODUCTION ? immutableZkEvm : immutableZkEvmTestnet
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+    ? immutableZkEvm
+    : immutableZkEvmTestnet
 }
 
 export function useConnectedToIMXCheck(): boolean {
@@ -32,10 +42,25 @@ export function useConnectedToIMXCheck(): boolean {
 /** Memoized action to convert an IMX Passport instance to an ethers.js Provider. */
 export function useImxProvider(): BrowserProvider | undefined {
   const [provider, setProvider] = useState<BrowserProvider>()
+  const { isConnected } = useAccount()
 
   useEffect(() => {
-    clientToProvider().then(setProvider).catch(console.error)
-  }, [])
+    if (!isConnected) {
+      setProvider(undefined)
+      return
+    }
+
+    let mounted = true
+    clientToProvider()
+      .then((nextProvider) => {
+        if (mounted) setProvider(nextProvider)
+      })
+      .catch(console.error)
+
+    return () => {
+      mounted = false
+    }
+  }, [isConnected])
 
   return provider
 }


### PR DESCRIPTION
## Summary
- defer Immutable Passport SDK loading and `connectEvm()` until a Wagmi wallet is connected
- keep the existing undefined-provider fallback and add a regression test for anonymous mounts
- server-render app home and games static sections instead of importing the client-only slider shell when `isSlider={false}`
- isolate installer version/download behavior into a small client action
- remove the stale commented action block and the unnecessary client boundary from the free-to-play game list

## Measured impact
Against a clean `origin/staging` build:
- app home initial entry: 36 client chunks / 4,056,081 bytes -> 35 / 3,555,420 bytes
- reduction: 500,661 bytes (12.3%)
- the baseline 426,627-byte Passport chunk is no longer in the home entry and is emitted as a deferred async chunk

## Validation
- `bun --filter app build` (21 routes)
- `bun --filter app test` (157 passed)
- `bun --filter app type-check`
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun --filter @nl/imx-passport type-check`
- `bun --filter @nl/imx-passport lint`
- Prettier, `git diff --check`, and `code-foundry doctor`
- production smoke: `/` and `/games` returned 200 with section headings and game cards present in the initial response

Targets `staging`; generated sitemap/robots files are not included.
