### PR TITLE
perf(app): slim verification wallet boundary

### DIFF
--- a/apps/app/src/app/(public-routes)/verification/layout.tsx
+++ b/apps/app/src/app/(public-routes)/verification/layout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react'
 
-import WalletContextWrapper from '@/contexts/WalletContextWrapper'
+import WalletAuthContextWrapper from '@/contexts/WalletAuthContextWrapper'
 
 export default function VerificationLayout({ children }: PropsWithChildren) {
-  return <WalletContextWrapper>{children}</WalletContextWrapper>
+  return <WalletAuthContextWrapper>{children}</WalletAuthContextWrapper>
 }

--- a/apps/app/src/contexts/WalletAuthContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletAuthContextWrapper.tsx
@@ -1,0 +1,23 @@
+'use server'
+
+import type { PropsWithChildren } from 'react'
+import { headers } from 'next/headers'
+
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+/**
+ * The smallest wallet boundary for routes that only authenticate a wallet.
+ *
+ * Keeping the balance and Immutable providers out of this boundary prevents
+ * auth-only deep links from downloading the dapp dashboard data clients.
+ */
+export default async function WalletAuthContextWrapper({ children }: PropsWithChildren) {
+  const cookies = (await headers()).get('cookie')
+
+  return (
+    <Web3ModalProvider cookies={cookies}>
+      <AuthTokenProvider>{children}</AuthTokenProvider>
+    </Web3ModalProvider>
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -80,6 +80,8 @@ const deferredDashboardDialogConsumers = [
   'apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx',
 ]
 
+const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
+
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
     describe(app, () => {
@@ -117,6 +119,17 @@ describe('dashboard dialog loading contract', () => {
 
       expect(source).toContain('DeferredDegenDialog')
       expect(source).not.toContain("from '@/components/dialog/DegenDialog'")
+    })
+  }
+})
+
+describe('auth-only route provider contract', () => {
+  for (const file of authOnlyRouteLayouts) {
+    it(`keeps heavy wallet features out of ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('WalletAuthContextWrapper')
+      expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
     })
   }
 })


### PR DESCRIPTION
## Summary
- keep the externally consumed verification route on the smallest wallet/auth provider boundary
- avoid loading Ethereum contract loaders, Immutable Passport, NFT balances, and token balances for auth-only deep links
- add a route contract guard against restoring the full wallet wrapper

## Validation
- `mise exec bun@1.3.14 -- bun test test/contract/route-surface.test.ts` (54 pass)
- `mise exec bun@1.3.14 -- bun --filter app test` (159 pass)
- `mise exec bun@1.3.14 -- bun --filter app type-check` (pass)
- `mise exec bun@1.3.14 -- bun --filter app lint` (pass; 8 pre-existing warnings)
- `mise exec bun@1.3.14 -- bun --filter app build` (pass)
- verification initial route JS: ~4.18 MB -> ~3.57 MB (~611 KB / 14.6% reduction)

The re-alignment workflow was separately verified on the latest scheduled and manual runs; both correctly skipped PR creation because main is already represented in staging under the merge policy.