### PR TITLE
perf(app): remove wallet code from public routes

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -45,7 +45,9 @@ import { isAuditFixtureEnabled } from '@/audit/fixture'
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
 })
-const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: false })
+const DegenCard = dynamic(() => import('@/components/cards/DegenCard/DashboardDegenCard'), {
+  ssr: false,
+})
 
 const DashboardDegensPage = (): React.ReactNode => {
   const { authToken, isLoggedIn } = useAuth()

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -23,7 +23,10 @@ import type { Degen } from '@/types/degens'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
 
 const DegenCard = dynamic(
-  () => import('@/components/cards/DegenCard').then((module) => module.DegenCardInView),
+  () =>
+    import('@/components/cards/DegenCard/DashboardDegenCard').then(
+      (module) => module.DashboardDegenCardInView
+    ),
   {
     ssr: false,
   }

--- a/apps/app/src/app/(public-routes)/degens/page.tsx
+++ b/apps/app/src/app/(public-routes)/degens/page.tsx
@@ -22,25 +22,18 @@ import {
   applySeventhTribesFix,
 } from '@/components/extended/DegensFilter/utils'
 import SectionTitle from '@/components/sections/SectionTitle'
-import { DEGEN_BASE_API_URL } from '@/constants/url'
+import { DEGEN_BASE_API_URL } from '@/constants/api'
 import useFetch from '@/hooks/useFetch'
 import usePagination from '@/hooks/usePagination'
 import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
 import DegensTopNav from '@/components/extended/DegensTopNav'
+import PublicDegenDialog from '@/components/dialog/PublicDegenDialog'
 
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
 })
 const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: false })
