### PR TITLE
perf: defer shared Sentry client SDK

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -51,5 +51,7 @@ export default withSentryConfig(nextConfig, {
   tunnelRoute: true, // Generates a random route for each build (recommended)
 
   // Capture React component names to see which component a user clicked on.
+  // Route grouping is not worth shipping Sentry's manifest on every initial route.
+  routeManifestInjection: false,
   webpack: { reactComponentAnnotation: { enabled: true }, treeshake: { removeDebugLogging: true } },
 })

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -21,6 +21,7 @@
     "@cowprotocol/cow-sdk": "^9.2.6",
     "@hookform/resolvers": "^5.6.0",
     "@nl/imx-passport": "workspace:*",
+    "@nl/sentry-client": "workspace:*",
     "@nl/ui": "workspace:*",
     "@openzeppelin/contracts": "^5.6.1",
     "@reduxjs/toolkit": "^2.12.0",

--- a/apps/app/src/app/global-error.tsx
+++ b/apps/app/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import * as Sentry from '@sentry/nextjs'
+import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    Sentry.captureException(error)
+    captureException(error)
   }, [error])
 
   return (

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -2,22 +2,13 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs'
+import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
 
-if (process.env.VERCEL_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
+scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
+  dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+})
 
-    // Adds request headers and IP for users, for more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-    sendDefaultPii: true,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    tracesSampleRate: 0.1, // 10% trace sampling to limit client overhead
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-  })
-}
-
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
+export const onRouterTransitionStart = captureRouterTransitionStart

--- a/apps/smashers/next.config.ts
+++ b/apps/smashers/next.config.ts
@@ -154,5 +154,7 @@ export default withSentryConfig(nextConfig, {
   tunnelRoute: true, // Generates a random route for each build (recommended)
 
   // Capture React component names to see which component a user clicked on.
+  // Route grouping is not worth shipping Sentry's manifest on every initial route.
+  routeManifestInjection: false,
   webpack: { reactComponentAnnotation: { enabled: true }, treeshake: { removeDebugLogging: true } },
 })

--- a/apps/smashers/package.json
+++ b/apps/smashers/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nl/playfab": "workspace:*",
+    "@nl/sentry-client": "workspace:*",
     "@nl/ui": "workspace:*",
     "@sentry/nextjs": "^10.69.0",
     "@vercel/edge": "^1.3.1",

--- a/apps/smashers/src/app/global-error.tsx
+++ b/apps/smashers/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import * as Sentry from '@sentry/nextjs'
+import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    Sentry.captureException(error)
+    captureException(error)
   }, [error])
 
   return (

--- a/apps/smashers/src/instrumentation-client.ts
+++ b/apps/smashers/src/instrumentation-client.ts
@@ -2,22 +2,13 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs'
+import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
 
-if (process.env.VERCEL_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
+scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
+  dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+})
 
-    // Adds request headers and IP for users, for more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-    sendDefaultPii: true,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    tracesSampleRate: 0.1, // 10% trace sampling to limit client overhead
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-  })
-}
-
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
+export const onRouterTransitionStart = captureRouterTransitionStart

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -120,5 +120,7 @@ export default withSentryConfig(nextConfig, {
   tunnelRoute: true, // Generates a random route for each build (recommended)
 
   // Capture React component names to see which component a user clicked on.
+  // Route grouping is not worth shipping Sentry's manifest on every initial route.
+  routeManifestInjection: false,
   webpack: { reactComponentAnnotation: { enabled: true }, treeshake: { removeDebugLogging: true } },
 })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@google/model-viewer": "^4.3.1",
+    "@nl/sentry-client": "workspace:*",
     "@nl/ui": "workspace:*",
     "@sentry/nextjs": "^10.69.0",
     "next": "16.3.0",

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import * as Sentry from '@sentry/nextjs'
+import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    Sentry.captureException(error)
+    captureException(error)
   }, [error])
 
   return (

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -2,22 +2,13 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs'
+import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
 
-if (process.env.VERCEL_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
+scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
+  dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+})
 
-    // Adds request headers and IP for users, for more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-    sendDefaultPii: true,
-
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    tracesSampleRate: 0.1, // 10% trace sampling to limit client overhead
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-  })
-}
-
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
+export const onRouterTransitionStart = captureRouterTransitionStart

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "@cowprotocol/cow-sdk": "^9.2.6",
         "@hookform/resolvers": "^5.6.0",
         "@nl/imx-passport": "workspace:*",
+        "@nl/sentry-client": "workspace:*",
         "@nl/ui": "workspace:*",
         "@openzeppelin/contracts": "^5.6.1",
         "@reduxjs/toolkit": "^2.12.0",
