### PR TITLE
perf(app): scope wallet providers to feature routes

### DIFF
--- a/apps/app/src/app/(private-routes)/layout.tsx
+++ b/apps/app/src/app/(private-routes)/layout.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from 'react'
+
+import AppContextWrapper from '@/contexts/AppContextWrapper'
+import MainLayout from '@/app/_layout/_MainLayout'
+
+export default function PrivateRoutesLayout({ children }: PropsWithChildren) {
+  return (
+    <AppContextWrapper>
+      <MainLayout>{children}</MainLayout>
+    </AppContextWrapper>
+  )
+}

--- a/apps/app/src/app/(public-routes)/degens/layout.tsx
+++ b/apps/app/src/app/(public-routes)/degens/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
 
+import WalletContextWrapper from '@/contexts/WalletContextWrapper'
+
 export const metadata: Metadata = { title: 'Degens' }
 
 export default function Layout({ children }: PropsWithChildren) {
-  return children
+  return <WalletContextWrapper>{children}</WalletContextWrapper>
 }

--- a/apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx
+++ b/apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const DeferredWeb3GameList = dynamic(() => import('./_Web3GameList/DeferredWeb3GameList'), {
+  ssr: false,
+  loading: () => <div className="col-span-12 min-h-24" aria-busy="true" />,
+})
+
+export default function Web3GameList() {
+  return <DeferredWeb3GameList />
+}

--- a/apps/app/src/app/(public-routes)/games/_Web3GameList/DeferredWeb3GameList.tsx
+++ b/apps/app/src/app/(public-routes)/games/_Web3GameList/DeferredWeb3GameList.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import WalletFeatureProviders from '@/contexts/WalletFeatureProviders'
+import Web3GameList from './index'
+
+export default function DeferredWeb3GameList() {
+  return (
+    <WalletFeatureProviders>
+      <Web3GameList />
+    </WalletFeatureProviders>
+  )
+}

--- a/apps/app/src/app/(public-routes)/games/crypto-winter/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/crypto-winter/page.tsx
@@ -3,6 +3,7 @@
 
 import dynamic from 'next/dynamic'
 import type { UnityConfig } from 'react-unity-webgl'
+import WalletRouteProvider from '@/components/providers/WalletRouteProvider'
 const GameWithAuth = dynamic(() => import('@/components/wrapper/GameWithAuth'), { ssr: false })
 
 const baseUrl = process.env.NEXT_PUBLIC_UNITY_CRYPTO_WINTER_BASE_URL as string
@@ -19,6 +20,10 @@ const cryptoWinterConfig: UnityConfig = {
   productVersion: buildVersion,
 }
 
-const CryptoWinterGame = () => <GameWithAuth unityConfig={cryptoWinterConfig} arcadeTokenRequired />
+const CryptoWinterGame = () => (
+  <WalletRouteProvider>
+    <GameWithAuth unityConfig={cryptoWinterConfig} arcadeTokenRequired />
+  </WalletRouteProvider>
+)
 
 export default CryptoWinterGame

--- a/apps/app/src/app/(public-routes)/games/mt-gawx/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/mt-gawx/page.tsx
@@ -3,6 +3,7 @@
 
 import dynamic from 'next/dynamic'
 import type { UnityConfig } from 'react-unity-webgl'
+import WalletRouteProvider from '@/components/providers/WalletRouteProvider'
 const GameWithAuth = dynamic(() => import('@/components/wrapper/GameWithAuth'), { ssr: false })
 
 const burnerBaseUrl = process.env.NEXT_PUBLIC_UNITY_BURNER_BASE_URL as string
@@ -19,6 +20,10 @@ const burnerConfig: UnityConfig = {
   productVersion: burnerBuildVersion,
 }
 
-const MtGawxGame = () => <GameWithAuth unityConfig={burnerConfig} />
+const MtGawxGame = () => (
+  <WalletRouteProvider>
+    <GameWithAuth unityConfig={burnerConfig} />
+  </WalletRouteProvider>
+)
 
 export default MtGawxGame

--- a/apps/app/src/app/(public-routes)/games/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/page.tsx
@@ -1,5 +1,5 @@
 import GameList from './_GameList'
-import Web3GameList from './_Web3GameList'
+import DeferredWeb3GameList from './DeferredWeb3GameList'
 import InstallerAction from './InstallerAction'
 import StaticSection from '@/components/sections/StaticSection'
 
