### PR TITLE
perf(app): narrow Mint-o-Matic wallet boundary

### DIFF
--- a/apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx
+++ b/apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
 
-import WalletContextWrapper from '@/contexts/WalletContextWrapper'
+import WalletMintContextWrapper from '@/contexts/WalletMintContextWrapper'
 
 export const metadata: Metadata = { title: 'Mint-o-Matic' }
 
 export default function Layout({ children }: PropsWithChildren) {
-  return <WalletContextWrapper>{children}</WalletContextWrapper>
+  return <WalletMintContextWrapper>{children}</WalletMintContextWrapper>
 }

--- a/apps/app/src/app/(public-routes)/mint-o-matic/page.tsx
+++ b/apps/app/src/app/(public-routes)/mint-o-matic/page.tsx
@@ -10,15 +10,15 @@ import { Title } from '@nl/ui/custom/typography'
 import { ErrorBoundary } from '@nl/ui/custom/error-boundry'
 import { Preloader } from '@nl/ui/custom/preloader'
 import useAuth from '@/hooks/useAuth'
-import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import { DEGEN_COLLECTION_URL } from '@/constants/url'
+import { useDegenOwnershipContext } from '@/contexts/DegenOwnershipContext'
 
 const CharacterCreator = dynamic(() => import('./_CharacterCreator'), { ssr: false })
 
 const MintPage = () => {
   const [isLoaded, setLoaded] = useState(false)
   const [progress, setProgress] = useState(0)
-  const { isDegenOwner } = useNFTsBalances()
+  const { isDegenOwner } = useDegenOwnershipContext()
   const { isConnected, isLoggedIn, handleConnectWallet } = useAuth()
 
   const searchParams = useSearchParams()

--- a/apps/app/src/contexts/AuditFixtureContextWrapper.tsx
+++ b/apps/app/src/contexts/AuditFixtureContextWrapper.tsx
@@ -1,92 +1,28 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
 import type { PropsWithChildren } from 'react'
-import { immutableZkEvmTestnet } from 'viem/chains'
 
-import {
-  AUDIT_FIXTURE_ADDRESS,
-  AUDIT_FIXTURE_CHARACTERS,
-  AUDIT_FIXTURE_TOKEN,
-} from '@/audit/fixture'
-import { COMICS, ITEMS } from '@/constants/marketplace'
-import AuthTokenContext from '@/contexts/AuthTokenContext'
-import IMXContext from '@/contexts/IMXContext'
-import NetworkContext from '@/contexts/NetworkContext'
-import NFTsBalanceContext from '@/contexts/NFTsBalanceContext'
+import AuditFixtureWalletContextWrapper from '@/contexts/AuditFixtureWalletContextWrapper'
 import TokensBalanceContext from '@/contexts/TokensBalanceContext'
-import type { Contracts } from '@/types/web3'
-
-const auditComics = COMICS.map((comic, index) => ({ ...comic, balance: index === 0 ? 1 : 0 }))
-const auditItems = ITEMS.map((item, index) => ({ ...item, balance: index === 0 ? 1 : 0 }))
 
 const AuditFixtureContextWrapper = ({ children }: PropsWithChildren): React.ReactNode => {
-  const pathname = usePathname()
-  const isProtectedSurface = pathname?.startsWith('/dashboard') ?? false
-
   return (
-    <AuthTokenContext.Provider
-      value={{
-        authToken: isProtectedSurface ? AUDIT_FIXTURE_TOKEN : undefined,
-        handleConnectWallet: async () => {},
-        isConnected: false,
-        isLoggedIn: isProtectedSurface,
-      }}
-    >
-      <IMXContext.Provider
+    <AuditFixtureWalletContextWrapper>
+      <TokensBalanceContext.Provider
         value={{
-          address: AUDIT_FIXTURE_ADDRESS,
-          imxChainId: immutableZkEvmTestnet.id,
-          imxContracts: {} as Contracts,
-          imxSigner: undefined,
-          passportProvider: undefined,
+          loadingArcadeBal: false,
+          loadingNFTLAccrued: false,
+          loadingNFTLBal: false,
+          refetchArcadeBal: () => {},
+          refreshClaimableNFTL: () => {},
+          refreshNFTLBalance: () => {},
+          tokensBalances: { AT: 24, NFTL: { eth: 1250, imx: 875 } },
+          totalAccruedNFTL: 42,
         }}
       >
-        <NetworkContext.Provider
-          value={{
-            address: AUDIT_FIXTURE_ADDRESS,
-            isConnected: false,
-            publicProvider: undefined,
-            readContracts: {} as Contracts,
-            signer: undefined,
-            tx: async () => null,
-            writeContracts: {} as Contracts,
-          }}
-        >
-          <NFTsBalanceContext.Provider
-            value={{
-              comicsBalances: auditComics,
-              degenCount: AUDIT_FIXTURE_CHARACTERS.length,
-              degensBalances: AUDIT_FIXTURE_CHARACTERS,
-              degenTokenIndices: AUDIT_FIXTURE_CHARACTERS.map((degen) => Number(degen.tokenId)),
-              isDegenOwner: true,
-              itemsBalances: auditItems,
-              loadingComics: false,
-              loadingDegens: false,
-              loadingItems: false,
-              refreshComicsBalances: () => {},
-              refreshDegenBalances: () => {},
-              refreshItemsBalances: () => {},
-            }}
-          >
-            <TokensBalanceContext.Provider
-              value={{
-                loadingArcadeBal: false,
-                loadingNFTLAccrued: false,
-                loadingNFTLBal: false,
-                refetchArcadeBal: () => {},
-                refreshClaimableNFTL: () => {},
-                refreshNFTLBalance: () => {},
-                tokensBalances: { AT: 24, NFTL: { eth: 1250, imx: 875 } },
-                totalAccruedNFTL: 42,
-              }}
-            >
-              {children}
-            </TokensBalanceContext.Provider>
-          </NFTsBalanceContext.Provider>
-        </NetworkContext.Provider>
-      </IMXContext.Provider>
-    </AuthTokenContext.Provider>
+        {children}
+      </TokensBalanceContext.Provider>
+    </AuditFixtureWalletContextWrapper>
   )
 }
 

--- a/apps/app/src/contexts/AuditFixtureMintContextWrapper.tsx
+++ b/apps/app/src/contexts/AuditFixtureMintContextWrapper.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { PropsWithChildren } from 'react'
+
+import {
+  AUDIT_FIXTURE_ADDRESS,
+  AUDIT_FIXTURE_CHARACTERS,
+  AUDIT_FIXTURE_TOKEN,
+} from '@/audit/fixture'
+import AuthTokenContext from '@/contexts/AuthTokenContext'
+import DegenOwnershipContext from '@/contexts/DegenOwnershipContext'
+import NetworkContext from '@/contexts/NetworkContext'
+import type { Contracts } from '@/types/web3'
+
+/** Audit fixture boundary for the mint route's auth, network, and ownership needs. */
+export default function AuditFixtureMintContextWrapper({
+  children,
+}: PropsWithChildren): React.ReactNode {
+  const pathname = usePathname()
+  const isProtectedSurface = pathname?.startsWith('/dashboard') ?? false
+
+  return (
+    <AuthTokenContext.Provider
+      value={{
+        authToken: isProtectedSurface ? AUDIT_FIXTURE_TOKEN : undefined,
+        handleConnectWallet: async () => {},
+        isConnected: false,
+        isLoggedIn: isProtectedSurface,
+      }}
+    >
+      <NetworkContext.Provider
+        value={{
+          address: AUDIT_FIXTURE_ADDRESS,
+          isConnected: false,
+          publicProvider: undefined,
+          readContracts: {} as Contracts,
+          signer: undefined,
+          tx: async () => null,
+          writeContracts: {} as Contracts,
+        }}
+      >
+        <DegenOwnershipContext.Provider
+          value={{
+            degenCount: AUDIT_FIXTURE_CHARACTERS.length,
+            degensBalances: AUDIT_FIXTURE_CHARACTERS,
+            degenTokenIndices: AUDIT_FIXTURE_CHARACTERS.map((degen) => Number(degen.tokenId)),
+            isDegenOwner: true,
+            loadingDegens: false,
+            refreshDegenBalances: () => {},
+          }}
+        >
+          {children}
+        </DegenOwnershipContext.Provider>
+      </NetworkContext.Provider>
+    </AuthTokenContext.Provider>
+  )
+}

--- a/apps/app/src/contexts/AuditFixtureWalletContextWrapper.tsx
+++ b/apps/app/src/contexts/AuditFixtureWalletContextWrapper.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { PropsWithChildren } from 'react'
+import { immutableZkEvmTestnet } from 'viem/chains'
+
+import {
+  AUDIT_FIXTURE_ADDRESS,
+  AUDIT_FIXTURE_CHARACTERS,
+  AUDIT_FIXTURE_TOKEN,
+} from '@/audit/fixture'
+import { COMICS, ITEMS } from '@/constants/marketplace'
+import AuthTokenContext from '@/contexts/AuthTokenContext'
+import IMXContext from '@/contexts/IMXContext'
+import NetworkContext from '@/contexts/NetworkContext'
+import NFTsBalanceContext from '@/contexts/NFTsBalanceContext'
+import type { Contracts } from '@/types/web3'
+
+const auditComics = COMICS.map((comic, index) => ({ ...comic, balance: index === 0 ? 1 : 0 }))
+const auditItems = ITEMS.map((item, index) => ({ ...item, balance: index === 0 ? 1 : 0 }))
+
+/**
+ * Shared audit fixture for routes that need wallet, network, Immutable, and
+ * NFT ownership contexts without the dashboard token-balance context.
+ */
+export default function AuditFixtureWalletContextWrapper({
+  children,
+}: PropsWithChildren): React.ReactNode {
+  const pathname = usePathname()
+  const isProtectedSurface = pathname?.startsWith('/dashboard') ?? false
+
+  return (
+    <AuthTokenContext.Provider
+      value={{
+        authToken: isProtectedSurface ? AUDIT_FIXTURE_TOKEN : undefined,
+        handleConnectWallet: async () => {},
+        isConnected: false,
+        isLoggedIn: isProtectedSurface,
+      }}
+    >
+      <IMXContext.Provider
+        value={{
+          address: AUDIT_FIXTURE_ADDRESS,
+          imxChainId: immutableZkEvmTestnet.id,
+          imxContracts: {} as Contracts,
+          imxSigner: undefined,
+          passportProvider: undefined,
+        }}
+      >
+        <NetworkContext.Provider
+          value={{
+            address: AUDIT_FIXTURE_ADDRESS,
+            isConnected: false,
+            publicProvider: undefined,
+            readContracts: {} as Contracts,
+            signer: undefined,
+            tx: async () => null,
+            writeContracts: {} as Contracts,
+          }}
+        >
+          <NFTsBalanceContext.Provider
+            value={{
+              comicsBalances: auditComics,
+              degenCount: AUDIT_FIXTURE_CHARACTERS.length,
+              degensBalances: AUDIT_FIXTURE_CHARACTERS,
+              degenTokenIndices: AUDIT_FIXTURE_CHARACTERS.map((degen) => Number(degen.tokenId)),
+              isDegenOwner: true,
+              itemsBalances: auditItems,
+              loadingComics: false,
+              loadingDegens: false,
+              loadingItems: false,
+              refreshComicsBalances: () => {},
+              refreshDegenBalances: () => {},
+              refreshItemsBalances: () => {},
+            }}
+          >
+            {children}
+          </NFTsBalanceContext.Provider>
+        </NetworkContext.Provider>
+      </IMXContext.Provider>
+    </AuthTokenContext.Provider>
+  )
+}

--- a/apps/app/src/contexts/DegenOwnershipContext.tsx
+++ b/apps/app/src/contexts/DegenOwnershipContext.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { createContext, useContext, type PropsWithChildren } from 'react'
+
+import useDegenOwnership, { type DegenOwnershipState } from '@/hooks/balances/useDegenOwnership'
+
+const CONTEXT_INITIAL_STATE: DegenOwnershipState = {
+  degenCount: 0,
+  degensBalances: [],
+  degenTokenIndices: [],
+  isDegenOwner: false,
+  loadingDegens: false,
+  refreshDegenBalances: () => {},
+}
+
+const DegenOwnershipContext = createContext<DegenOwnershipState>(CONTEXT_INITIAL_STATE)
+
+export const DegenOwnershipProvider = ({ children }: PropsWithChildren): React.ReactNode => {
+  const ownership = useDegenOwnership()
+
+  return (
+    <DegenOwnershipContext.Provider value={ownership}>{children}</DegenOwnershipContext.Provider>
+  )
+}
+
+export const useDegenOwnershipContext = () => useContext(DegenOwnershipContext)
+
+export default DegenOwnershipContext

--- a/apps/app/src/contexts/NFTsBalanceContext.tsx
+++ b/apps/app/src/contexts/NFTsBalanceContext.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { createContext, useEffect, useRef, useMemo } from 'react'
+import { createContext, useEffect, useMemo, useRef } from 'react'
 import type { PropsWithChildren } from 'react'
 import type { Character } from '@/types/graph'
 import type { Comic, Item } from '@/types/marketplace'
 
-import { useOwnerSearch } from '@/hooks/useGraphQL'
-import useAuth from '@/hooks/useAuth'
 import useComicsBalances from '@/hooks/balances/useComicsBalances'
+import useDegenOwnership from '@/hooks/balances/useDegenOwnership'
 import useItemsBalances from '@/hooks/balances/useItemsBalances'
+import useAuth from '@/hooks/useAuth'
 
 interface NFTsBalanceContext {
   comicsBalances: Comic[]
@@ -45,22 +45,14 @@ const NFTsBalanceContext = createContext<NFTsBalanceContext>(CONTEXT_INITIAL_STA
 export const NFTsBalanceProvider = ({ children }: PropsWithChildren): React.ReactNode => {
   const firstRenderRef = useRef(true)
   const { isLoggedIn } = useAuth()
-
-  // Load user DEGEN balances from Subgraph
-  const { isFetching, data: owner, refetch: refreshDegenBalances } = useOwnerSearch()
-  const { characterCount: degenCount = 0 } = owner || {}
-  const isDegenOwner = degenCount > 0
-
-  const degensBalances = useMemo(() => {
-    return owner?.characters
-      ? owner.characters.map((degen) => ({ ...degen, id: degen.tokenId.toString() }))
-      : []
-  }, [owner])
-
-  const degenTokenIndices = useMemo(
-    () => degensBalances.map((d) => parseInt(d.id, 10)),
-    [degensBalances]
-  )
+  const {
+    degenCount,
+    degensBalances,
+    degenTokenIndices,
+    isDegenOwner,
+    loadingDegens,
+    refreshDegenBalances,
+  } = useDegenOwnership()
 
   // Load user Immutable zkEVM NFT balances
   const {
@@ -74,7 +66,8 @@ export const NFTsBalanceProvider = ({ children }: PropsWithChildren): React.Reac
     refetch: refreshItemsBalances,
   } = useItemsBalances()
 
-  // Refetch on login state change, avoiding initial render
+  // Refetch marketplace balances on login state change. DEGEN ownership has
+  // the same lifecycle in its smaller, reusable ownership hook.
   useEffect(() => {
     if (firstRenderRef.current) {
       firstRenderRef.current = false
@@ -82,7 +75,6 @@ export const NFTsBalanceProvider = ({ children }: PropsWithChildren): React.Reac
     }
     if (!isLoggedIn) return
     refreshComicsBalances()
-    refreshDegenBalances()
     refreshItemsBalances()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoggedIn])
@@ -97,7 +89,7 @@ export const NFTsBalanceProvider = ({ children }: PropsWithChildren): React.Reac
         isDegenOwner,
         itemsBalances,
         loadingComics,
-        loadingDegens: isFetching,
+        loadingDegens,
         loadingItems,
         refreshComicsBalances,
         refreshDegenBalances,

--- a/apps/app/src/contexts/WalletMintContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletMintContextWrapper.tsx
@@ -1,0 +1,34 @@
+'use server'
+
+import type { PropsWithChildren } from 'react'
+import { headers } from 'next/headers'
+
+import AuditFixtureMintContextWrapper from '@/contexts/AuditFixtureMintContextWrapper'
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { DegenOwnershipProvider } from '@/contexts/DegenOwnershipContext'
+import { NetworkProvider } from '@/contexts/NetworkContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+/**
+ * Wallet boundary for Mint-o-Matic.
+ *
+ * The mint route needs wallet authentication, network access, and DEGEN
+ * ownership. Keeping marketplace, Immutable, and token-balance providers out
+ * of this boundary avoids loading dashboard clients on the public mint surface.
+ */
+export default async function WalletMintContextWrapper({ children }: PropsWithChildren) {
+  const cookies = (await headers()).get('cookie')
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+  const walletContexts = auditFixtureEnabled ? (
+    <AuditFixtureMintContextWrapper>{children}</AuditFixtureMintContextWrapper>
+  ) : (
+    <NetworkProvider>
+      <AuthTokenProvider>
+        <DegenOwnershipProvider>{children}</DegenOwnershipProvider>
+      </AuthTokenProvider>
+    </NetworkProvider>
+  )
+
+  return <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+}

--- a/apps/app/src/hooks/balances/useDegenOwnership.ts
+++ b/apps/app/src/hooks/balances/useDegenOwnership.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+
+import { useOwnerSearch } from '@/hooks/useGraphQL'
+import useAuth from '@/hooks/useAuth'
+import type { Character } from '@/types/graph'
+
+export interface DegenOwnershipState {
+  degenCount: number
+  degensBalances: Character[]
+  degenTokenIndices: number[]
+  isDegenOwner: boolean
+  loadingDegens: boolean
+  refreshDegenBalances: () => void
+}
+
+export default function useDegenOwnership(): DegenOwnershipState {
+  const firstRenderRef = useRef(true)
+  const { isLoggedIn } = useAuth()
+  const { isFetching, data: owner, refetch: refreshDegenBalances } = useOwnerSearch()
+  const { characterCount: degenCount = 0 } = owner || {}
+  const isDegenOwner = degenCount > 0
+
+  const degensBalances = useMemo(() => {
+    return owner?.characters
+      ? owner.characters.map((degen) => ({ ...degen, id: degen.tokenId.toString() }))
+      : []
+  }, [owner])
+
+  const degenTokenIndices = useMemo(
+    () => degensBalances.map((degen) => parseInt(degen.id, 10)),
+    [degensBalances]
+  )
+
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      return
+    }
+    if (!isLoggedIn) return
+    refreshDegenBalances()
+  }, [isLoggedIn, refreshDegenBalances])
+
+  return {
+    degenCount,
+    degensBalances,
+    degenTokenIndices,
+    isDegenOwner,
+    loadingDegens: isFetching,
+    refreshDegenBalances,
+  }
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -81,6 +81,7 @@ const deferredDashboardDialogConsumers = [
 ]
 
 const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
+const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx']
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -130,6 +131,18 @@ describe('auth-only route provider contract', () => {
 
       expect(source).toContain('WalletAuthContextWrapper')
       expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
+    })
+  }
+})
+
+describe('NFT-only route provider contract', () => {
+  for (const file of nftOnlyRouteLayouts) {
+    it(`keeps dashboard token balances out of ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('WalletMintContextWrapper')
+      expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
+      expect(source).not.toContain("from '@/contexts/AuditFixtureContextWrapper'")
     })
   }
 })


### PR DESCRIPTION
## Summary\n- give Mint-o-Matic a route-specific wallet boundary for auth, network, and DEGEN ownership only\n- share the DEGEN ownership lifecycle hook while keeping dashboard NFT/token providers unchanged\n- split audit fixtures so the mint route does not import Immutable, comics/items, or token-balance clients\n\n## Validation\n- contract: 55 pass\n- app tests: 159 pass\n- app type-check: passed\n- app lint: passed with 8 pre-existing image warnings\n- app build: passed\n- route initial JS: Mint-o-Matic 4,294,201 bytes / 44 chunks vs 4,304,772 bytes before this tranche\n- mint manifest contains no full NFT/Immutable/token modules\n