@@ -160,6 +161,7 @@
       "version": "1.0.3",
       "dependencies": {
         "@nl/playfab": "workspace:*",
+        "@nl/sentry-client": "workspace:*",
         "@nl/ui": "workspace:*",
         "@sentry/nextjs": "^10.69.0",
         "@vercel/edge": "^1.3.1",
@@ -199,6 +201,7 @@
       "version": "1.0.3",
       "dependencies": {
         "@google/model-viewer": "^4.3.1",
+        "@nl/sentry-client": "workspace:*",
         "@nl/ui": "workspace:*",
         "@sentry/nextjs": "^10.69.0",
         "next": "16.3.0",
@@ -274,6 +277,13 @@
     "packages/prettier-config": {
       "name": "@nl/prettier-config",
       "version": "1.0.1",
+    },
+    "packages/sentry-client": {
+      "name": "@nl/sentry-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sentry/nextjs": "^10.69.0",
+      },
     },
     "packages/typescript-config": {
       "name": "@nl/typescript-config",
@@ -1316,6 +1326,8 @@
     "@nl/playfab": ["@nl/playfab@workspace:packages/playfab"],
 
     "@nl/prettier-config": ["@nl/prettier-config@workspace:packages/prettier-config"],
+
+    "@nl/sentry-client": ["@nl/sentry-client@workspace:packages/sentry-client"],
 
     "@nl/typescript-config": ["@nl/typescript-config@workspace:packages/typescript-config"],
 

--- a/packages/sentry-client/eslint.config.mjs
+++ b/packages/sentry-client/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from '@nl/eslint-config/react-internal'
+
+/** @type {import('eslint').Linter.Config} */
+export default config

--- a/packages/sentry-client/package.json
+++ b/packages/sentry-client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@nl/sentry-client",
+  "version": "1.0.0",
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "private": true,
+  "main": "./src/client.ts",
+  "exports": {
+    "./client": "./src/client.ts"
+  },
+  "scripts": {
+    "format": "prettier --write \"**/*.{js,ts,tsx,md,mdx,json}\" --ignore-path ../../.gitignore",
+    "lint": "eslint . --max-warnings 0",
+    "test": "bun test --isolate --preload ../../test/happy-dom-setup.ts --preload ../../test/preload.ts --preload ../../test/setup.ts --pass-with-no-tests",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sentry/nextjs": "^10.69.0"
+  }
+}

--- a/packages/sentry-client/src/client.ts
+++ b/packages/sentry-client/src/client.ts
@@ -1,0 +1,57 @@
+type SentryModule = typeof import('@sentry/nextjs')
+type SentryInitOptions = Parameters<SentryModule['init']>[0]
+type RouterTransitionArgs = Parameters<SentryModule['captureRouterTransitionStart']>
+
+let sentryModulePromise: Promise<SentryModule> | undefined
+let sentryInitPromise: Promise<SentryModule> | undefined
+let sentryInitOptions: SentryInitOptions | undefined
+
+export function loadSentry(): Promise<SentryModule> {
+  sentryModulePromise ??= import('@sentry/nextjs')
+  return sentryModulePromise
+}
+
+const reportSentryLoadError = (error: unknown): void => {
+  console.error('Failed to load Sentry client SDK', error)
+}
+
+function initializeSentry(options: SentryInitOptions): Promise<SentryModule> {
+  const initOptions = (sentryInitOptions ??= options)
+  sentryInitPromise ??= loadSentry().then((sentry) => {
+    sentry.init(initOptions)
+    return sentry
+  })
+  return sentryInitPromise
+}
+
+function getSentryForCapture(): Promise<SentryModule> {
+  return sentryInitOptions ? initializeSentry(sentryInitOptions) : loadSentry()
+}
+
+export function scheduleSentryInit(enabled: boolean, options: SentryInitOptions): void {
+  if (!enabled || typeof window === 'undefined') return
+
+  const initialize = () => {
+    void initializeSentry(options).catch(reportSentryLoadError)
+  }
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(initialize, { timeout: 2000 })
+  } else {
+    globalThis.setTimeout(initialize, 0)
+  }
+}
+
+export function captureException(error: unknown): void {
+  void getSentryForCapture()
+    .then(({ captureException: capture }) => capture(error))
+    .catch(reportSentryLoadError)
+}
+
+export function captureRouterTransitionStart(...args: RouterTransitionArgs): void {
+  if (typeof window === 'undefined' || process.env.VERCEL_ENV !== 'production') return
+
+  void getSentryForCapture()
+    .then(({ captureRouterTransitionStart: capture }) => capture(...args))
+    .catch(reportSentryLoadError)
+}

--- a/packages/sentry-client/tsconfig.json
+++ b/packages/sentry-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@nl/typescript-config/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -198,6 +198,32 @@ describe('dashboard overview loading contract', () => {
   })
 })
 
+const sentryClientBoundaries = [
+  'apps/app/src/instrumentation-client.ts',
+  'apps/app/src/app/global-error.tsx',
+  'apps/web/src/instrumentation-client.ts',
+  'apps/web/src/app/global-error.tsx',
+  'apps/smashers/src/instrumentation-client.ts',
+  'apps/smashers/src/app/global-error.tsx',
+]
+
+describe('deferred Sentry client contract', () => {
+  for (const file of sentryClientBoundaries) {
+    it(`keeps the Sentry SDK out of the static client boundary in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).not.toContain("from '@sentry/nextjs'")
+      expect(source).toContain('@nl/sentry-client/client')
+    })
+  }
+
+  it('keeps the shared Sentry loader dynamic', () => {
+    const source = readFileSync(join(process.cwd(), 'packages/sentry-client/src/client.ts'), 'utf8')
+
+    expect(source).toContain("import('@sentry/nextjs')")
+  })
+})
+
 function countRouteFiles(dir: string): number {
   let count = 0
   for (const entry of readdirSync(dir)) {


### PR DESCRIPTION
## Summary
- share one deferred Sentry client loader across app, web, and Smashers
- initialize Sentry during idle time, while preserving immediate initialization for early errors and first production navigation capture
- keep server and edge Sentry instrumentation unchanged
- disable client route-manifest injection to keep the manifest/runtime out of every initial route

## Measured impact
- app /dashboard: 4,396,903 -> 4,146,310 initial JS bytes (-250,593; -5.7%)
- web /team: 939,138 -> 688,523 initial JS bytes (-250,615; -26.7%)
- Smashers /login: 1,274,951 -> 1,029,076 initial JS bytes (-245,875; -19.3%)
- the ~584 KB Sentry SDK is emitted as a deferred chunk and is absent from initial route chunk lists

## Validation
- frozen Bun install
- Prettier format check
- app and shared UI tests
- route contract tests
- type checks and lint for all three apps plus shared package
- production builds for app, web, and Smashers