### PR TITLE
perf(app): defer public wallet storage

### DIFF
--- a/apps/app/src/contexts/PublicAppContextWrapper.tsx
+++ b/apps/app/src/contexts/PublicAppContextWrapper.tsx
@@ -3,15 +3,12 @@
 import type { PropsWithChildren } from 'react'
 
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import ReduxProvider from '@/store/ReduxProvider'
 
 export default async function PublicAppContextWrapper({ children }: PropsWithChildren) {
   return (
-    <LocalStorageProvider>
-      <ReduxProvider>
-        <FeatureFlagProvider>{children}</FeatureFlagProvider>
-      </ReduxProvider>
-    </LocalStorageProvider>
+    <ReduxProvider>
+      <FeatureFlagProvider>{children}</FeatureFlagProvider>
+    </ReduxProvider>
   )
 }

--- a/apps/app/src/contexts/WalletAuthContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletAuthContextWrapper.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from 'react'
 import { headers } from 'next/headers'
 
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 
 /**
@@ -16,8 +17,10 @@ export default async function WalletAuthContextWrapper({ children }: PropsWithCh
   const cookies = (await headers()).get('cookie')
 
   return (
-    <Web3ModalProvider cookies={cookies}>
-      <AuthTokenProvider>{children}</AuthTokenProvider>
-    </Web3ModalProvider>
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>
+        <AuthTokenProvider>{children}</AuthTokenProvider>
+      </Web3ModalProvider>
+    </LocalStorageProvider>
   )
 }

--- a/apps/app/src/contexts/WalletFeatureProviders.tsx
+++ b/apps/app/src/contexts/WalletFeatureProviders.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from 'react'
 import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { IMXProvider } from '@/contexts/IMXContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { NetworkProvider } from '@/contexts/NetworkContext'
 import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
 import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
@@ -28,5 +29,9 @@ export default function WalletFeatureProviders({ children }: PropsWithChildren) 
     </NetworkProvider>
   )
 
-  return <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+    </LocalStorageProvider>
+  )
 }

--- a/apps/app/src/contexts/WalletMintContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletMintContextWrapper.tsx
@@ -6,6 +6,7 @@ import { headers } from 'next/headers'
 import AuditFixtureMintContextWrapper from '@/contexts/AuditFixtureMintContextWrapper'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { DegenOwnershipProvider } from '@/contexts/DegenOwnershipContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { NetworkProvider } from '@/contexts/NetworkContext'
 import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 
@@ -30,5 +31,9 @@ export default async function WalletMintContextWrapper({ children }: PropsWithCh
     </NetworkProvider>
   )
 
-  return <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
+    </LocalStorageProvider>
+  )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -82,6 +82,12 @@ const deferredDashboardDialogConsumers = [
 
 const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
 const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx']
+const publicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.tsx'
+const walletStorageBoundaries = [
+  'apps/app/src/contexts/WalletAuthContextWrapper.tsx',
+  'apps/app/src/contexts/WalletFeatureProviders.tsx',
+  'apps/app/src/contexts/WalletMintContextWrapper.tsx',
+]
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -143,6 +149,22 @@ describe('NFT-only route provider contract', () => {
       expect(source).toContain('WalletMintContextWrapper')
       expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
       expect(source).not.toContain("from '@/contexts/AuditFixtureContextWrapper'")
+    })
+  }
+})
+
+describe('public storage provider contract', () => {
+  it('keeps wallet storage out of the shared public shell', () => {
+    const source = readFileSync(join(process.cwd(), publicProviderBoundary), 'utf8')
+
+    expect(source).not.toContain("from '@/contexts/LocalStorageContext'")
+  })
+
+  for (const file of walletStorageBoundaries) {
+    it(`keeps wallet storage available in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain("from '@/contexts/LocalStorageContext'")
     })
   }
 })


### PR DESCRIPTION
## Summary
- remove LocalStorageProvider from the shared wallet-free public app shell
- mount it inside the auth, mint, and feature-wallet boundaries that actually consume auth storage
- add a route contract to prevent public-shell storage regressions

## Performance evidence
- /: 1,556,839 -> 1,064,745 bytes
- /degens: 1,994,853 -> 1,508,911 bytes
- /games: 1,854,918 -> 1,362,791 bytes
- /leaderboards: 1,655,973 -> 1,163,846 bytes

## Validation
- contract: 59 pass
- app tests: 159 pass
- type-check: passed
- lint: passed with 8 pre-existing image warnings
- format: passed
- app build: passed
- code-foundry doctor: passed
