### PR TITLE
perf(app): defer dashboard overview sections

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -15,7 +15,6 @@ import { DEGEN_BASE_API_URL, DEGEN_COLLECTION_URL, PROFILE_FAV_DEGENS_API } from
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
 import EmptyState from '@/components/EmptyState'
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
-import RenameDegenDialogContent from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import useFetch from '@/hooks/useFetch'
 import { useProfileFavDegens } from '@/hooks/useGamerProfile'
@@ -27,6 +26,18 @@ const DegenCard = dynamic(
   () => import('@/components/cards/DegenCard').then((module) => module.DegenCardInView),
   {
     ssr: false,
+  }
+)
+
+const RenameDegenDialogContent = dynamic(
+  () => import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+        Loading rename form
+      </div>
+    ),
   }
 )
 

--- a/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import MyComics from './MyComics'
+import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
 import MyDegens from './MyDegens'
-import MyItems from './MyItems'
 import MyNFTL from './_MyNFTL'
 import MyStats from './MyStats'
+
+const loadMyComics = () => import('./MyComics')
+const loadMyItems = () => import('./MyItems')
 
 const DashboardOverview = (): React.ReactNode => {
   return (
@@ -22,10 +24,10 @@ const DashboardOverview = (): React.ReactNode => {
           <MyDegens />
         </div>
         <div className="w-full">
-          <MyComics />
+          <DeferredDashboardSection label="My Comics" load={loadMyComics} />
         </div>
         <div className="w-full">
-          <MyItems />
+          <DeferredDashboardSection label="My Items" load={loadMyItems} />
         </div>
       </div>
     </div>

--- a/apps/app/src/components/providers/DeferredDashboardSection.tsx
+++ b/apps/app/src/components/providers/DeferredDashboardSection.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+interface DeferredDashboardSectionProps {
+  load: () => Promise<{ default: ComponentType }>
+  label: string
+  rootMargin?: string
+}
+
+export function DashboardSectionLoading({ label }: { label: string }): React.ReactNode {
+  return (
+    <div
+      className="min-h-48"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={`Loading ${label}`}
+    >
+      <span className="sr-only">Loading {label}</span>
+    </div>
+  )
+}
+
+/** Loads below-the-fold dashboard content shortly before it enters the viewport. */
+export default function DeferredDashboardSection({
+  load,
+  label,
+  rootMargin = '320px',
+}: DeferredDashboardSectionProps): React.ReactNode {
+  const sectionRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(sectionRef, rootMargin)
+  const [LoadedSection, setLoadedSection] = useState<ComponentType | null>(null)
+
+  useEffect(() => {
+    if (!isNearViewport || LoadedSection) return
+
+    let cancelled = false
+    load()
+      .then(({ default: Section }) => {
+        if (!cancelled) setLoadedSection(() => Section)
+      })
+      .catch(console.error)
+
+    return () => {
+      cancelled = true
+    }
+  }, [isNearViewport, load, LoadedSection])
+
+  return (
+    <div ref={sectionRef} aria-busy={!LoadedSection}>
+      {LoadedSection ? <LoadedSection /> : <DashboardSectionLoading label={label} />}
+    </div>
+  )
+}

--- a/packages/ui/src/hooks/useOnScreen.ts
+++ b/packages/ui/src/hooks/useOnScreen.ts
@@ -50,6 +50,11 @@ export function useOnScreen<T extends Element = HTMLDivElement>(
     const element = ref.current
     if (!element) return
 
+    if (typeof IntersectionObserver === 'undefined') {
+      setIntersecting(true)
+      return
+    }
+
     const sharedObserver = getSharedObserver(rootMargin)
     const callbacks = callbacksByElement.get(element) ?? new Set<VisibilityCallback>()
     callbacks.add(setIntersecting)

--- a/packages/ui/src/hooks/visibility.test.tsx
+++ b/packages/ui/src/hooks/visibility.test.tsx
@@ -49,6 +49,25 @@ describe('useOnScreen', () => {
     expect(observe).not.toHaveBeenCalled()
   })
 
+  it('treats the element as visible when IntersectionObserver is unavailable', () => {
+    const originalObserver = globalThis.IntersectionObserver
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      const { result } = renderHook(() => useOnScreen({ current: document.createElement('div') }))
+
+      expect(result.current).toBe(true)
+    } finally {
+      Object.defineProperty(globalThis, 'IntersectionObserver', {
+        configurable: true,
+        value: originalObserver,
+      })
+    }
+  })
+
   it('shares one observer across consumers that use the same rootMargin', () => {
     const constructorCalls = mock()
     stubGlobal(

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -88,6 +88,7 @@ const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletFeatureProviders.tsx',
   'apps/app/src/contexts/WalletMintContextWrapper.tsx',
 ]
+const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -128,6 +129,20 @@ describe('dashboard dialog loading contract', () => {
       expect(source).not.toContain("from '@/components/dialog/DegenDialog'")
     })
   }
+
+  it('defers the dashboard rename form until the dialog opens', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx'),
+      'utf8'
+    )
+
+    expect(source).toContain(
+      "import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent')"
+    )
+    expect(source).not.toContain(
+      "from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'"
+    )
+  })
 })
 
 describe('auth-only route provider contract', () => {
@@ -167,6 +182,20 @@ describe('public storage provider contract', () => {
       expect(source).toContain("from '@/contexts/LocalStorageContext'")
     })
   }
+})
+
+describe('dashboard overview loading contract', () => {
+  it('defers below-the-fold comic and item sections', () => {
+    const source = readFileSync(join(process.cwd(), dashboardOverview), 'utf8')
+
+    expect(source).toContain('import DeferredDashboardSection')
+    expect(source).toContain("const loadMyComics = () => import('./MyComics')")
+    expect(source).toContain("const loadMyItems = () => import('./MyItems')")
+    expect(source).toContain("import('./MyComics')")
+    expect(source).toContain("import('./MyItems')")
+    expect(source).toContain('<DeferredDashboardSection label="My Comics" load={loadMyComics} />')
+    expect(source).toContain('<DeferredDashboardSection label="My Items" load={loadMyItems} />')
+  })
 })
 
 function countRouteFiles(dir: string): number {


### PR DESCRIPTION
## Summary
- Defer dashboard overview Comics and Items until they approach the viewport using a shared visibility-aware loader.
- Defer the overview rename form until its dialog is opened.
- Keep loading states accessible and fall back to immediate rendering when IntersectionObserver is unavailable.

## Performance evidence
The measured /dashboard initial route payload decreased from 4,520,019 bytes / 52 chunks after PR #472 to 4,509,497 bytes / 52 chunks on this branch (10,522 bytes, about 0.23%). The deferred section modules are no longer part of the initial overview component chunk and load through the conditional import when needed.

## Validation
- bun --filter app build
- bun --filter app test: 159 pass
- bun --filter app lint: pass, with the same 8 pre-existing image warnings
- bun --filter app type-check
- bun --filter @nl/ui test: 135 pass
- bun --filter @nl/ui lint
- bun --filter @nl/ui type-check
- route-surface contract: 61 pass
- Prettier and git diff --check
