### PR TITLE
perf(app): defer dashboard degen dialogs

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -36,7 +36,7 @@ import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
 import { v4 as uuidv4 } from 'uuid'
 import EmptyState from '@/components/EmptyState'
-import DegenDialog from '@/components/dialog/DegenDialog'
+import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import DegensTopNav from '@/components/extended/DegensTopNav'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
@@ -387,16 +387,18 @@ const DashboardDegensPage = (): React.ReactNode => {
           renderMain={renderMain}
         />
       </div>
-      <DegenDialog
-        open={isDegenModalOpen}
-        degen={selectedDegen}
-        isClaim={isClaimDialog}
-        isRent={isRentDialog}
-        isEquip={isEquipDialog}
-        setIsClaim={setIsClaimDialog}
-        setIsRent={setIsRentDialog}
-        onClose={() => setIsDegenModalOpen(false)}
-      />
+      {isDegenModalOpen && (
+        <DeferredDegenDialog
+          open
+          degen={selectedDegen}
+          isClaim={isClaimDialog}
+          isRent={isRentDialog}
+          isEquip={isEquipDialog}
+          setIsClaim={setIsClaimDialog}
+          setIsRent={setIsRentDialog}
+          onClose={() => setIsDegenModalOpen(false)}
+        />
+      )}
       <Dialog
         open={isRenameDegenModalOpen}
         onOpenChange={(open) => !open && setIsRenameDegenModalOpen(false)}

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -14,7 +14,7 @@ import SectionSlider from '@/components/sections/SectionSlider'
 import { DEGEN_BASE_API_URL, DEGEN_COLLECTION_URL, PROFILE_FAV_DEGENS_API } from '@/constants/url'
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
 import EmptyState from '@/components/EmptyState'
-import DegenDialog from '@/components/dialog/DegenDialog'
+import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
 import RenameDegenDialogContent from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import useFetch from '@/hooks/useFetch'
@@ -162,15 +162,17 @@ const MyDegens = (): React.ReactNode => {
           </div>
         )}
       </SectionSlider>
-      <DegenDialog
-        open={isDegenModalOpen}
-        degen={selectedDegen}
-        isClaim={isClaimDialog}
-        isRent={isRentDialog}
-        setIsClaim={setIsClaimDialog}
-        setIsRent={setIsRentDialog}
-        onClose={() => setIsDegenModalOpen(false)}
-      />
+      {isDegenModalOpen && (
+        <DeferredDegenDialog
+          open
+          degen={selectedDegen}
+          isClaim={isClaimDialog}
+          isRent={isRentDialog}
+          setIsClaim={setIsClaimDialog}
+          setIsRent={setIsRentDialog}
+          onClose={() => setIsDegenModalOpen(false)}
+        />
+      )}
       <Dialog
         open={isRenameDegenModalOpen}
         onOpenChange={(open) => !open && setIsRenameDegenModalOpen(false)}

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
@@ -14,7 +14,7 @@ import usePlayerProfile from '@/hooks/usePlayerProfile'
 import { Countdown } from '@nl/ui/base/countdown'
 import useLocalStorage from '@/hooks/useLocalStorage'
 
-import DegenDialog from '@/components/dialog/DegenDialog'
+import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
 import { RentalDataGrid } from '@/types/rentalDataGrid'
 import ChangeNicknameDialog from './ChangeNicknameDialog'
 
@@ -522,13 +522,15 @@ const MyRentalsDataGrid = ({
       </Dialog>
 
       {/* Degen Traits Dialog */}
-      <DegenDialog
-        open={isDegenModalOpen}
-        degen={selectedDegen}
-        isRent={isRentDialog}
-        setIsRent={setIsRentDialog}
-        onClose={() => setIsDegenModalOpen(false)}
-      />
+      {isDegenModalOpen && (
+        <DeferredDegenDialog
+          open
+          degen={selectedDegen}
+          isRent={isRentDialog}
+          setIsRent={setIsRentDialog}
+          onClose={() => setIsDegenModalOpen(false)}
+        />
+      )}
     </>
   )
 }

--- a/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
@@ -117,7 +117,7 @@ const ViewTraitsContentDialog = ({
               </Button>
             )} */}
           {onClose && (
-            <Button variant="default" className="w-full" onClick={onClose}>
+            <Button variant="default" className="w-full" onClick={onClose} autoFocus>
               Close
             </Button>
           )}

--- a/apps/app/src/components/dialog/DegenDialog/index.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { Dialog, DialogContent } from '@nl/ui/base/dialog'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { cn } from '@nl/ui/utils'
@@ -14,11 +15,30 @@ import type { CharacterType, Degen, GetDegenResponse } from '@/types/degens'
 import { errorMsgHandler } from '@/utils/errorHandlers'
 import useAuth from '@/hooks/useAuth'
 
