### PR TITLE
perf(app): keep archived leaderboard data server-side

### DIFF
--- a/apps/app/src/app/api/leaderboards/route.ts
+++ b/apps/app/src/app/api/leaderboards/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { fetchScores } from '@/utils/leaderboard-server'
+
+export const dynamic = 'force-dynamic'
+
+const parsePositiveInteger = (value: string | null, fallback: number) => {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const game = searchParams.get('game')
+  const score = searchParams.get('score')
+
+  if (!game || !score) {
+    return NextResponse.json({ error: 'game and score are required' }, { status: 400 })
+  }
+
+  try {
+    const result = await fetchScores(
+      game,
+      score,
+      searchParams.get('time') ?? 'all_time',
+      Math.min(parsePositiveInteger(searchParams.get('count'), 50), 100),
+      parsePositiveInteger(searchParams.get('offset'), 0)
+    )
+    return NextResponse.json(result)
+  } catch {
+    return NextResponse.json({ error: 'Unknown leaderboard' }, { status: 400 })
+  }
+}

--- a/apps/app/src/constants/leaderboards/data.ts
+++ b/apps/app/src/constants/leaderboards/data.ts
@@ -1,0 +1,19 @@
+import { SMASHERS_LEADERBOARDS } from './leaderboard-smashers'
+import { WEN_GAME_LEADERBOARDS } from './leaderboard-wen-game'
+import { CRYPTO_WINTER_LEADERBOARDS } from './leaderboard-crypto-winter'
+import { MT_GAWX_LEADERBOARDS } from './leaderboard-mt-gawx'
+
+// Keep the archived datasets server-side. The browser only needs the selected page of rows.
+export type LeaderboardRow = {
+  rank: number
+  user_id: string
+  score: string
+  stats: Record<string, string>
+}
+
+export const LEADERBOARDS: Record<string, Record<string, LeaderboardRow[]>> = {
+  crypto_winter: CRYPTO_WINTER_LEADERBOARDS,
+  nftl_burner: MT_GAWX_LEADERBOARDS,
+  nifty_smashers: SMASHERS_LEADERBOARDS,
+  wen_game: WEN_GAME_LEADERBOARDS,
+}

--- a/apps/app/src/constants/leaderboards/index.ts
+++ b/apps/app/src/constants/leaderboards/index.ts
@@ -2,11 +2,6 @@ import { GTM_EVENTS } from '@nl/ui/gtm'
 import type { TableType, LeaderboardGame } from '@/types/leaderboard'
 import { Game, TimeFilter } from '@/types/leaderboard'
 
