### PR TITLE
perf(app): defer public degen wallet features

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -224,7 +224,6 @@ const DashboardDegensPage = (): React.ReactNode => {
       <DegensFilter
         onFilter={handleFilter}
         defaultFilterValues={defaultValues as DegenFilter}
-        isDegenOwner={true}
         searchTerm={searchTerm}
       />
     ),

--- a/apps/app/src/app/(public-routes)/degens/layout.tsx
+++ b/apps/app/src/app/(public-routes)/degens/layout.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
 
-import WalletContextWrapper from '@/contexts/WalletContextWrapper'
-
 export const metadata: Metadata = { title: 'Degens' }
 
 export default function Layout({ children }: PropsWithChildren) {
-  return <WalletContextWrapper>{children}</WalletContextWrapper>
+  return children
 }

--- a/apps/app/src/app/(public-routes)/degens/page.tsx
+++ b/apps/app/src/app/(public-routes)/degens/page.tsx
@@ -7,7 +7,6 @@ import dynamic from 'next/dynamic'
 import { v4 as uuidv4 } from 'uuid'
 
 import { Button } from '@nl/ui/base/button'
-import { Dialog } from '@nl/ui/base/dialog'
 import { Icon } from '@nl/ui/base/icon'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
@@ -22,25 +21,28 @@ import {
   getGridSizeClass,
   applySeventhTribesFix,
 } from '@/components/extended/DegensFilter/utils'
-import RenameDegenDialogContent from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'
 import SectionTitle from '@/components/sections/SectionTitle'
 import { DEGEN_BASE_API_URL } from '@/constants/url'
 import useFetch from '@/hooks/useFetch'
 import usePagination from '@/hooks/usePagination'
 import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
-import useNetworkContext from '@/hooks/useNetworkContext'
-import DegenDialog from '@/components/dialog/DegenDialog'
-import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import DegensTopNav from '@/components/extended/DegensTopNav'
 
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
 })
 const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: false })