-import ClaimDegenContentDialog from './ClaimDegenContentDialog'
-import EquipDegenContentDialog from './EquipDegenContentDialog'
-import RentDegenContentDialog from './RentDegenContentDialog'
-import ViewTraitsContentDialog from './ViewTraitsContentDialog'
 import styles from './index.module.css'
+
+const DialogContentLoading = () => (
+  <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+    Loading degen dialog content
+  </div>
+)
+
+const ClaimDegenContentDialog = dynamic(() => import('./ClaimDegenContentDialog'), {
+  ssr: false,
+  loading: DialogContentLoading,
+})
+const EquipDegenContentDialog = dynamic(() => import('./EquipDegenContentDialog'), {
+  ssr: false,
+  loading: DialogContentLoading,
+})
+const RentDegenContentDialog = dynamic(() => import('./RentDegenContentDialog'), {
+  ssr: false,
+  loading: DialogContentLoading,
+})
+const ViewTraitsContentDialog = dynamic(() => import('./ViewTraitsContentDialog'), {
+  ssr: false,
+  loading: DialogContentLoading,
+})
 
 export interface DegenDialogProps {
   degen?: Degen

--- a/apps/app/src/components/providers/DeferredDegenDialog.tsx
+++ b/apps/app/src/components/providers/DeferredDegenDialog.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import type { DegenDialogProps } from '@/components/dialog/DegenDialog'
+
+const DegenDialog = dynamic(() => import('@/components/dialog/DegenDialog'), {
+  ssr: false,
+  loading: () => (
+    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+      Loading degen details
+    </div>
+  ),
+})
+
+export default function DeferredDegenDialog(props: DegenDialogProps) {
+  return <DegenDialog {...props} />
+}

--- a/apps/app/src/components/providers/WalletDegenDialog.tsx
+++ b/apps/app/src/components/providers/WalletDegenDialog.tsx
@@ -1,22 +1,13 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import type { DegenDialogProps } from '@/components/dialog/DegenDialog'
+import DeferredDegenDialog from './DeferredDegenDialog'
 import WalletRouteProvider from './WalletRouteProvider'
-
-const DegenDialog = dynamic(() => import('@/components/dialog/DegenDialog'), {
-  ssr: false,
-  loading: () => (
-    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
-      Loading degen dialog
-    </div>
-  ),
-})
 
 export default function WalletDegenDialog(props: DegenDialogProps) {
   return (
     <WalletRouteProvider>
-      <DegenDialog {...props} />
+      <DeferredDegenDialog {...props} />
     </WalletRouteProvider>
   )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
@@ -74,6 +74,12 @@ const appRouteContracts: Record<string, string[]> = {
   ],
 }
 
+const deferredDashboardDialogConsumers = [
+  'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx',
+]
+
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
     describe(app, () => {
@@ -100,6 +106,17 @@ describe('app route trees exist', () => {
       expect(existsSync(root), `Missing route tree root: apps/${app}/src/app`).toBe(true)
       const count = countRouteFiles(root)
       expect(count, `No route files found under apps/${app}/src/app`).toBeGreaterThan(0)
+    })
+  }
+})
+
+describe('dashboard dialog loading contract', () => {
+  for (const file of deferredDashboardDialogConsumers) {
+    it(`defers the Degen dialog in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('DeferredDegenDialog')
+      expect(source).not.toContain("from '@/components/dialog/DegenDialog'")
     })
   }
 })


### PR DESCRIPTION
## Summary
- defer the Degen dialog tree on private dashboard routes until a user opens it
- split claim, equip, rent, and trait dialog content into interaction-time chunks
- reuse one shared deferred loader for public and private Degen dialogs
- preserve the unified theme and add an explicit focus target for the async trait dialog
- add a route contract preventing static DegenDialog imports from returning

## Performance
- `/dashboard`: 4,501,221 -> 4,406,536 bytes (~95 KB reduction, ~2.1%)
- `/dashboard/degens`: 4,482,200 -> 4,374,577 bytes (~108 KB reduction, ~2.4%)
- `/dashboard/rentals`: 4,503,560 -> 4,387,424 bytes (~116 KB reduction, ~2.6%)
- dialog branches now load only when the selected interaction requires them

## Validation
- `bun --filter app type-check`
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun --filter app build`
- full Bun suite with coverage: 775 passed, 6 skipped, 0 failed
- route contract: 53 passed
- authenticated audit-fixture browser QA: dashboard rendered, trait dialog opened, focus landed on Close, Escape closed it, no framework overlay; only expected localhost analytics/WalletConnect warningsn