-import { SMASHERS_LEADERBOARDS } from './leaderboard-smashers'
-import { WEN_GAME_LEADERBOARDS } from './leaderboard-wen-game'
-import { CRYPTO_WINTER_LEADERBOARDS } from './leaderboard-crypto-winter'
-import { MT_GAWX_LEADERBOARDS } from './leaderboard-mt-gawx'
-
 export const NiftySmashersTables: TableType[] = [
   {
     key: 'win_rate',
@@ -72,12 +67,3 @@ export const LEADERBOARD_TIME_FILTERS = [
   { key: 'monthly', display: TimeFilter.Monthly },
   { key: 'all_time', display: TimeFilter.AllTime },
 ]
-
-// Leaderboard Data
-
-export const LEADERBOARDS = {
-  crypto_winter: CRYPTO_WINTER_LEADERBOARDS,
-  nftl_burner: MT_GAWX_LEADERBOARDS,
-  nifty_smashers: SMASHERS_LEADERBOARDS,
-  wen_game: WEN_GAME_LEADERBOARDS,
-}

--- a/apps/app/src/constants/url.ts
+++ b/apps/app/src/constants/url.ts
@@ -51,7 +51,6 @@ export const GET_PRODUCT = (productId: string, currency: string) =>
 // Leaderboards
 export const GET_RANK_BY_USER_ID_API = `${BASE_API_URL}/GetRank`
 export const LEADERBOARD_USERNAMES_API_URL = `${BASE_API_URL}/profiles/public/profiles`
-export const LEADERBOARD_SCORE_API_URL = `${BASE_API_URL}/scores`
 
 // QUICKSWAP URL FOR NFTL PURCHASE
 export const NFTL_PURCHASE_URL = `https://quickswap.exchange/#/analytics/v3/token/${getContractAddress(

--- a/apps/app/src/utils/leaderboard-server.ts
+++ b/apps/app/src/utils/leaderboard-server.ts
@@ -1,0 +1,78 @@
+import { LEADERBOARD_USERNAMES_API_URL } from '@/constants/url'
+import { LEADERBOARDS, type LeaderboardRow } from '@/constants/leaderboards/data'
+
+type UserName = { name?: string }
+type UserNames = Record<string, UserName> | UserName[]
+type ScoredLeaderboardRow = Omit<LeaderboardRow, 'stats'> & {
+  stats: Record<string, string | number>
+}
+type LeaderboardResponse = { data: ScoredLeaderboardRow[]; count: number }
+
+export const fetchUserNames = async (items: string[]): Promise<UserNames> => {
+  try {
+    const res = await fetch(`${LEADERBOARD_USERNAMES_API_URL}?ids=${items}&include_stats=false`, {
+      cache: 'no-store',
+    })
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
+export const fetchScores = async (
+  gameType: string,
+  scoreType: string,
+  _timeFilter: string,
+  count: number,
+  offset: number
+): Promise<LeaderboardResponse> => {
+  const leaderboard = LEADERBOARDS[gameType]?.[scoreType]
+
+  if (!leaderboard || !Array.isArray(leaderboard)) {
+    throw new Error('Unknown leaderboard')
+  }
+
+  const json = { data: leaderboard.slice(offset, offset + count), count: leaderboard.length }
+
+  const addAvg = json.data.map((data) => {
+    const { earnings, matches } = data?.stats || {}
+    const avg =
+      earnings && matches ? Math.round((parseFloat(earnings) * 100) / parseFloat(matches)) / 100 : 0
+    let rate = 0
+    let earningsParsed = Math.round(parseFloat(earnings || '0') * 10) / 10
+    let kills = Number(data.stats?.kills ?? '0')
+    switch (scoreType) {
+      case 'win_rate':
+        rate = parseFloat(data.score) * 100
+        break
+      case 'earnings':
+        earningsParsed = Number(data.score)
+        break
+      case 'kills':
+        kills = Number(data.score)
+        break
+      default:
+        break
+    }
+    return {
+      ...data,
+      stats: {
+        ...data.stats,
+        score: Number(data.score ?? '0').toLocaleString(),
+        'avg_NFTL/match': avg,
+        win_rate: `${rate}%`,
+        earnings: earningsParsed.toLocaleString(),
+        kills: kills.toLocaleString(),
+      },
+    }
+  })
+
+  const items = json.data.map((data) => data.user_id)
+  const names = Object.entries(await fetchUserNames(items))
+  for (const row of addAvg) {
+    const match = names.find(([userId]) => row.user_id === userId)
+    if (match) row.user_id = match[1]?.name || ''
+  }
+
+  return { data: addAvg, count: json.count }
+}

--- a/apps/app/src/utils/leaderboard.test.ts
+++ b/apps/app/src/utils/leaderboard.test.ts
@@ -1,17 +1,19 @@
 const stubGlobal = (name, value) => {
   Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
 }
+
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mock } from 'bun:test'
 
 let fetchRankByUserId: typeof import('./leaderboard').fetchRankByUserId
-let fetchScores: typeof import('./leaderboard').fetchScores
-let fetchUserNames: typeof import('./leaderboard').fetchUserNames
+let fetchClientScores: typeof import('./leaderboard').fetchScores
+let fetchScores: typeof import('./leaderboard-server').fetchScores
+let fetchUserNames: typeof import('./leaderboard-server').fetchUserNames
 let getComparator: typeof import('./leaderboard').getComparator
 let stableSort: typeof import('./leaderboard').stableSort
 
 beforeEach(async () => {
-  mock.module('@/constants/leaderboards', () => {
+  mock.module('@/constants/leaderboards/data', () => {
     const row = (score: string, userId: string, stats: Record<string, string> = {}) => ({
       rank: 1,
       score,
@@ -30,10 +32,14 @@ beforeEach(async () => {
     }
   })
 
-  const leaderboard = await import('./leaderboard')
+  const [leaderboard, leaderboardServer] = await Promise.all([
+    import('./leaderboard'),
+    import('./leaderboard-server'),
+  ])
   fetchRankByUserId = leaderboard.fetchRankByUserId
-  fetchScores = leaderboard.fetchScores
-  fetchUserNames = leaderboard.fetchUserNames
+  fetchClientScores = leaderboard.fetchScores
+  fetchScores = leaderboardServer.fetchScores
+  fetchUserNames = leaderboardServer.fetchUserNames
   getComparator = leaderboard.getComparator
   stableSort = leaderboard.stableSort
 })
@@ -50,6 +56,20 @@ describe('leaderboard data loaders', () => {
 
     stubGlobal('fetch', mock().mockRejectedValue(new Error('offline')))
     await expect(fetchUserNames(['user-1'])).resolves.toEqual([])
+  })
+
+  it('requests only the selected leaderboard page from the app route', async () => {
+    const fetchMock = mock().mockResolvedValue({
+      ok: true,
+      json: mock().mockResolvedValue({ data: [], count: 0 }),
+    })
+    stubGlobal('fetch', fetchMock)
+
+    await fetchClientScores('smashers', 'kills', 'all_time', 50, 100)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/leaderboards?game=smashers&score=kills&time=all_time&count=50&offset=100'
+    )
   })
 
   it.each<[string, string, string, string]>([

--- a/apps/app/src/utils/leaderboard.ts
+++ b/apps/app/src/utils/leaderboard.ts
@@ -1,19 +1,5 @@
-import type { DataType, ReturnDataType, Order } from '@/types/leaderboard'
-import {
-  GET_RANK_BY_USER_ID_API,
-  LEADERBOARD_SCORE_API_URL,
-  LEADERBOARD_USERNAMES_API_URL,
-} from '@/constants/url'
-import { LEADERBOARDS } from '@/constants/leaderboards'
-
-export const fetchUserNames = async (items: string[]): Promise<DataType[]> => {
-  try {
-    const res = await fetch(`${LEADERBOARD_USERNAMES_API_URL}?ids=${items}&include_stats=false`)
-    return await res.json()
-  } catch (e) {
-    return []
-  }
-}
+import type { DataType, Order, ReturnDataType } from '@/types/leaderboard'
+import { GET_RANK_BY_USER_ID_API } from '@/constants/url'
 
 export const fetchScores = async (
   gameType: string,
@@ -22,58 +8,18 @@ export const fetchScores = async (
   count: number,
   offset: number
 ): Promise<ReturnDataType> => {
-  // @ts-expect-error ignore implicit any
-  const leaderboard = LEADERBOARDS[gameType][scoreType]
-  const json = { data: leaderboard.slice(offset, offset + count), count: leaderboard.length }
-
-  const addAvg = json.data.map((data: DataType) => {
-    const { earnings, matches } = data?.stats || {}
-    const avg =
-      earnings && matches ? Math.round((parseFloat(earnings) * 100) / parseFloat(matches)) / 100 : 0
-    let rate = 0
-    let earningsParsed = Math.round(parseFloat(earnings || '0') * 10) / 10
-    let kills = Number(data.stats?.kills ?? '0')
-    switch (scoreType) {
-      case 'win_rate':
-        rate = parseFloat(data.score) * 100
-        break
-      case 'earnings':
-        earningsParsed = Number(data.score)
-        break
-      case 'kills':
-        kills = Number(data.score)
-        break
-      default:
-        break
-    }
-    return {
-      ...data,
-      stats: {
-        ...data.stats,
-        score: Number(data.score ?? '0').toLocaleString(),
-        'avg_NFTL/match': avg,
-        win_rate: `${rate}%`,
-        earnings: earningsParsed.toLocaleString(),
-        kills: kills.toLocaleString(),
-      },
-    }
-  })
-  // get names
-  const items: string[] = []
-  for (let i = 0; i < json.data.length; i++) {
-    items.push(json.data[i].user_id)
-  }
-  const dd: DataType[] = await fetchUserNames(items)
-  const a = Object.entries(dd)
-  for (let i = 0; i < addAvg.length; i++) {
-    for (let j = 0; j < a.length; j++) {
-      if (addAvg[i].user_id === a?.[j]?.[0]) {
-        addAvg[i].user_id = a?.[j]?.[1]?.name || ''
-      }
-    }
-  }
-
-  return { data: addAvg, count: json.count }
+  const response = await fetch(
+    `/api/leaderboards?${new URLSearchParams({
+      game: gameType,
+      score: scoreType,
+      time: timeFilter,
+      count: String(count),
+      offset: String(offset),
+    })}`,
+    { cache: 'no-store' }
+  )
+  if (!response.ok) throw new Error('Unable to load leaderboard')
+  return response.json()
 }
 
 function descendingComparator(a: DataType, b: DataType, orderBy: keyof DataType['stats']) {
@@ -99,8 +45,6 @@ export const getComparator = <Key extends keyof unknown>(
     : (a, b) => -descendingComparator(a, b, orderBy)
 }
 
-// This method is created for cross-browser compatibility, if you don't
-// need to support IE11, you can use Array.prototype.sort() directly
 export const stableSort = <T>(array: readonly T[], comparator: (a: T, b: T) => number): T[] => {
   const stabilizedThis = array.map((el, index) => [el, index] as [T, number])
   stabilizedThis.sort((a, b) => {


### PR DESCRIPTION
## What changed
- Move archived leaderboard datasets behind a server-only data module and `/api/leaderboards` route.
- Keep the browser-side leaderboard client focused on requesting the selected page.
- Preserve username enrichment, pagination, selectors, styling, and existing leaderboard behavior.
- Remove the now-unused score API constant and add coverage for the client/server data boundary.

## Why
The archived route was shipping all historical leaderboard rows to every visitor, even though the UI initially rendered only 50 rows.

## Measured impact
On clean production builds from the aligned `staging` baseline:
- `/leaderboards` initial browser JavaScript: 5,617,697 bytes -> 4,433,584 bytes
- Reduction: 1,184,113 bytes (21.1%)
- Client dataset literal: present -> absent
- `/` and `/games`: unchanged within measurement noise

## Validation
- `bun --filter @nl/ui test`
- `bun --filter @nl/ui type-check`
- `bun --filter @nl/ui lint`
- `bun --filter app test` (158 pass)
- `bun --filter app type-check`
- `bun --filter app lint` (0 errors, 8 existing image warnings)
- `bun --filter app build`
- `bun --filter web type-check`
- `bun --filter smashers type-check`
- Production smoke: `/`, `/games`, `/leaderboards`, and `/api/leaderboards` returned 200; missing API parameters returned 400.