@@ -13,7 +13,7 @@ const GamesPage = () => {
       </StaticSection>
       <StaticSection firstSection title="Web3 Games" actions={<InstallerAction />}>
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
-          <Web3GameList />
+          <DeferredWeb3GameList />
         </div>
       </StaticSection>
     </>

--- a/apps/app/src/app/(public-routes)/games/smashers/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/smashers/page.tsx
@@ -3,6 +3,7 @@
 
 import dynamic from 'next/dynamic'
 import type { UnityConfig } from 'react-unity-webgl'
+import WalletRouteProvider from '@/components/providers/WalletRouteProvider'
 const GameWithAuth = dynamic(() => import('@/components/wrapper/GameWithAuth'), { ssr: false })
 
 const smashersBaseUrl = process.env.NEXT_PUBLIC_UNITY_SMASHERS_BASE_URL as string
@@ -22,24 +23,26 @@ const smashersConfig: UnityConfig = {
 }
 
 const SmashersGame = () => (
-  <>
-    <div style={{ marginBottom: 20 }}>
-      <strong>
-        Note: This is a deprecated version of Nifty Smashers. If you&apos;re looking for our latest
-        mobile game please visit{' '}
-        <a
-          href="https://niftysmashers.com"
-          target="_blank"
-          rel="noreferrer"
-          style={{ color: 'var(--color-blue)' }}
-        >
-          niftysmashers.com
-        </a>
-      </strong>
-    </div>
+  <WalletRouteProvider>
+    <>
+      <div style={{ marginBottom: 20 }}>
+        <strong>
+          Note: This is a deprecated version of Nifty Smashers. If you&apos;re looking for our
+          latest mobile game please visit{' '}
+          <a
+            href="https://niftysmashers.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: 'var(--color-blue)' }}
+          >
+            niftysmashers.com
+          </a>
+        </strong>
+      </div>
 
-    <GameWithAuth unityConfig={smashersConfig} />
-  </>
+      <GameWithAuth unityConfig={smashersConfig} />
+    </>
+  </WalletRouteProvider>
 )
 
 export default SmashersGame

--- a/apps/app/src/app/(public-routes)/games/wen-game/page.tsx
+++ b/apps/app/src/app/(public-routes)/games/wen-game/page.tsx
@@ -3,6 +3,7 @@
 
 import dynamic from 'next/dynamic'
 import type { UnityConfig } from 'react-unity-webgl'
+import WalletRouteProvider from '@/components/providers/WalletRouteProvider'
 const GameWithAuth = dynamic(() => import('@/components/wrapper/GameWithAuth'), { ssr: false })
 
 const wenBaseUrl = process.env.NEXT_PUBLIC_UNITY_WEN_BASE_URL as string
@@ -19,6 +20,10 @@ const wenConfig: UnityConfig = {
   productVersion: wenBuildVersion,
 }
 
-const WenGame = () => <GameWithAuth unityConfig={wenConfig} arcadeTokenRequired />
+const WenGame = () => (
+  <WalletRouteProvider>
+    <GameWithAuth unityConfig={wenConfig} arcadeTokenRequired />
+  </WalletRouteProvider>
+)
 
 export default WenGame

--- a/apps/app/src/app/(public-routes)/layout.tsx
+++ b/apps/app/src/app/(public-routes)/layout.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from 'react'
+
+import PublicAppContextWrapper from '@/contexts/PublicAppContextWrapper'
+import PublicMainLayout from '@/app/_layout/_PublicMainLayout'
+
+export default function PublicRoutesLayout({ children }: PropsWithChildren) {
+  return (
+    <PublicAppContextWrapper>
+      <PublicMainLayout>{children}</PublicMainLayout>
+    </PublicAppContextWrapper>
+  )
+}

--- a/apps/app/src/app/(public-routes)/page.tsx
+++ b/apps/app/src/app/(public-routes)/page.tsx
@@ -1,5 +1,5 @@
-import GameList from '@/app/(public-routes)/games/_GameList'
-import Web3GameList from '@/app/(public-routes)/games/_Web3GameList'
+import GameList from './games/_GameList'
+import DeferredWeb3GameList from './games/DeferredWeb3GameList'
 import StaticSection from '@/components/sections/StaticSection'
 
 const Home = () => {
@@ -12,7 +12,7 @@ const Home = () => {
       </StaticSection>
       <StaticSection firstSection title="Web3 Games">
         <div className="grid grid-cols-12 gap-y-8 pb-8 sm:gap-y-0 sm:pb-4 md:pb-0">
-          <Web3GameList />
+          <DeferredWeb3GameList />
         </div>
       </StaticSection>
     </>

--- a/apps/app/src/app/(public-routes)/verification/layout.tsx
+++ b/apps/app/src/app/(public-routes)/verification/layout.tsx
@@ -1,10 +1,7 @@
-import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
 
 import WalletContextWrapper from '@/contexts/WalletContextWrapper'
 
-export const metadata: Metadata = { title: 'Mint-o-Matic' }
-
-export default function Layout({ children }: PropsWithChildren) {
+export default function VerificationLayout({ children }: PropsWithChildren) {
   return <WalletContextWrapper>{children}</WalletContextWrapper>
 }

--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import type { PropsWithChildren, ReactNode } from 'react'
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+import { cn } from '@nl/ui/utils'
+import { ScrollArea } from '@nl/ui/base/scroll-area'
+import { Toaster } from '@nl/ui/base/sonner'
+import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
+
+import { openDrawer } from '@/store/slices/menu'
+import { useDispatch, useSelector } from '@/store/hooks'
+import Breadcrumbs from '@/components/extended/Breadcrumbs'
+import Snackbar from '@/components/extended/Snackbar'
+import navigation from '@/constants/menu-items'
+import styles from './_MainLayout/MainLayout.module.css'
+
+const container = true
+
+interface AppShellProps extends PropsWithChildren {
+  header: ReactNode
+  sidebar: ReactNode
+  networkWarning?: ReactNode
+}
+
+export default function AppShell({ children, header, sidebar, networkWarning }: AppShellProps) {
+  const pathname = usePathname()
+  const dispatch = useDispatch()
+  const matchDownXL = useMediaQuery('(max-width:1280px)')
+  const { drawerOpen } = useSelector((state) => state.menu)
+
+  useEffect(() => {
+    dispatch(openDrawer(!matchDownXL))
+  }, [matchDownXL, dispatch])
+
+  const isNoFilterPage = pathname && /(degens|dashboard\/degens)/.test(pathname)
+
+  const content = (
+    <>
+      <Breadcrumbs separator="chevron-right" navigation={navigation} icon title rightAlign />
+      {children}
+    </>
+  )
+
+  return (
+    <>
+      <div className="flex">
+        <header
+          className="fixed top-0 right-0 left-0 z-50 border-0 bg-sidebar transition-[width]"
+          style={{
+            transition: drawerOpen ? 'width 200ms cubic-bezier(0.4, 0, 0.6, 1) 0ms' : 'none',
+          }}
+        >
+          {networkWarning}
+          <div className="py-1 lg:py-0">{header}</div>
+        </header>
+
+        {sidebar}
+
+        <main className={cn(styles.main, drawerOpen ? styles.mainOpen : styles.mainClosed)}>
+          {!isNoFilterPage ? (
+            <ScrollArea className="h-full" viewportClassName="py-5 md:py-10">
+              {container ? <div className="container">{content}</div> : content}
+            </ScrollArea>
+          ) : (
+            content
+          )}
+        </main>
+      </div>
+      <Snackbar />
+      <Toaster position="top-right" closeButton richColors />
+    </>
+  )
+}

--- a/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
@@ -1,3 +1,4 @@
+import dynamic from 'next/dynamic'
 import { Button } from '@nl/ui/base/button'
 
 import { useDispatch, useSelector } from '@/store/hooks'
@@ -6,8 +7,9 @@ import { openDrawer } from '@/store/slices/menu'
 // assets
 import { Icon } from '@nl/ui/base/icon'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
-import AddNFTL from './AddNFTLToMetamask'
 import LogoSection from '../_LogoSection'
+
+const AddNFTL = dynamic(() => import('./AddNFTLToMetamask'), { ssr: false })
 
 const appHeaderHeight = 60
 
@@ -19,7 +21,7 @@ const pages = [
   { name: 'Docs', link: 'https://niftyleague.com/docs' },
 ] as { name: string; link: string }[]
 
-const Header = () => {
+const Header = ({ showWalletActions = false }: { showWalletActions?: boolean }) => {
   const dispatch = useDispatch()
   const { drawerOpen } = useSelector((state) => state.menu)
 
@@ -47,7 +49,7 @@ const Header = () => {
         </Button>
       </div>
       <div className="hidden items-center justify-between gap-4 lg:flex">
-        <AddNFTL />
+        {showWalletActions && <AddNFTL />}
         {pages.map((page) => (
           <a
             key={page.name}

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/PublicSidebar.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/PublicSidebar.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import SidebarFrame from './SidebarFrame'
+import MenuList from './_MenuList'
+
+export default function PublicSidebar() {
+  return (
+    <SidebarFrame>
+      <MenuList />
+    </SidebarFrame>
+  )
+}

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import type { PropsWithChildren, ReactNode } from 'react'
+import { memo, useMemo } from 'react'
+
+import { ScrollArea } from '@nl/ui/base/scroll-area'
+import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
+import { cn } from '@nl/ui/utils'
+
+import { openDrawer } from '@/store/slices/menu'
+import { useDispatch, useSelector } from '@/store/hooks'
+import LogoSection from '../_LogoSection'
+
+const appDrawerWidth = 260
+const appHeaderHeight = 60
+
+interface SidebarFrameProps extends PropsWithChildren {
+  footer?: ReactNode
+}
+
+function SidebarFrame({ children, footer }: SidebarFrameProps) {
+  const isSmallScreen = useMediaQuery('(max-width:1024px)')
+  const dispatch = useDispatch()
+  const { drawerOpen } = useSelector((state) => state.menu)
+
+  const logo = useMemo(
+    () => (
+      <div className="block lg:hidden">
+        <div className="mx-auto flex p-2">
+          <LogoSection />
+        </div>
+      </div>
+    ),
+    []
+  )
+
+  const drawer = useMemo(
+    () => (
+      <ScrollArea
+        style={{
+          height: isSmallScreen ? 'calc(100vh - 56px)' : 'calc(100vh - 100px)',
+        }}
+        viewportClassName="px-4"
+      >
+        <div className="flex h-full flex-col justify-between">
+          <div>{children}</div>
+          {footer && <div className="flex flex-col items-center">{footer}</div>}
+        </div>
+      </ScrollArea>
+    ),
+    [children, footer, isSmallScreen]
+  )
+
+  return (
+    <nav
+      aria-label="Primary navigation"
+      className={cn('shrink-0', isSmallScreen ? 'w-auto' : 'w-[260px]')}
+    >
+      {isSmallScreen && (
+        <div
+          className={cn(
+            'fixed inset-0 z-50 transition-opacity',
+            drawerOpen
+              ? 'pointer-events-auto bg-black/50 opacity-100'
+              : 'pointer-events-none opacity-0'
+          )}
+          onClick={() => dispatch(openDrawer(!drawerOpen))}
+        >
+          <div
+            className="bg-sidebar text-sidebar-foreground absolute inset-y-0 left-0 border-r-0"
+            style={{ width: appDrawerWidth }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {drawerOpen && logo}
+            {drawerOpen && drawer}
+          </div>
+        </div>
+      )}
+
+      {!isSmallScreen && (
+        <aside
+          className={cn(
+            'bg-sidebar text-sidebar-foreground fixed bottom-0 left-0 z-40 border-r-0 transition-transform duration-200',
+            !drawerOpen && '-translate-x-full'
+          )}
+          style={{ width: appDrawerWidth, top: appHeaderHeight }}
+        >
+          {drawerOpen && logo}
+          {drawerOpen && drawer}
+        </aside>
+      )}
+    </nav>
+  )
+}
+
+export default memo(SidebarFrame)

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/index.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react'
 // project imports
 import NavGroup from './_NavGroup'
 import { PublicItems, PrivateItems } from '@/constants/menu-items'
-import useAuth from '@/hooks/useAuth'
 
 // ==============================|| SIDEBAR MENU LIST ||============================== //
 
@@ -15,21 +14,8 @@ const getMenuItemsByLoginStatus = (loginStatus: boolean) => {
   return { items: [...PublicItems.items] }
 }
 
-const MenuList = () => {
-  const { isLoggedIn } = useAuth()
+const MenuList = ({ isLoggedIn = false }: { isLoggedIn?: boolean }) => {
   const lastItems = getMenuItemsByLoginStatus(isLoggedIn).items
-  const lastItem = lastItems.length > 1 ? lastItems[1] : undefined
-  if (lastItem) {
-    const childs = lastItem.children && lastItem.children[0] && lastItem.children[0].children
-    if (childs && !childs.find((t) => t.id === 'gamer-profile')) {
-      childs.splice(1, 0, {
-        id: 'gamer-profile',
-        title: 'Gamer Profile',
-        type: 'item',
-        url: '/dashboard/gamer-profile',
-      })
-    }
-  }
 
   const navItems = lastItems.map((item) => {
     switch (item.type) {

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/index.tsx
@@ -1,107 +1,20 @@
-import { memo, useMemo } from 'react'
-
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
-import { cn } from '@nl/ui/utils'
-
-// third-party
-// project imports
-import { ScrollArea } from '@nl/ui/base/scroll-area'
+import useAuth from '@/hooks/useAuth'
 import MenuList from './_MenuList'
-import LogoSection from '../_LogoSection'
-import { openDrawer } from '@/store/slices/menu'
-import { useDispatch, useSelector } from '@/store/hooks'
 import UserProfile from './_UserProfile'
 import LogoutButton from './_LogoutButton'
-
-const appDrawerWidth = 260
-const appHeaderHeight = 60
+import SidebarFrame from './SidebarFrame'
 
 // ==============================|| SIDEBAR DRAWER ||============================== //
 
 const Sidebar = () => {
-  const isSmallScreen = useMediaQuery('(max-width:1024px)')
-
-  const dispatch = useDispatch()
-  const { drawerOpen } = useSelector((state) => state.menu)
-
-  const logo = useMemo(
-    () => (
-      <div className="block lg:hidden">
-        <div className="mx-auto flex p-2">
-          <LogoSection />
-        </div>
-      </div>
-    ),
-    []
-  )
-
-  const drawer = useMemo(
-    () => (
-      <ScrollArea
-        style={{
-          height: isSmallScreen ? 'calc(100vh - 56px)' : 'calc(100vh - 100px)',
-        }}
-        viewportClassName="px-4"
-      >
-        <div className="flex h-full flex-col justify-between">
-          <div>
-            <UserProfile />
-            <MenuList />
-            {/* <OnboardingCard /> */}
-          </div>
-          <div className="flex flex-col items-center">
-            <LogoutButton sx={{ marginBottom: 12, width: '85%' }} />
-          </div>
-        </div>
-      </ScrollArea>
-    ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isSmallScreen]
-  )
+  const { isLoggedIn } = useAuth()
 
   return (
-    <nav
-      aria-label="mailbox folders"
-      className={cn('shrink-0', isSmallScreen ? 'w-auto' : 'w-[260px]')}
-      style={{ flexShrink: isSmallScreen ? undefined : 0 }}
-    >
-      {/* temporary drawer (mobile) */}
-      {isSmallScreen && (
-        <div
-          className={cn(
-            'fixed inset-0 z-50 transition-opacity',
-            drawerOpen
-              ? 'pointer-events-auto bg-black/50 opacity-100'
-              : 'pointer-events-none opacity-0'
-          )}
-          onClick={() => dispatch(openDrawer(!drawerOpen))}
-        >
-          <div
-            className="bg-sidebar text-sidebar-foreground absolute inset-y-0 left-0 border-r-0"
-            style={{ width: appDrawerWidth }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {drawerOpen && logo}
-            {drawerOpen && drawer}
-          </div>
-        </div>
-      )}
-
-      {/* persistent drawer (desktop) */}
-      {!isSmallScreen && (
-        <aside
-          className={cn(
-            'bg-sidebar text-sidebar-foreground fixed bottom-0 left-0 z-40 border-r-0 transition-transform duration-200',
-            !drawerOpen && '-translate-x-full'
-          )}
-          style={{ width: appDrawerWidth, top: appHeaderHeight }}
-        >
-          {drawerOpen && logo}
-          {drawerOpen && drawer}
-        </aside>
-      )}
-    </nav>
+    <SidebarFrame footer={<LogoutButton sx={{ marginBottom: 12, width: '85%' }} />}>
+      <UserProfile />
+      <MenuList isLoggedIn={isLoggedIn} />
+    </SidebarFrame>
   )
 }
 
-export default memo(Sidebar)
+export default Sidebar

--- a/apps/app/src/app/_layout/_MainLayout/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/index.tsx
@@ -1,140 +1,61 @@
 'use client'
 
 // third party
-import { type PropsWithChildren, useEffect, useMemo } from 'react'
-import { usePathname } from 'next/navigation'
+import { type PropsWithChildren } from 'react'
 import { useAccount, useSwitchChain } from 'wagmi'
 
-// Redux
-import { openDrawer } from '@/store/slices/menu'
-import { useDispatch, useSelector } from '@/store/hooks'
-
 // project imports
-import { cn } from '@nl/ui/utils'
 import { Button } from '@nl/ui/base/button'
-import { ScrollArea } from '@nl/ui/base/scroll-area'
-import { Toaster } from '@nl/ui/base/sonner'
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
-import navigation from '@/constants/menu-items'
 import { useConnectedToIMXCheck } from '@/hooks/useImxProvider'
 import { TARGET_NETWORK } from '@/constants/networks'
 
 // components
 import { Icon } from '@nl/ui/base/icon'
-import Breadcrumbs from '@/components/extended/Breadcrumbs'
-import Snackbar from '@/components/extended/Snackbar'
+import AppShell from '@/app/_layout/AppShell'
 import Header from './_Header'
 import Sidebar from './_Sidebar'
-import styles from './MainLayout.module.css'
-
-const appHeaderHeight = 60
-const container = true
 
 // ==============================|| MAIN LAYOUT ||============================== //
 
 const MainLayout = ({ children }: PropsWithChildren) => {
-  const pathname = usePathname()
-  const dispatch = useDispatch()
   const { address, chain } = useAccount()
   const { switchChain } = useSwitchChain()
   const isConnectedToIMX = useConnectedToIMXCheck()
 
-  const matchDownXL = useMediaQuery('(max-width:1280px)')
-  const { drawerOpen } = useSelector((state) => state.menu)
-
-  useEffect(() => {
-    dispatch(openDrawer(!matchDownXL))
-  }, [matchDownXL, dispatch])
-
-  const header = useMemo(
-    () => (
-      <div className="py-1 lg:py-0">
-        <Header />
+  const networkWarning =
+    address && TARGET_NETWORK.chainId !== chain?.id ? (
+      <div
+        className={
+          isConnectedToIMX
+            ? 'bg-success-dark/[80%] flex h-[60px] w-full items-center justify-center'
+            : 'bg-error/[80%] flex h-[60px] w-full items-center justify-center'
+        }
+        style={{ zIndex: 1, position: 'absolute' }}
+      >
+        <Icon name={isConnectedToIMX ? 'info' : 'triangle-alert'} size="lg" strokeWidth={2.5} />
+        <span className="px-2 text-xl font-semibold">
+          {isConnectedToIMX
+            ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`
+            : `Please switch to ${TARGET_NETWORK.label}`}
+        </span>
+        <Button
+          className="px-4 py-0.5"
+          variant="default"
+          onClick={() => switchChain?.({ chainId: TARGET_NETWORK.chainId })}
+        >
+          Switch
+        </Button>
       </div>
-    ),
-    []
-  )
-  const isNoFilterPage = pathname && /(degens|dashboard\/degens)/.test(pathname)
-
-  const getContent = () => {
-    if (container && !isNoFilterPage) {
-      return (
-        <div className="container">
-          <Breadcrumbs separator="chevron-right" navigation={navigation} icon title rightAlign />
-          {children}
-        </div>
-      )
-    }
-    return (
-      <>
-        <Breadcrumbs separator="chevron-right" navigation={navigation} icon title rightAlign />
-        {children}
-      </>
-    )
-  }
+    ) : null
 
   return (
-    <>
-      <div className="flex">
-        {/* header */}
-        <header
-          className="fixed top-0 right-0 left-0 z-50 border-0 bg-sidebar transition-[width]"
-          style={{
-            transition: drawerOpen ? 'width 200ms cubic-bezier(0.4, 0, 0.6, 1) 0ms' : 'none',
-          }}
-        >
-          {address && TARGET_NETWORK.chainId !== chain?.id && (
-            <div
-              className={
-                isConnectedToIMX
-                  ? 'bg-success-dark/[80%] flex h-[60px] w-full items-center justify-center'
-                  : 'bg-error/[80%] flex h-[60px] w-full items-center justify-center'
-              }
-              style={{ zIndex: 1, position: 'absolute' }}
-            >
-              <Icon
-                name={isConnectedToIMX ? 'info' : 'triangle-alert'}
-                size="lg"
-                strokeWidth={2.5}
-              />
-
-              <span className="px-2 text-xl font-semibold">
-                {isConnectedToIMX
-                  ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`
-                  : `Please switch to ${TARGET_NETWORK.label}`}
-              </span>
-              <Button
-                className="px-4 py-0.5"
-                variant="default"
-                onClick={() => switchChain?.({ chainId: TARGET_NETWORK.chainId })}
-              >
-                Switch
-              </Button>
-            </div>
-          )}
-          {header}
-        </header>
-
-        {/* drawer */}
-        <Sidebar />
-
-        {/* main content */}
-        <main className={cn(styles.main, drawerOpen ? styles.mainOpen : styles.mainClosed)}>
-          {!isNoFilterPage ? (
-            <ScrollArea
-              className="h-full"
-              viewportClassName={cn('py-5 md:py-10', !container && 'px-5 md:px-20')}
-            >
-              {getContent()}
-            </ScrollArea>
-          ) : (
-            getContent()
-          )}
-        </main>
-      </div>
-      <Snackbar />
-      <Toaster position="top-right" closeButton richColors />
-    </>
+    <AppShell
+      header={<Header showWalletActions />}
+      sidebar={<Sidebar />}
+      networkWarning={networkWarning}
+    >
+      {children}
+    </AppShell>
   )
 }
 

--- a/apps/app/src/app/_layout/_PublicMainLayout/index.tsx
+++ b/apps/app/src/app/_layout/_PublicMainLayout/index.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+
+import AppShell from '@/app/_layout/AppShell'
+import Header from '@/app/_layout/_MainLayout/_Header'
+import PublicSidebar from '@/app/_layout/_MainLayout/_Sidebar/PublicSidebar'
+
+export default function PublicMainLayout({ children }: PropsWithChildren) {
+  return (
+    <AppShell header={<Header />} sidebar={<PublicSidebar />}>
+      {children}
+    </AppShell>
+  )
+}

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -7,9 +7,6 @@ import { GoogleTagManager, WebVitals } from '@nl/ui/gtm'
 import { customFontClassName } from '@nl/ui/fonts'
 import { cn } from '@nl/ui/utils'
 
-import AppContextWrapper from '@/contexts/AppContextWrapper'
-import MainLayout from '@/app/_layout/_MainLayout'
-
 import '@/styles/app.css'
 
 export const metadata: Metadata = {
@@ -73,9 +70,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       <GoogleTagManager />
 
       <body suppressHydrationWarning>
-        <AppContextWrapper>
-          <MainLayout>{children}</MainLayout>
-        </AppContextWrapper>
+        {children}
 
         <WebVitals />
         <Script

--- a/apps/app/src/components/leaderboards/EnhancedTable/EnhancedTableWithWallet.tsx
+++ b/apps/app/src/components/leaderboards/EnhancedTable/EnhancedTableWithWallet.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import type { TableProps } from '@/types/leaderboard'
+import WalletFeatureProviders from '@/contexts/WalletFeatureProviders'
+import EnhancedTable from './EnhancedTable'
+
+export default function EnhancedTableWithWallet(props: TableProps) {
+  return (
+    <WalletFeatureProviders>
+      <EnhancedTable {...props} />
+    </WalletFeatureProviders>
+  )
+}

--- a/apps/app/src/components/leaderboards/index.tsx
+++ b/apps/app/src/components/leaderboards/index.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-nested-ternary */
 import { useState, useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import dynamic from 'next/dynamic'
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
 import { gtm, GTM_EVENTS } from '@nl/ui/gtm'
@@ -11,10 +12,14 @@ import {
   LEADERBOARD_TIME_FILTERS,
   NiftySmashersTables,
 } from '@/constants/leaderboards'
-import EnhancedTable from '@/components/leaderboards/EnhancedTable/EnhancedTable'
 import './modal-table.css'
 
 import styles from './index.module.css'
+
+const EnhancedTable = dynamic(() => import('./EnhancedTable/EnhancedTableWithWallet'), {
+  ssr: false,
+  loading: () => <div className="flex min-h-96 items-center justify-center" aria-busy="true" />,
+})
 
 export default function LeaderBoards(): React.ReactNode {
   const router = useRouter()

--- a/apps/app/src/components/providers/WalletRouteProvider.tsx
+++ b/apps/app/src/components/providers/WalletRouteProvider.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+import dynamic from 'next/dynamic'
+
+const WalletFeatureProviders = dynamic(() => import('@/contexts/WalletFeatureProviders'), {
+  ssr: false,
+  loading: () => null,
+})
+
+export default function WalletRouteProvider({ children }: PropsWithChildren) {
+  return <WalletFeatureProviders>{children}</WalletFeatureProviders>
+}

--- a/apps/app/src/constants/menu-items/Private.tsx
+++ b/apps/app/src/constants/menu-items/Private.tsx
@@ -13,6 +13,12 @@ const PrivateItems: NavItemType = {
       icon: 'layout-grid',
       children: [
         { id: 'dashboard', title: 'Overview', type: 'item', url: '/dashboard' },
+        {
+          id: 'gamer-profile',
+          title: 'Gamer Profile',
+          type: 'item',
+          url: '/dashboard/gamer-profile',
+        },
         { id: 'degens', title: 'DEGENs', type: 'item', url: '/dashboard/degens' },
         { id: 'items', title: 'Comics & Items', type: 'item', url: '/dashboard/items' },
         // {

--- a/apps/app/src/contexts/AppContextWrapper.tsx
+++ b/apps/app/src/contexts/AppContextWrapper.tsx
@@ -2,52 +2,10 @@
 
 // third party
 import type { PropsWithChildren } from 'react'
-import { headers } from 'next/headers'
-
-// app context
-import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
-import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
-import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
-import { IMXProvider } from '@/contexts/IMXContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { NetworkProvider } from '@/contexts/NetworkContext'
-import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
-import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
-import ReduxProvider from '@/store/ReduxProvider'
+import WalletContextWrapper from '@/contexts/WalletContextWrapper'
 
 const AppContextWrapper = async ({ children }: PropsWithChildren) => {
-  const headersList = await headers()
-  const cookies = headersList.get('cookie')
-  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
-
-  const appContexts = auditFixtureEnabled ? (
-    <AuditFixtureContextWrapper>
-      <ReduxProvider>
-        <FeatureFlagProvider>{children}</FeatureFlagProvider>
-      </ReduxProvider>
-    </AuditFixtureContextWrapper>
-  ) : (
-    <NetworkProvider>
-      <IMXProvider>
-        <ReduxProvider>
-          <AuthTokenProvider>
-            <NFTsBalanceProvider>
-              <TokensBalanceProvider>
-                <FeatureFlagProvider>{children}</FeatureFlagProvider>
-              </TokensBalanceProvider>
-            </NFTsBalanceProvider>
-          </AuthTokenProvider>
-        </ReduxProvider>
-      </IMXProvider>
-    </NetworkProvider>
-  )
-
-  return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>{appContexts}</Web3ModalProvider>
-    </LocalStorageProvider>
-  )
+  return <WalletContextWrapper includeCoreProviders>{children}</WalletContextWrapper>
 }
 
 export default AppContextWrapper

--- a/apps/app/src/contexts/PublicAppContextWrapper.tsx
+++ b/apps/app/src/contexts/PublicAppContextWrapper.tsx
@@ -1,0 +1,17 @@
+'use server'
+
+import type { PropsWithChildren } from 'react'
+
+import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import ReduxProvider from '@/store/ReduxProvider'
+
+export default async function PublicAppContextWrapper({ children }: PropsWithChildren) {
+  return (
+    <LocalStorageProvider>
+      <ReduxProvider>
+        <FeatureFlagProvider>{children}</FeatureFlagProvider>
+      </ReduxProvider>
+    </LocalStorageProvider>
+  )
+}

--- a/apps/app/src/contexts/WalletContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletContextWrapper.tsx
@@ -1,0 +1,69 @@
+'use server'
+
+import type { PropsWithChildren } from 'react'
+import { headers } from 'next/headers'
+
+import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
+import { IMXProvider } from '@/contexts/IMXContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { NetworkProvider } from '@/contexts/NetworkContext'
+import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
+import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import ReduxProvider from '@/store/ReduxProvider'
+
+interface WalletContextWrapperProps extends PropsWithChildren {
+  includeCoreProviders?: boolean
+}
+
+export default async function WalletContextWrapper({
+  children,
+  includeCoreProviders = false,
+}: WalletContextWrapperProps) {
+  const cookies = (await headers()).get('cookie')
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+  const walletContexts = auditFixtureEnabled ? (
+    includeCoreProviders ? (
+      <AuditFixtureContextWrapper>
+        <ReduxProvider>
+          <FeatureFlagProvider>{children}</FeatureFlagProvider>
+        </ReduxProvider>
+      </AuditFixtureContextWrapper>
+    ) : (
+      <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
+    )
+  ) : (
+    <NetworkProvider>
+      <IMXProvider>
+        {includeCoreProviders ? (
+          <ReduxProvider>
+            <AuthTokenProvider>
+              <NFTsBalanceProvider>
+                <TokensBalanceProvider>
+                  <FeatureFlagProvider>{children}</FeatureFlagProvider>
+                </TokensBalanceProvider>
+              </NFTsBalanceProvider>
+            </AuthTokenProvider>
+          </ReduxProvider>
+        ) : (
+          <AuthTokenProvider>
+            <NFTsBalanceProvider>
+              <TokensBalanceProvider>{children}</TokensBalanceProvider>
+            </NFTsBalanceProvider>
+          </AuthTokenProvider>
+        )}
+      </IMXProvider>
+    </NetworkProvider>
+  )
+
+  const web3Contexts = <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+
+  return includeCoreProviders ? (
+    <LocalStorageProvider>{web3Contexts}</LocalStorageProvider>
+  ) : (
+    web3Contexts
+  )
+}

--- a/apps/app/src/contexts/WalletFeatureProviders.tsx
+++ b/apps/app/src/contexts/WalletFeatureProviders.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+
+import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { IMXProvider } from '@/contexts/IMXContext'
+import { NetworkProvider } from '@/contexts/NetworkContext'
+import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
+import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+export default function WalletFeatureProviders({ children }: PropsWithChildren) {
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+  const walletContexts = auditFixtureEnabled ? (
+    <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
+  ) : (
+    <NetworkProvider>
+      <IMXProvider>
+        <AuthTokenProvider>
+          <NFTsBalanceProvider>
+            <TokensBalanceProvider>{children}</TokensBalanceProvider>
+          </NFTsBalanceProvider>
+        </AuthTokenProvider>
+      </IMXProvider>
+    </NetworkProvider>
+  )
+
+  return <Web3ModalProvider>{walletContexts}</Web3ModalProvider>
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -57,7 +57,9 @@ const appRouteContracts: Record<string, string[]> = {
   ],
   app: [
     // dApp: auth-critical, SEO, and externally deep-linked routes.
-    'src/app/page.tsx',
+    // The public route group preserves the external `/` URL while keeping its
+    // wallet-free layout boundary explicit in the source tree.
+    'src/app/(public-routes)/page.tsx',
     'src/app/robots.ts',
     'src/app/sitemap.ts',
     'src/app/(public-routes)/degens/page.tsx',


### PR DESCRIPTION
## Summary
- move AppKit, wagmi, IMX, auth, and balance providers off the global root layout
- keep a shared public shell and defer wallet-only game and leaderboard islands
- preserve private dashboard provider order and make the gamer profile menu entry static

## Validation
- app build, type-check, lint, and 158 app tests pass
- 134 shared UI tests pass
- browser smoke covered public shell, deferred wallet modal, wallet-enabled degens, and deferred leaderboard table

## Measured impact
- /: about 4.38 MB to 1.56 MB raw route scripts
- /games: about 4.38 MB to 1.86 MB
- /leaderboards: about 4.41 MB to 1.66 MB