-const WalletDegenDialog = dynamic(() => import('@/components/providers/WalletDegenDialog'), {
-  ssr: false,
-  loading: () => (
-    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
-      Loading degen details
-    </div>
-  ),
-})
 
 const AllDegensPage = (): React.ReactNode => {
   const [degens, setDegens] = useState<Degen[]>([])
@@ -52,7 +45,6 @@ const AllDegensPage = (): React.ReactNode => {
   const [filteredData, setFilteredData] = useState<Degen[]>([])
   const [selectedDegen, setSelectedDegen] = useState<Degen>()
   const [isDegenModalOpen, setIsDegenModalOpen] = useState<boolean>(false)
-  const [isRentDialog, setIsRentDialog] = useState<boolean>(false)
   const searchParams = useSearchParams()
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined)
   const [layoutMode, setLayoutMode] = useState<string>('gridView')
@@ -134,7 +126,6 @@ const AllDegensPage = (): React.ReactNode => {
 
   const handleViewTraits = useCallback((degen: Degen): void => {
     setSelectedDegen(degen)
-    setIsRentDialog(false)
     setIsDegenModalOpen(true)
   }, [])
 
@@ -279,13 +270,7 @@ const AllDegensPage = (): React.ReactNode => {
         />
       </div>
       {isDegenModalOpen && (
-        <WalletDegenDialog
-          open
-          degen={selectedDegen}
-          isRent={isRentDialog}
-          setIsRent={setIsRentDialog}
-          onClose={() => setIsDegenModalOpen(false)}
-        />
+        <PublicDegenDialog open degen={selectedDegen} onClose={() => setIsDegenModalOpen(false)} />
       )}
     </>
   )

--- a/apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx
+++ b/apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx
@@ -1,12 +1,45 @@
 'use client'
 
-import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
-const DeferredWeb3GameList = dynamic(() => import('./_Web3GameList/DeferredWeb3GameList'), {
-  ssr: false,
-  loading: () => <div className="col-span-12 min-h-24" aria-busy="true" />,
-})
+type Web3GameListComponent = typeof import('./_Web3GameList/DeferredWeb3GameList').default
+
+const LoadingWeb3GameList = ({ error = false }: { error?: boolean }) => (
+  <div className="col-span-12 min-h-24" role="status" aria-busy={!error} aria-live="polite">
+    <span className="sr-only">
+      {error ? 'Web3 games could not be loaded' : 'Loading Web3 games'}
+    </span>
+  </div>
+)
 
 export default function Web3GameList() {
-  return <DeferredWeb3GameList />
+  const listRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(listRef, '200px')
+  const [GameList, setGameList] = useState<Web3GameListComponent | null>(null)
+  const [hasError, setHasError] = useState(false)
+
+  useEffect(() => {
+    if (!isNearViewport || GameList) return
+
+    let active = true
+
+    void import('./_Web3GameList/DeferredWeb3GameList')
+      .then(({ default: LoadedGameList }) => {
+        if (active) setGameList(() => LoadedGameList)
+      })
+      .catch(() => {
+        if (active) setHasError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [GameList, isNearViewport])
+
+  return (
+    <div ref={listRef} className={GameList ? 'contents' : 'col-span-12 min-h-24'}>
+      {GameList ? <GameList /> : <LoadingWeb3GameList error={hasError} />}
+    </div>
+  )
 }

--- a/apps/app/src/app/(public-routes)/games/_Web3GameList/DeferredWeb3GameList.tsx
+++ b/apps/app/src/app/(public-routes)/games/_Web3GameList/DeferredWeb3GameList.tsx
@@ -1,12 +1,7 @@
 'use client'
 
-import WalletFeatureProviders from '@/contexts/WalletFeatureProviders'
 import Web3GameList from './index'
 
 export default function DeferredWeb3GameList() {
-  return (
-    <WalletFeatureProviders>
-      <Web3GameList />
-    </WalletFeatureProviders>
-  )
+  return <Web3GameList />
 }

--- a/apps/app/src/app/(public-routes)/games/_Web3GameList/index.tsx
+++ b/apps/app/src/app/(public-routes)/games/_Web3GameList/index.tsx
@@ -1,45 +1,13 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { Button } from '@nl/ui/base/button'
-import BuyArcadeTokensDialog from '@/components/dialog/BuyArcadeTokensDialog'
-import ConnectWrapper from '@/components/wrapper/ConnectWrapper'
 import GameCard from '@/components/cards/GameCard'
 import DownloadGameDialog from '@/components/dialog/DownloadGameDialog'
-import useTokensBalances from '@/hooks/balances/useTokensBalances'
 
 import styles from './grid-item.module.css'
 
 const Web3GameList = () => {
-  const router = useRouter()
-  const { tokensBalances, refetchArcadeBal } = useTokensBalances()
-  const [openBuyAT, setOpenBuyAT] = useState(false)
-
-  const goToPlayOnGame = useCallback(() => {
-    router.push('/games/smashers')
-  }, [router])
-
-  const goToPlayWENGame = useCallback(() => {
-    if (Number(tokensBalances.AT) > 0) {
-      router.push('/games/wen-game')
-    } else {
-      setOpenBuyAT(true)
-    }
-  }, [tokensBalances.AT, router])
-
-  const goToPlayMtGawx = useCallback(() => {
-    router.push('/games/mt-gawx')
-  }, [router])
-
-  const goToPlayCryptoWinter = useCallback(() => {
-    if (Number(tokensBalances.AT) > 0) {
-      router.push('/games/crypto-winter')
-    } else {
-      setOpenBuyAT(true)
-    }
-  }, [tokensBalances.AT, router])
-
   return (
     <>
       <div className={`${styles.gridItem} col-span-12 md:col-span-6 xl:col-span-4`}>
@@ -54,15 +22,9 @@ const Web3GameList = () => {
           actions={
             <>
               <DownloadGameDialog />
-              <ConnectWrapper color="primary" fullWidth buttonText="Connect Wallet to play">
-                <Button
-                  variant="outline"
-                  className="w-full min-w-20 flex-1"
-                  onClick={goToPlayOnGame}
-                >
-                  Play in Browser
-                </Button>
-              </ConnectWrapper>
+              <Button asChild variant="outline" className="w-full min-w-20 flex-1">
+                <Link href="/games/smashers">Play in Browser</Link>
+              </Button>
             </>
           }
         />
@@ -75,15 +37,9 @@ const Web3GameList = () => {
           image="/img/games/wen.gif"
           autoHeight={false}
           actions={
-            <ConnectWrapper color="primary" fullWidth buttonText="Connect Wallet to play">
-              <Button
-                variant="outline"
-                className="w-full min-w-20 flex-1"
-                onClick={goToPlayWENGame}
-              >
-                {Number(tokensBalances.AT) > 0 ? 'Play in Browser' : 'Buy Arcade Tokens'}
-              </Button>
-            </ConnectWrapper>
+            <Button asChild variant="outline" className="w-full min-w-20 flex-1">
+              <Link href="/games/wen-game">Play in Browser</Link>
+            </Button>
           }
         />
       </div>
@@ -95,15 +51,9 @@ const Web3GameList = () => {
           image="/img/games/crypto-winter.gif"
           autoHeight={false}
           actions={
-            <ConnectWrapper color="primary" fullWidth buttonText="Connect Wallet to play">
-              <Button
-                variant="outline"
-                className="w-full min-w-20 flex-1"
-                onClick={goToPlayCryptoWinter}
-              >
-                {Number(tokensBalances.AT) > 0 ? 'Play in Browser' : 'Buy Arcade Tokens'}
-              </Button>
-            </ConnectWrapper>
+            <Button asChild variant="outline" className="w-full min-w-20 flex-1">
+              <Link href="/games/crypto-winter">Play in Browser</Link>
+            </Button>
           }
         />
       </div>
@@ -111,21 +61,14 @@ const Web3GameList = () => {
         <GameCard
           title="Mt. Gawx"
           required="NFTL required"
-          description={`Hearing the DEGENs' desperate pleas to spend their hard-earned NFTL and with bigger sinks still under his development, Satoshi suggests the DEGENs climb to the top of the Mt. Gawx volcano to offer their NFTL sacrifices to the fiery depths to see who might burn the most, and to discover whether the rumors of Rugman offering interesting rewards to burners are true.\n\nStrange thing is, every time they lob in NFTL, it's almost as if the volcano's… responding.\n\nCould the fabled 7th tribe be waking up from their centuries-long slumber, deep in the caves where Rugman resides?`}
+          description={`Hearing the DEGENs' desperate pleas to spend their hard-earned NFTL and with bigger sinks still under his development, Satoshi suggests the DEGENs climb to the top of the Mt. Gawx volcano to offer their NFTL sacrifices to the fiery depths to see who might burn the most, and to discover whether the rumors of Rugman offering interesting rewards for burners are true.\n\nStrange thing is, every time they lob in NFTL, it's almost as if the volcano's… responding.\n\nCould the fabled 7th tribe be waking up from their centuries-long slumber, deep in the caves where Rugman resides?`}
           showMore={true}
           image="/img/games/mt-gawx.gif"
           autoHeight={true}
           actions={
-            <ConnectWrapper color="primary" fullWidth buttonText="Connect Wallet to play">
-              <Button
-                disabled
-                variant="outline"
-                className="w-full min-w-20 flex-1"
-                onClick={goToPlayMtGawx}
-              >
-                Mountain Closed
-              </Button>
-            </ConnectWrapper>
+            <Button disabled variant="outline" className="w-full min-w-20 flex-1">
+              Mountain Closed
+            </Button>
           }
         />
       </div>
@@ -140,27 +83,12 @@ const Web3GameList = () => {
           image="/img/games/nifty-tennis.webp"
           autoHeight={true}
           actions={
-            <>
-              <Button
-                disabled
-                variant="outline"
-                className="w-full min-w-20 flex-1"
-                onClick={goToPlayMtGawx}
-              >
-                Not Available
-              </Button>
-            </>
+            <Button disabled variant="outline" className="w-full min-w-20 flex-1">
+              Not Available
+            </Button>
           }
         />
       </div>
-      <BuyArcadeTokensDialog
-        open={openBuyAT}
-        onSuccess={() => {
-          setOpenBuyAT(false)
-          refetchArcadeBal()
-        }}
-        onClose={() => setOpenBuyAT(false)}
-      />
     </>
   )
 }

--- a/apps/app/src/audit/fixture.ts
+++ b/apps/app/src/audit/fixture.ts
@@ -12,7 +12,7 @@ import {
   GET_GAMER_PROFILE_API,
   MY_PROFILE_API_URL,
   PROFILE_FAV_DEGENS_API,
-} from '@/constants/url'
+} from '@/constants/api'
 
 export const isAuditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
 

--- a/apps/app/src/components/cards/DegenCard/DashboardDegenCard.tsx
+++ b/apps/app/src/components/cards/DegenCard/DashboardDegenCard.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import DegenCard, { DegenCardInView, type DegenCardProps } from './index'
+
+const DegenDashboardActions = dynamic(() => import('./DegenDashboardActions'), { ssr: false })
+
+function withDashboardActions(props: DegenCardProps) {
+  const { degen, favs = [], size = 'normal', onClickFavorite } = props
+
+  return {
+    ...props,
+    dashboardActions: (
+      <DegenDashboardActions
+        tokenId={degen.id}
+        fav={favs.includes(degen.id)}
+        size={size}
+        onClickFavorite={onClickFavorite}
+      />
+    ),
+  }
+}
+
+export function DashboardDegenCard(props: DegenCardProps) {
+  return <DegenCard {...withDashboardActions(props)} />
+}
+
+export function DashboardDegenCardInView(props: DegenCardProps) {
+  return <DegenCardInView {...withDashboardActions(props)} />
+}
+
+export default DashboardDegenCard

--- a/apps/app/src/components/cards/DegenCard/index.tsx
+++ b/apps/app/src/components/cards/DegenCard/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { memo, useRef } from 'react'
-import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 import { Button } from '@nl/ui/base/button'
@@ -12,9 +11,7 @@ import type { SxProps, Theme } from '@/types'
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
 import DegenImage from './DegenImage'
 import type { Degen } from '@/types/degens'
-import { DEGEN_PURCHASE_URL } from '@/constants/url'
-
-const DegenDashboardActions = dynamic(() => import('./DegenDashboardActions'), { ssr: false })
+import { DEGEN_PURCHASE_URL } from '@/constants/public-urls'
 
 export interface DegenCardProps {
   degen: Degen
@@ -33,12 +30,12 @@ export interface DegenCardProps {
   onClickRent?: React.MouseEventHandler<HTMLButtonElement>
   onClickSelect?: React.MouseEventHandler<HTMLButtonElement>
   sx?: SxProps<Theme>
+  dashboardActions?: React.ReactNode
 }
 
 const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenCardProps>>> = memo(
   ({
     degen,
-    favs = [],
     isDashboardDegen = false,
     isSelectableDegen = false,
     isSelected = false,
@@ -48,11 +45,10 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
     onClickClaim,
     onClickDetail,
     onClickEditName,
-    onClickFavorite,
     onClickSelect,
+    dashboardActions,
   }) => {
     const { id, name } = degen
-    const fav = favs.some((f) => f === id)
 
     const buttonFontSize = size === 'small' ? '12px' : 'var(--text-sm)'
 
@@ -124,14 +120,7 @@ const DegenCard: React.FC<React.PropsWithChildren<React.PropsWithChildren<DegenC
             </Button>
           )}
         </div>
-        {isDashboardDegen && (
-          <DegenDashboardActions
-            tokenId={id}
-            fav={fav}
-            size={size}
-            onClickFavorite={onClickFavorite}
-          />
-        )}
+        {dashboardActions}
       </Card>
     )
   }

--- a/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
@@ -8,7 +8,7 @@ import { Title } from '@nl/ui/custom/typography'
 import DegenImage from '@/components/cards/DegenCard/DegenImage'
 import { TRAIT_KEY_VALUE_MAP, TRAIT_NAME_MAP } from '@/constants/cosmeticsFilters'
 import type { Degen, GetDegenResponse } from '@/types/degens'
-import { DEGEN_PURCHASE_URL } from '@/constants/url'
+import { DEGEN_PURCHASE_URL } from '@/constants/public-urls'
 import type { SxProps } from '@/types'
 
 export interface ViewTraitsContentDialogProps {

--- a/apps/app/src/components/dialog/PublicDegenDialog.test.tsx
+++ b/apps/app/src/components/dialog/PublicDegenDialog.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { Degen } from '@/types/degens'
+
+let PublicDegenDialog: typeof import('./PublicDegenDialog').default
+
+beforeEach(async () => {
+  mock.module('@/components/cards/DegenCard/DegenImage', () => ({
+    default: ({ tokenId }: { tokenId: string }) => <div data-testid="degen-image">{tokenId}</div>,
+  }))
+  PublicDegenDialog = (await import('./PublicDegenDialog')).default
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('PublicDegenDialog', () => {
+  it('renders accessible public details without wallet providers', () => {
+    const onClose = mock(() => {})
+    const degen = {
+      id: '101',
+      name: 'Audit Ape',
+      traits_string: 'blue, cap',
+    } as Degen
+
+    render(<PublicDegenDialog open degen={degen} onClose={onClose} />)
+
+    expect(screen.getByRole('dialog', { name: 'Audit Ape' })).not.toBeNull()
+    expect(screen.getByText('blue')).not.toBeNull()
+    expect(screen.getByText('cap')).not.toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close degen details' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/app/src/components/dialog/PublicDegenDialog.tsx
+++ b/apps/app/src/components/dialog/PublicDegenDialog.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Button } from '@nl/ui/base/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@nl/ui/base/dialog'
+import DegenImage from '@/components/cards/DegenCard/DegenImage'
+import { DEGEN_PURCHASE_URL } from '@/constants/public-urls'
+import type { Degen } from '@/types/degens'
+
+interface PublicDegenDialogProps {
+  open: boolean
+  degen?: Degen
+  onClose: () => void
+}
+
+export default function PublicDegenDialog({ open, degen, onClose }: PublicDegenDialogProps) {
+  const traits = useMemo(
+    () =>
+      degen?.traits_string
+        ?.split(',')
+        .map((trait) => trait.trim())
+        .filter(Boolean) ?? [],
+    [degen?.traits_string]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-w-[900px]">
+        <div className="grid grid-cols-12 gap-6">
+          <div className="col-span-12 flex flex-col items-center gap-4 md:col-span-6">
+            {degen?.id && <DegenImage tokenId={degen.id} sx={{ maxWidth: '500px' }} />}
+            <DialogHeader className="items-center">
+              <DialogTitle>{degen?.name || 'No Name DEGEN'}</DialogTitle>
+              <DialogDescription>Degen #{degen?.id}</DialogDescription>
+              {degen?.id && (
+                <a
+                  href={DEGEN_PURCHASE_URL(degen.id)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-sm text-muted-foreground underline underline-offset-4"
+                >
+                  View on OpenSea
+                </a>
+              )}
+              {degen?.owner && (
+                <p className="text-sm text-muted-foreground">
+                  Owned by {`${degen.owner.slice(0, 5)}...${degen.owner.slice(-4)}`}
+                </p>
+              )}
+            </DialogHeader>
+          </div>
+          <div className="col-span-12 flex flex-col gap-6 md:col-span-6">
+            <div>
+              <h2 className="text-xl font-semibold">Degen Traits</h2>
+              {traits.length ? (
+                <ul className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3">
+                  {traits.map((trait) => (
+                    <li key={trait} className="rounded-md border px-3 py-2 text-center text-sm">
+                      {trait}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-6 text-sm text-muted-foreground">Trait data unavailable.</p>
+              )}
+            </div>
+            <Button className="w-full" onClick={onClose} autoFocus aria-label="Close degen details">
+              Close
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/app/src/constants/api.ts
+++ b/apps/app/src/constants/api.ts
@@ -1,0 +1,7 @@
+export const BASE_API_URL = 'https://odgwhiwhzb.execute-api.us-east-1.amazonaws.com/prod'
+
+export const DEGEN_BASE_API_URL = 'https://nifty-league.s3.amazonaws.com'
+
+export const MY_PROFILE_API_URL = `${BASE_API_URL}/stats/profile`
+export const PROFILE_FAV_DEGENS_API = `${BASE_API_URL}/profiles/favorites`
+export const GET_GAMER_PROFILE_API = `${BASE_API_URL}/profiles/profile?include_stats=true`

--- a/apps/app/src/constants/public-urls.ts
+++ b/apps/app/src/constants/public-urls.ts
@@ -1,0 +1,4 @@
+const DEGEN_MAINNET_CONTRACT_ADDRESS = '0x986aea67C7d6A15036e18678065eb663Fc5BE883'
+
+export const DEGEN_PURCHASE_URL = (id: string | number) =>
+  `https://opensea.io/item/ethereum/${DEGEN_MAINNET_CONTRACT_ADDRESS}/${id}`

--- a/apps/app/src/constants/url.ts
+++ b/apps/app/src/constants/url.ts
@@ -1,17 +1,28 @@
-import { mainnet, immutableZkEvm } from 'viem/chains'
-import { getContractAddress, DEGEN_CONTRACT, NFTL_IMX_CONTRACT } from './contracts'
+import { immutableZkEvm } from 'viem/chains'
+import { getContractAddress, NFTL_IMX_CONTRACT } from './contracts'
+import {
+  BASE_API_URL,
+  DEGEN_BASE_API_URL,
+  GET_GAMER_PROFILE_API,
+  MY_PROFILE_API_URL,
+  PROFILE_FAV_DEGENS_API,
+} from './api'
+export {
+  BASE_API_URL,
+  DEGEN_BASE_API_URL,
+  GET_GAMER_PROFILE_API,
+  MY_PROFILE_API_URL,
+  PROFILE_FAV_DEGENS_API,
+} from './api'
+export { DEGEN_PURCHASE_URL } from './public-urls'
 
 const NEXT_PUBLIC_NETWORK = process.env.NEXT_PUBLIC_NETWORK as string
-
-export const BASE_API_URL = 'https://odgwhiwhzb.execute-api.us-east-1.amazonaws.com/prod'
 
 // Authentication
 export const WALLET_VERIFICATION = `${BASE_API_URL}/verification`
 export const ADDRESS_VERIFICATION = `${BASE_API_URL}/verification/address`
 
 // Degen API url
-export const DEGEN_BASE_API_URL = 'https://nifty-league.s3.amazonaws.com'
-
 // Rentals API url
 export const DISABLE_RENT_API_URL = `${BASE_API_URL}/rentals/rentable/`
 export const DEGEN_ASSETS_DOWNLOAD_URL = `${BASE_API_URL}/assets/degen`
@@ -31,11 +42,7 @@ export const GET_DEGEN_DETAIL_URL = (degenId: string): string =>
 export const GAMER_ACCOUNT_API = `${BASE_API_URL}/accounts/account`
 
 // Gamer Profile API
-export const MY_PROFILE_API_URL = `${BASE_API_URL}/stats/profile`
-export const PROFILE_FAV_DEGENS_API = `${BASE_API_URL}/profiles/favorites`
-
 const GAMER_PROFILE_BASE = 'profiles/profile'
-export const GET_GAMER_PROFILE_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}?include_stats=true`
 export const PROFILE_RENAME_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/rename`
 export const GET_PROFILE_AVATARS_AND_COST_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/avatars`
 export const UPDATE_PROFILE_AVATAR_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/avatar`
@@ -60,9 +67,6 @@ export const NFTL_PURCHASE_URL = `https://quickswap.exchange/#/analytics/v3/toke
 
 // DEGEN URLs
 export const DEGEN_COLLECTION_URL = 'https://opensea.io/collection/niftydegen'
-export const DEGEN_PURCHASE_URL = (id: string | number) =>
-  `https://opensea.io/item/ethereum/${getContractAddress(mainnet.id, DEGEN_CONTRACT)}/${id}`
-
 // Marketplace URLs
 export const COMICS_PURCHASE_URL = 'https://tokentrove.com/collection/NiftyLeague'
 export const ITEM_PURCHASE_URL = 'https://tokentrove.com/collection/NiftyLeague'

--- a/apps/app/src/hooks/useVersion.ts
+++ b/apps/app/src/hooks/useVersion.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useUserAgent } from '@nl/ui/hooks/useUserAgent'
-import { DEGEN_BASE_API_URL } from '@/constants/url'
+import { DEGEN_BASE_API_URL } from '@/constants/api'
 import { TARGET_NETWORK } from '@/constants/networks'
 
 const useVersion = () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -224,6 +224,65 @@ describe('deferred Sentry client contract', () => {
   })
 })
 
+describe('public route dependency contract', () => {
+  it('keeps API-only constants separate from the contract registry', () => {
+    const source = readFileSync(join(process.cwd(), 'apps/app/src/constants/api.ts'), 'utf8')
+
+    expect(source).not.toContain('constants/contracts')
+    expect(source).not.toContain('deployments')
+  })
+
+  it('keeps the public degen dialog wallet-free', () => {
+    const page = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(public-routes)/degens/page.tsx'),
+      'utf8'
+    )
+    const dialog = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/dialog/PublicDegenDialog.tsx'),
+      'utf8'
+    )
+
+    expect(page).toContain('PublicDegenDialog')
+    expect(page).not.toContain('WalletDegenDialog')
+    expect(dialog).toContain("from '@nl/ui/base/dialog'")
+    expect(dialog).not.toContain('WalletFeatureProviders')
+    expect(dialog).not.toContain('useNetworkContext')
+  })
+
+  it('keeps wallet-backed game providers out of public game cards', () => {
+    const loader = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx'),
+      'utf8'
+    )
+    const list = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(public-routes)/games/_Web3GameList/index.tsx'),
+      'utf8'
+    )
+
+    expect(loader).toContain('useOnScreen')
+    expect(loader).toContain("import('./_Web3GameList/DeferredWeb3GameList')")
+    expect(list).toContain('asChild')
+    expect(list).not.toContain('WalletFeatureProviders')
+    expect(list).not.toContain('ConnectWrapper')
+    expect(list).not.toContain('useTokensBalances')
+  })
+
+  it('keeps dashboard-only card actions in a private wrapper', () => {
+    const card = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/cards/DegenCard/index.tsx'),
+      'utf8'
+    )
+    const dashboardCard = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/cards/DegenCard/DashboardDegenCard.tsx'),
+      'utf8'
+    )
+
+    expect(card).not.toContain("from './DegenDashboardActions'")
+    expect(card).toContain('dashboardActions?: React.ReactNode')
+    expect(dashboardCard).toContain("import('./DegenDashboardActions')")
+  })
+})
+
 function countRouteFiles(dir: string): number {
   let count = 0
   for (const entry of readdirSync(dir)) {


### PR DESCRIPTION
## Summary
- keep the public `/degens` details dialog and `/games` cards wallet-free
- load the Web3 game list near the viewport and route wallet actions to wallet-aware game pages
- split API-only constants and dashboard-only degen actions from public client boundaries
- add route dependency and accessibility regression coverage

## Performance evidence
- `/degens`: 1,145,724 -> 884,207 initial JS bytes (-261,517 / 22.8%)
- `/games`: 1,014,971 -> 723,794 initial JS bytes (-291,177 / 28.7%)
- the prior 293 KB contract chunk is absent from both route manifests and generated HTML

## Validation
- `bun run format:check`
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun --filter app test` (160 pass, 0 fail)
- route contract suite (72 pass, 0 fail)
- app, web, and smashers production builds