+const WalletDegenDialog = dynamic(() => import('@/components/providers/WalletDegenDialog'), {
+  ssr: false,
+  loading: () => (
+    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+      Loading degen details
+    </div>
+  ),
+})
 
 const AllDegensPage = (): React.ReactNode => {
-  const { address } = useNetworkContext()
   const [degens, setDegens] = useState<Degen[]>([])
   // Start closed so mobile does not push the first card below the fold before the
   // responsive drawer effect runs. The layout opens it after mount on desktop.
@@ -49,7 +51,6 @@ const AllDegensPage = (): React.ReactNode => {
   const [defaultValues, setDefaultValues] = useState<DegenFilter | undefined>()
   const [filteredData, setFilteredData] = useState<Degen[]>([])
   const [selectedDegen, setSelectedDegen] = useState<Degen>()
-  const [isRenameDegenModalOpen, setIsRenameDegenModalOpen] = useState<boolean>(false)
   const [isDegenModalOpen, setIsDegenModalOpen] = useState<boolean>(false)
   const [isRentDialog, setIsRentDialog] = useState<boolean>(false)
   const searchParams = useSearchParams()
@@ -66,8 +67,6 @@ const AllDegensPage = (): React.ReactNode => {
     return Object.values(data).map(applySeventhTribesFix)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!data])
-
-  const { isDegenOwner } = useNFTsBalances()
 
   const isMobile = useMediaQuery('(max-width:640px)')
   const isSmallScreen = useMediaQuery('(max-width:1280px)')
@@ -98,7 +97,7 @@ const AllDegensPage = (): React.ReactNode => {
       setDegens([])
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [originalDegens, address])
+  }, [originalDegens])
 
   const handleChangeSearchTerm: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> = (
     e
@@ -133,11 +132,6 @@ const AllDegensPage = (): React.ReactNode => {
     [degens?.length, filters]
   )
 
-  const handleClickEditName = useCallback((degen: Degen): void => {
-    setSelectedDegen(degen)
-    setIsRenameDegenModalOpen(true)
-  }, [])
-
   const handleViewTraits = useCallback((degen: Degen): void => {
     setSelectedDegen(degen)
     setIsRentDialog(false)
@@ -161,11 +155,10 @@ const AllDegensPage = (): React.ReactNode => {
         <DegensFilter
           onFilter={handleFilter}
           defaultFilterValues={defaultValues as DegenFilter}
-          isDegenOwner={isDegenOwner}
           searchTerm={searchTerm}
         />
       ),
-    [defaultValues, isDegenOwner, handleFilter, searchTerm]
+    [defaultValues, handleFilter, searchTerm]
   )
 
   const renderDegen = useCallback(
@@ -174,12 +167,11 @@ const AllDegensPage = (): React.ReactNode => {
         <DegenCard
           degen={degen}
           size={isGridView ? 'normal' : 'small'}
-          onClickEditName={() => handleClickEditName(degen)}
           onClickDetail={() => handleViewTraits(degen)}
         />
       </div>
     ),
-    [handleClickEditName, handleViewTraits, isDrawerOpen, isGridView]
+    [handleViewTraits, isDrawerOpen, isGridView]
   )
 
   const renderMain = useCallback(
@@ -286,22 +278,15 @@ const AllDegensPage = (): React.ReactNode => {
           renderMain={renderMain}
         />
       </div>
-      <DegenDialog
-        open={isDegenModalOpen}
-        degen={selectedDegen}
-        isRent={isRentDialog}
-        setIsRent={setIsRentDialog}
-        onClose={() => setIsDegenModalOpen(false)}
-      />
-      <Dialog
-        open={isRenameDegenModalOpen}
-        onOpenChange={(open) => !open && setIsRenameDegenModalOpen(false)}
-      >
-        <RenameDegenDialogContent
+      {isDegenModalOpen && (
+        <WalletDegenDialog
+          open
           degen={selectedDegen}
-          onSuccess={() => setIsRenameDegenModalOpen(false)}
+          isRent={isRentDialog}
+          setIsRent={setIsRentDialog}
+          onClose={() => setIsDegenModalOpen(false)}
         />
-      </Dialog>
+      )}
     </>
   )
 }

--- a/apps/app/src/components/cards/DegenCard/DegenDashboardActions.tsx
+++ b/apps/app/src/components/cards/DegenCard/DegenDashboardActions.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { memo, useMemo } from 'react'
+import Image from 'next/image'
+import { toast } from 'sonner'
+import { Button } from '@nl/ui/base/button'
+import { Icon } from '@nl/ui/base/icon'
+import { formatNumberToDisplay } from '@nl/ui/utils'
+import useClaimableNFTL from '@/hooks/balances/useClaimableNFTL'
+import useAuth from '@/hooks/useAuth'
+import { downloadDegenAsZip } from '@/utils/file'
+import { errorMsgHandler } from '@/utils/errorHandlers'
+
+interface DegenDashboardActionsProps {
+  tokenId: string
+  fav: boolean
+  size: 'small' | 'normal'
+  onClickFavorite?: React.MouseEventHandler<HTMLButtonElement>
+}
+
+const DegenClaimBal = memo(({ tokenId, fontSize }: { tokenId: string; fontSize: string }) => {
+  const degenTokenIndices = useMemo(() => [parseInt(tokenId, 10)], [tokenId])
+  const { balance } = useClaimableNFTL(degenTokenIndices)
+  const amountParsed = formatNumberToDisplay(balance, 0)
+  return <span className="text-center" style={{ fontSize }}>{`${amountParsed} NFTL`}</span>
+})
+
+DegenClaimBal.displayName = 'DegenClaimBal'
+
+const DegenDashboardActions = ({
+  tokenId,
+  fav,
+  size,
+  onClickFavorite,
+}: DegenDashboardActionsProps) => {
+  const { authToken } = useAuth()
+  const tinyFontSize = size === 'small' ? '8px' : 'var(--text-xs)'
+
+  const onClickDownload = async () => {
+    if (!authToken) return
+    try {
+      await downloadDegenAsZip(authToken, tokenId)
+    } catch (err) {
+      toast.error(errorMsgHandler(err))
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-row items-center justify-between px-2 pt-2"
+      style={{ lineHeight: '1.5em' }}
+    >
+      <div className="flex flex-row items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="mr-3 size-6 cursor-pointer p-0"
+          onClick={onClickFavorite}
+          aria-label={fav ? 'Remove degen from favorites' : 'Add degen to favorites'}
+        >
+          <Icon
+            name="heart"
+            strokeWidth={fav ? 0 : 1.5}
+            fill={fav ? 'foreground' : undefined}
+            size={size === 'small' ? 12 : 16}
+            aria-hidden="true"
+          />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto cursor-pointer gap-0 p-0"
+          onClick={onClickDownload}
+          aria-label="Download degen"
+        >
+          <span style={{ fontSize: tinyFontSize, paddingRight: '4px' }}>IP</span>
+          <Image
+            src="/icons/download-solid.svg"
+            alt=""
+            width={size === 'small' ? 12 : 16}
+            height={size === 'small' ? 12 : 16}
+          />
+        </Button>
+      </div>
+      <DegenClaimBal tokenId={tokenId} fontSize={tinyFontSize} />
+    </div>
+  )
+}
+
+export default DegenDashboardActions

--- a/apps/app/src/components/cards/DegenCard/index.test.tsx
+++ b/apps/app/src/components/cards/DegenCard/index.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { Degen } from '@/types/degens'
+
+let DegenCard: typeof import('./index').default
+
+beforeEach(async () => {
+  mock.module('./DegenImage', () => ({
+    default: ({ tokenId }: { tokenId: string }) => <div data-testid="degen-image">{tokenId}</div>,
+  }))
+  DegenCard = (await import('./index')).default
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+const publicDegen = {
+  id: '1',
+  name: 'Nifty Andy',
+  owner: '0x0000000000000000000000000000000000000000',
+} as Degen
+
+describe('DegenCard', () => {
+  it('renders the public card without wallet or auth providers', () => {
+    render(<DegenCard degen={publicDegen} />)
+
+    expect(screen.getByRole('heading', { name: 'Nifty Andy' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Details' })).not.toBeNull()
+    expect(screen.queryByRole('button', { name: /favorite/i })).toBeNull()
+  })
+})

--- a/apps/app/src/components/cards/DegenCard/index.tsx
+++ b/apps/app/src/components/cards/DegenCard/index.tsx
@@ -1,24 +1,20 @@
 'use client'
 
-import { memo, useMemo, useRef } from 'react'
-import Image from 'next/image'
+import { memo, useRef } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
-import { toast } from 'sonner'
 import { Button } from '@nl/ui/base/button'
 import { Card, CardContent } from '@nl/ui/base/card'
 import { Icon } from '@nl/ui/base/icon'
 import { Title } from '@nl/ui/custom/typography'
-import { formatNumberToDisplay } from '@nl/ui/utils'
 import type { SxProps, Theme } from '@/types'
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
-import useClaimableNFTL from '@/hooks/balances/useClaimableNFTL'
 import DegenImage from './DegenImage'
-import { downloadDegenAsZip } from '@/utils/file'
-import { errorMsgHandler } from '@/utils/errorHandlers'
 import type { Degen } from '@/types/degens'
-import useAuth from '@/hooks/useAuth'
 import { DEGEN_PURCHASE_URL } from '@/constants/url'
+
+const DegenDashboardActions = dynamic(() => import('./DegenDashboardActions'), { ssr: false })
 
 export interface DegenCardProps {
   degen: Degen
@@ -31,24 +27,13 @@ export interface DegenCardProps {
   favs?: string[]
   onClickClaim?: React.MouseEventHandler<HTMLButtonElement>
   onClickDetail?: React.MouseEventHandler<HTMLButtonElement>
-  onClickEditName?: React.MouseEventHandler<SVGSVGElement>
+  onClickEditName?: React.MouseEventHandler<HTMLButtonElement>
   onClickEquip?: React.MouseEventHandler<HTMLButtonElement>
-  onClickFavorite?: React.MouseEventHandler<SVGSVGElement>
+  onClickFavorite?: React.MouseEventHandler<HTMLButtonElement>
   onClickRent?: React.MouseEventHandler<HTMLButtonElement>
   onClickSelect?: React.MouseEventHandler<HTMLButtonElement>
   sx?: SxProps<Theme>
 }
-
-const DegenClaimBal: React.FC<
-  React.PropsWithChildren<React.PropsWithChildren<{ tokenId: string; fontSize: string }>>
-> = memo(({ tokenId, fontSize }) => {
-  const degenTokenIndices = useMemo(() => [parseInt(tokenId, 10)], [tokenId])
-  const { balance } = useClaimableNFTL(degenTokenIndices)
-  const amountParsed = formatNumberToDisplay(balance, 0)
-  return <span className="text-center" style={{ fontSize }}>{`${amountParsed} NFTL`}</span>
-})
-
-DegenClaimBal.displayName = 'DegenClaimBal'
 
 const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenCardProps>>> = memo(
   ({
@@ -68,20 +53,8 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
   }) => {
     const { id, name } = degen
     const fav = favs.some((f) => f === id)
-    const { authToken } = useAuth()
-
-    const onClickDownload = async () => {
-      if (authToken) {
-        try {
-          await downloadDegenAsZip(authToken, id)
-        } catch (err) {
-          toast.error(errorMsgHandler(err))
-        }
-      }
-    }
 
     const buttonFontSize = size === 'small' ? '12px' : 'var(--text-sm)'
-    const tinyFontSize = size === 'small' ? '8px' : 'var(--text-xs)'
 
     return (
       <Card
@@ -90,18 +63,22 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
       >
         {id && <DegenImage tokenId={id} />}
         <CardContent className="px-2 py-2">
-          <div className="flex flex-row justify-between gap-2 hover:[&_svg]:block">
+          <div className="group flex flex-row justify-between gap-2">
             <div className="flex">
               <Title level={size === 'small' ? 6 : 5} className="truncate-text-1">
                 {name || '[No Name]'}
               </Title>
               {isDashboardDegen && (
-                <Icon
-                  name="pencil"
-                  size="sm"
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Edit degen name"
                   onClick={onClickEditName}
-                  className="ml-1 hidden cursor-pointer"
-                />
+                  className="ml-1 hidden size-6 cursor-pointer p-0 group-hover:inline-flex"
+                >
+                  <Icon name="pencil" size="sm" aria-hidden="true" />
+                </Button>
               )}
             </div>
             <Link
@@ -148,31 +125,12 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
           )}
         </div>
         {isDashboardDegen && (
-          <div
-            className="flex flex-row items-center justify-between px-2 pt-2"
-            style={{ lineHeight: '1.5em' }}
-          >
-            <div className="flex flex-row items-center">
-              <Icon
-                name="heart"
-                strokeWidth={fav ? 0 : 1.5}
-                fill={fav ? 'foreground' : undefined}
-                size={size === 'small' ? 12 : 16}
-                onClick={onClickFavorite}
-                className="mr-3 cursor-pointer"
-              />
-              <div className="flex cursor-pointer items-center" onClick={onClickDownload}>
-                <span style={{ fontSize: tinyFontSize, paddingRight: '4px' }}>IP</span>
-                <Image
-                  src="/icons/download-solid.svg"
-                  alt="Download Icon"
-                  width={size === 'small' ? 12 : 16}
-                  height={size === 'small' ? 12 : 16}
-                />
-              </div>
-            </div>
-            <DegenClaimBal tokenId={id} fontSize={tinyFontSize} />
-          </div>
+          <DegenDashboardActions
+            tokenId={id}
+            fav={fav}
+            size={size}
+            onClickFavorite={onClickFavorite}
+          />
         )}
       </Card>
     )

--- a/apps/app/src/components/extended/DegensFilter/index.tsx
+++ b/apps/app/src/components/extended/DegensFilter/index.tsx
@@ -27,14 +27,12 @@ import styles from './index.module.css'
 interface DegensFilterProps {
   onFilter: (filter: DegenFilter) => void
   defaultFilterValues: DegenFilter
-  isDegenOwner?: boolean
   searchTerm?: string
 }
 
 const DegensFilter = ({
   onFilter,
   defaultFilterValues,
-  isDegenOwner,
   searchTerm,
 }: DegensFilterProps): React.ReactNode => {
   const mountedRef = useRef(false)
@@ -192,7 +190,7 @@ const DegensFilter = ({
         searchTerm: newFilters.searchTerm,
         walletAddress: newFilters.walletAddress,
       })
-  }, [defaultFilterValues, isDegenOwner, onFilter, params])
+  }, [defaultFilterValues, onFilter, params])
 
   return (
     <div className="flex flex-col gap-3 overflow-x-hidden max-sm:py-4">

--- a/apps/app/src/components/providers/WalletDegenDialog.tsx
+++ b/apps/app/src/components/providers/WalletDegenDialog.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { DegenDialogProps } from '@/components/dialog/DegenDialog'
+import WalletRouteProvider from './WalletRouteProvider'
+
+const DegenDialog = dynamic(() => import('@/components/dialog/DegenDialog'), {
+  ssr: false,
+  loading: () => (
+    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+      Loading degen dialog
+    </div>
+  ),
+})
+
+export default function WalletDegenDialog(props: DegenDialogProps) {
+  return (
+    <WalletRouteProvider>
+      <DegenDialog {...props} />
+    </WalletRouteProvider>
+  )
+}

--- a/apps/app/src/components/providers/WalletRouteProvider.tsx
+++ b/apps/app/src/components/providers/WalletRouteProvider.tsx
@@ -3,9 +3,15 @@
 import type { PropsWithChildren } from 'react'
 import dynamic from 'next/dynamic'
 
+const WalletFeatureLoading = () => (
+  <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+    Loading wallet features
+  </div>
+)
+
 const WalletFeatureProviders = dynamic(() => import('@/contexts/WalletFeatureProviders'), {
   ssr: false,
-  loading: () => null,
+  loading: WalletFeatureLoading,
 })
 
 export default function WalletRouteProvider({ children }: PropsWithChildren) {

--- a/apps/app/src/contexts/WalletFeatureProviders.tsx
+++ b/apps/app/src/contexts/WalletFeatureProviders.tsx
@@ -12,6 +12,7 @@ import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 
 export default function WalletFeatureProviders({ children }: PropsWithChildren) {
   const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+  const cookies = typeof document === 'undefined' ? null : document.cookie
 
   const walletContexts = auditFixtureEnabled ? (
     <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
@@ -27,5 +28,5 @@ export default function WalletFeatureProviders({ children }: PropsWithChildren) 
     </NetworkProvider>
   )
 
-  return <Web3ModalProvider>{walletContexts}</Web3ModalProvider>
+  return <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
 }


### PR DESCRIPTION
## Summary
- keep the public Degens route free of wallet providers until a wallet-only dialog is opened
- defer dashboard-only card actions and use shared shadcn buttons with accessible labels
- preserve wallet cookie hydration and add loading status feedback for deferred wallet islands
- add a regression test proving the public card renders without wallet/auth providers

## Performance
- `/degens` raw initial script payload: ~4.57 MB -> ~2.00 MB (~56% reduction)
- route bundle stats: ~4.45 MB -> ~1.89 MB (~58% reduction)

## Validation
- `bun --filter app type-check`
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun --filter app build`
- full Bun suite with coverage: 772 passed, 6 skipped, 0 failed
- focused route/filter/card tests
- browser QA on local production build: `/degens` rendered, dialog opened, focus landed on Close, Escape closed it, no runtime overlayn