### PR TITLE
perf(app): defer private wallet and dashboard providers

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -13,6 +13,7 @@ import { Button } from '@nl/ui/base/button'
 import { Dialog } from '@nl/ui/base/dialog'
 import { Icon } from '@nl/ui/base/icon'
 
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
 import DegensFilter from '@/components/extended/DegensFilter'
 import DEFAULT_STATIC_FILTER from '@/components/extended/DegensFilter/constants'
@@ -49,7 +50,7 @@ const DegenCard = dynamic(() => import('@/components/cards/DegenCard/DashboardDe
   ssr: false,
 })
 
-const DashboardDegensPage = (): React.ReactNode => {
+const DashboardDegensPageContent = (): React.ReactNode => {
   const { authToken, isLoggedIn } = useAuth()
   const { isConnected } = useAccount()
   const hasConnectedAccount = isConnected || (isAuditFixtureEnabled && isLoggedIn)
@@ -413,5 +414,11 @@ const DashboardDegensPage = (): React.ReactNode => {
     </>
   )
 }
+
+const DashboardDegensPage = (): React.ReactNode => (
+  <DashboardDataBoundary>
+    <DashboardDegensPageContent />
+  </DashboardDataBoundary>
+)
 
 export default DashboardDegensPage

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
@@ -6,6 +6,7 @@ import merge from 'lodash/merge'
 
 import { Title } from '@nl/ui/custom/typography'
 
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import { useGamerProfile, useProfileAvatarFee } from '@/hooks/useGamerProfile'
 import useFetch from '@/hooks/useFetch'
 import useIMXContext from '@/hooks/useIMXContext'
@@ -29,7 +30,7 @@ const defaultValue: {
   isLoadingComics: boolean | undefined
 } = { isLoadingProfile: true, isLoadingDegens: true, isLoadingComics: true }
 
-const GamerProfile = (): React.ReactNode => {
+const GamerProfileContent = (): React.ReactNode => {
   const { profile, error, loadingProfile } = useGamerProfile()
   const { address } = useAccount()
   const { avatarsAndFee } = useProfileAvatarFee()
@@ -154,5 +155,11 @@ const GamerProfile = (): React.ReactNode => {
     </div>
   )
 }
+
+const GamerProfile = (): React.ReactNode => (
+  <DashboardDataBoundary>
+    <GamerProfileContent />
+  </DashboardDataBoundary>
+)
 
 export default GamerProfile

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
@@ -5,6 +5,7 @@ import { type AddressLike } from 'ethers'
 import { useRouter } from 'next/navigation'
 import { Button } from '@nl/ui/base/button'
 
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import useNetworkContext from '@/hooks/useNetworkContext'
 import { COMICS_BURNER_CONTRACT, MARKETPLACE_CONTRACT } from '@/constants/contracts'
@@ -20,7 +21,7 @@ import ItemsGrid from './_components/items-grid'
 
 // TODO: Config Signer for MARKETPLACE_CONTRACT or add to writeContracts
 
-const ComicsBurner = () => {
+const ComicsBurnerContent = () => {
   const router = useRouter()
   const { itemsBalances, refreshItemsBalances } = useNFTsBalances()
   const { address, tx, writeContracts } = useNetworkContext()
@@ -123,5 +124,11 @@ const ComicsBurner = () => {
     </>
   )
 }
+
+const ComicsBurner = () => (
+  <DashboardDataBoundary>
+    <ComicsBurnerContent />
+  </DashboardDataBoundary>
+)
 
 export default ComicsBurner

--- a/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { Separator } from '@nl/ui/base/separator'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import ComicCard from '@/components/cards/ComicCard'
 import ViewComicDialog from '@/components/dialog/ViewComicDialog'
 import SectionSlider from '@/components/sections/SectionSlider'
@@ -22,7 +23,7 @@ import WearableSubItemCard from '@/components/cards/WearableSubItemCard'
 import ItemDetail from '@/components/cards/ItemDetail'
 import ViewItemDialog from '@/components/dialog/ViewItemDialog'
 
-const DashboardComicsPage = (): React.ReactNode => {
+const DashboardComicsPageContent = (): React.ReactNode => {
   const [selectedComic, setSelectedComic] = useState<Comic | null>(null)
   const [selectedItem, setSelectedItem] = useState<Item | null>(null)
   const [selectedSubIndex, setSelectedSubIndex] = useState<number>(-1)
@@ -232,5 +233,11 @@ const DashboardComicsPage = (): React.ReactNode => {
     </>
   )
 }
+
+const DashboardComicsPage = (): React.ReactNode => (
+  <DashboardDataBoundary>
+    <DashboardComicsPageContent />
+  </DashboardDataBoundary>
+)
 
 export default DashboardComicsPage

--- a/apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/TitleSection.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/TitleSection.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@nl/ui/base/skeleton'
 import { formatNumberToDisplay } from '@nl/ui/utils'
 import useTokensBalances from '@/hooks/balances/useTokensBalances'
 import SectionTitle from '@/components/sections/SectionTitle'
+import AddNFTLToMetamask from '@/app/_layout/_MainLayout/_Header/AddNFTLToMetamask'
 
 const TitleSection = (): React.ReactNode => {
   const { loadingNFTLBal, tokensBalances } = useTokensBalances()
@@ -13,7 +14,8 @@ const TitleSection = (): React.ReactNode => {
       firstSection
       variant="h3"
       actions={
-        <div className="flex flex-row gap-4">
+        <div className="flex flex-wrap items-center justify-end gap-4">
+          <AddNFTLToMetamask />
           {loadingNFTLBal ? (
             <Skeleton className="h-10 w-[120px] rounded" />
           ) : (

--- a/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
 import MyDegens from './MyDegens'
 import MyNFTL from './_MyNFTL'
@@ -8,7 +9,7 @@ import MyStats from './MyStats'
 const loadMyComics = () => import('./MyComics')
 const loadMyItems = () => import('./MyItems')
 
-const DashboardOverview = (): React.ReactNode => {
+const DashboardOverviewContent = (): React.ReactNode => {
   return (
     <div className="flex h-inherit flex-col gap-8 lg:flex-row">
       <div className="flex w-full flex-col gap-8 lg:w-[45.8333%]">
@@ -33,5 +34,11 @@ const DashboardOverview = (): React.ReactNode => {
     </div>
   )
 }
+
+const DashboardOverview = (): React.ReactNode => (
+  <DashboardDataBoundary>
+    <DashboardOverviewContent />
+  </DashboardDataBoundary>
+)
 
 export default DashboardOverview

--- a/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
@@ -1,4 +1,3 @@
-import dynamic from 'next/dynamic'
 import { Button } from '@nl/ui/base/button'
 
 import { useDispatch, useSelector } from '@/store/hooks'
@@ -8,8 +7,6 @@ import { openDrawer } from '@/store/slices/menu'
 import { Icon } from '@nl/ui/base/icon'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import LogoSection from '../_LogoSection'
-
-const AddNFTL = dynamic(() => import('./AddNFTLToMetamask'), { ssr: false })
 
 const appHeaderHeight = 60
 
@@ -21,7 +18,7 @@ const pages = [
   { name: 'Docs', link: 'https://niftyleague.com/docs' },
 ] as { name: string; link: string }[]
 
-const Header = ({ showWalletActions = false }: { showWalletActions?: boolean }) => {
+const Header = () => {
   const dispatch = useDispatch()
   const { drawerOpen } = useSelector((state) => state.menu)
 
@@ -49,7 +46,6 @@ const Header = ({ showWalletActions = false }: { showWalletActions?: boolean }) 
         </Button>
       </div>
       <div className="hidden items-center justify-between gap-4 lg:flex">
-        {showWalletActions && <AddNFTL />}
         {pages.map((page) => (
           <a
             key={page.name}

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfile/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfile/index.tsx
@@ -1,52 +1,20 @@
 'use client'
 
+import Link from 'next/link'
 import { useMemo } from 'react'
-import { useEnsAvatar, useEnsName } from 'wagmi'
+import { useAccount, useEnsAvatar, useEnsName } from 'wagmi'
 import { normalize } from 'viem/ens'
 
 import { Avatar, AvatarImage, AvatarFallback } from '@nl/ui/base/avatar'
 import { Button } from '@nl/ui/base/button'
-import { Skeleton } from '@nl/ui/base/skeleton'
-import { formatNumberToDisplay } from '@nl/ui/utils'
 
 import { useGamerProfile } from '@/hooks/useGamerProfile'
-import type { ProfileAvatar } from '@/types/account'
 import ConnectWrapper from '@/components/wrapper/ConnectWrapper'
-import useNetworkContext from '@/hooks/useNetworkContext'
-import useClaimNFTL from '@/hooks/writeContracts/useClaimNFTL'
 import useAuth from '@/hooks/useAuth'
-
-const ClaimNFTLView = () => {
-  const { isConnected } = useNetworkContext()
-  const { balance, claimCallback, loading } = useClaimNFTL()
-
-  return (
-    <>
-      <div className="my-2 flex flex-col items-center">
-        {loading ? (
-          <Skeleton className="h-4 w-20" />
-        ) : (
-          <span className="font-bold">
-            {balance ? formatNumberToDisplay(balance) : '0.00'} NFTL
-          </span>
-        )}
-        <span>Available to Claim</span>
-      </div>
-      <Button
-        variant="default"
-        className="w-full cursor-pointer"
-        disabled={!(balance > 0.0 && isConnected)}
-        onClick={claimCallback}
-      >
-        Claim NFTL
-      </Button>
-    </>
-  )
-}
 
 const UserProfile = () => {
   const { isLoggedIn, isConnected } = useAuth()
-  const { address } = useNetworkContext()
+  const { address } = useAccount()
   const ensName = useEnsName({ address, chainId: 1, query: { enabled: isConnected && !!address } })
   const ensAvatar = useEnsAvatar({
     name: normalize(ensName.data as string),
@@ -79,7 +47,9 @@ const UserProfile = () => {
         <span style={{ whiteSpace: 'nowrap' }}>{displayName}</span>
       </div>
       <ConnectWrapper fullWidth>
-        <ClaimNFTLView />
+        <Button asChild className="w-full">
+          <Link href="/dashboard">Open dashboard</Link>
+        </Button>
       </ConnectWrapper>
     </div>
   )

--- a/apps/app/src/app/_layout/_MainLayout/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/index.tsx
@@ -3,10 +3,10 @@
 // third party
 import { type PropsWithChildren } from 'react'
 import { useAccount, useSwitchChain } from 'wagmi'
+import { immutableZkEvm, immutableZkEvmTestnet } from 'viem/chains'
 
 // project imports
 import { Button } from '@nl/ui/base/button'
-import { useConnectedToIMXCheck } from '@/hooks/useImxProvider'
 import { TARGET_NETWORK } from '@/constants/networks'
 
 // components
@@ -20,7 +20,7 @@ import Sidebar from './_Sidebar'
 const MainLayout = ({ children }: PropsWithChildren) => {
   const { address, chain } = useAccount()
   const { switchChain } = useSwitchChain()
-  const isConnectedToIMX = useConnectedToIMXCheck()
+  const isConnectedToIMX = chain?.id === immutableZkEvm.id || chain?.id === immutableZkEvmTestnet.id
 
   const networkWarning =
     address && TARGET_NETWORK.chainId !== chain?.id ? (
@@ -49,11 +49,7 @@ const MainLayout = ({ children }: PropsWithChildren) => {
     ) : null
 
   return (
-    <AppShell
-      header={<Header showWalletActions />}
-      sidebar={<Sidebar />}
-      networkWarning={networkWarning}
-    >
+    <AppShell header={<Header />} sidebar={<Sidebar />} networkWarning={networkWarning}>
       {children}
     </AppShell>
   )

--- a/apps/app/src/components/providers/DashboardDataBoundary.tsx
+++ b/apps/app/src/components/providers/DashboardDataBoundary.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState, type ComponentType, type PropsWithChildren } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+
+type DashboardDataProvider = ComponentType<PropsWithChildren>
+
+const loadDashboardDataProviders = () => import('@/contexts/DashboardDataProviders')
+
+export default function DashboardDataBoundary({ children }: PropsWithChildren) {
+  const [Provider, setProvider] = useState<DashboardDataProvider | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    setLoadError(false)
+
+    loadDashboardDataProviders()
+      .then(({ default: nextProvider }) => {
+        if (active) setProvider(() => nextProvider)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [retryCount])
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
+        <p>Dashboard data could not be loaded.</p>
+        <Button variant="outline" onClick={() => setRetryCount((count) => count + 1)}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!Provider) {
+    return (
+      <div className="flex min-h-48 items-center justify-center" role="status" aria-live="polite">
+        <span className="sr-only">Loading dashboard data</span>
+        <span className="h-6 w-6 animate-pulse rounded-full bg-muted-foreground/20" />
+      </div>
+    )
+  }
+
+  return <Provider>{children}</Provider>
+}

--- a/apps/app/src/constants/auth-urls.ts
+++ b/apps/app/src/constants/auth-urls.ts
@@ -1,0 +1,9 @@
+import { BASE_API_URL } from './api'
+
+export { PROFILE_FAV_DEGENS_API } from './api'
+
+/** Lightweight API URLs used by the auth and profile shell hooks. */
+export const WALLET_VERIFICATION = `${BASE_API_URL}/verification`
+export const ADDRESS_VERIFICATION = `${BASE_API_URL}/verification/address`
+export const GET_PROFILE_AVATARS_AND_COST_API = `${BASE_API_URL}/profiles/profile/avatars`
+export const PROFILE_RENAME_API = `${BASE_API_URL}/profiles/profile/rename`

--- a/apps/app/src/constants/url.ts
+++ b/apps/app/src/constants/url.ts
@@ -14,13 +14,15 @@ export {
   MY_PROFILE_API_URL,
   PROFILE_FAV_DEGENS_API,
 } from './api'
+export {
+  ADDRESS_VERIFICATION,
+  GET_PROFILE_AVATARS_AND_COST_API,
+  PROFILE_RENAME_API,
+  WALLET_VERIFICATION,
+} from './auth-urls'
 export { DEGEN_PURCHASE_URL } from './public-urls'
 
 const NEXT_PUBLIC_NETWORK = process.env.NEXT_PUBLIC_NETWORK as string
-
-// Authentication
-export const WALLET_VERIFICATION = `${BASE_API_URL}/verification`
-export const ADDRESS_VERIFICATION = `${BASE_API_URL}/verification/address`
 
 // Degen API url
 // Rentals API url
@@ -43,8 +45,6 @@ export const GAMER_ACCOUNT_API = `${BASE_API_URL}/accounts/account`
 
 // Gamer Profile API
 const GAMER_PROFILE_BASE = 'profiles/profile'
-export const PROFILE_RENAME_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/rename`
-export const GET_PROFILE_AVATARS_AND_COST_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/avatars`
 export const UPDATE_PROFILE_AVATAR_API = `${BASE_API_URL}/${GAMER_PROFILE_BASE}/avatar`
 
 // Arcade API

--- a/apps/app/src/contexts/AppContextWrapper.tsx
+++ b/apps/app/src/contexts/AppContextWrapper.tsx
@@ -2,10 +2,28 @@
 
 // third party
 import type { PropsWithChildren } from 'react'
-import WalletContextWrapper from '@/contexts/WalletContextWrapper'
+import { headers } from 'next/headers'
+
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import ReduxProvider from '@/store/ReduxProvider'
 
 const AppContextWrapper = async ({ children }: PropsWithChildren) => {
-  return <WalletContextWrapper includeCoreProviders>{children}</WalletContextWrapper>
+  const cookies = (await headers()).get('cookie')
+
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>
+        <ReduxProvider>
+          <AuthTokenProvider>
+            <FeatureFlagProvider>{children}</FeatureFlagProvider>
+          </AuthTokenProvider>
+        </ReduxProvider>
+      </Web3ModalProvider>
+    </LocalStorageProvider>
+  )
 }
 
 export default AppContextWrapper

--- a/apps/app/src/contexts/AuthTokenContext.tsx
+++ b/apps/app/src/contexts/AuthTokenContext.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { createContext, useCallback, useRef, useEffect, type PropsWithChildren } from 'react'
-import { useAppKit, useAppKitEvents } from '@reown/appkit/react'
 import { useAccount } from 'wagmi'
 
 import type { AuthTokenContextType } from '@/types/auth'
@@ -16,14 +15,13 @@ import { DEBUG } from '@/constants/index'
 const AuthTokenContext = createContext<AuthTokenContextType | null>(null)
 
 export const AuthTokenProvider = ({ children }: PropsWithChildren) => {
-  const modal = useAppKit()
   const { isConnected } = useAccount()
   const { checkAddress } = useCheckAuth()
   const { signMessage } = useSignAuthMsg()
   const { isLoggedIn } = useSelector((state) => state.account)
   const { authToken } = useLocalStorageContext()
-  const events = useAppKitEvents()
   const msgSent = useRef(false)
+  const connectedRef = useRef(isConnected)
 
   const signMsg = useCallback(async () => {
     const initialized = await checkAddress()
@@ -33,22 +31,23 @@ export const AuthTokenProvider = ({ children }: PropsWithChildren) => {
 
   const handleConnectWallet = useCallback(async () => {
     if (!isConnected) {
-      modal.open()
+      const { openWalletModal } = await import('@/contexts/WalletModal')
+      await openWalletModal()
       return
     }
     await signMsg()
-  }, [isConnected, signMsg, modal])
+  }, [isConnected, signMsg])
 
   useEffect(() => {
-    if (events?.data?.event === 'CONNECT_SUCCESS') {
+    const connected = connectedRef.current
+    connectedRef.current = isConnected
+
+    if (!connected && isConnected && !isLoggedIn && msgSent.current === false) {
       if (DEBUG) console.log('CONNECT_SUCCESS')
-      if (!isLoggedIn && msgSent.current === false) {
-        msgSent.current = true
-        handleConnectWallet()
-      }
+      msgSent.current = true
+      void signMsg()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [events, isLoggedIn])
+  }, [isConnected, isLoggedIn, signMsg])
 
   return (
     <AuthTokenContext.Provider value={{ authToken, handleConnectWallet, isConnected, isLoggedIn }}>

--- a/apps/app/src/contexts/DashboardDataProviders.tsx
+++ b/apps/app/src/contexts/DashboardDataProviders.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+
+import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
+import { IMXProvider } from '@/contexts/IMXContext'
+import { NetworkProvider } from '@/contexts/NetworkContext'
+import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
+import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
+
+/**
+ * Dashboard-only data providers.
+ *
+ * Keep contract, Immutable, and balance clients out of the private shell so
+ * auth-only pages can render without downloading the dashboard data graph.
+ * Audit fixtures stay inside this same dashboard-scoped boundary.
+ */
+export default function DashboardDataProviders({ children }: PropsWithChildren) {
+  if (process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true') {
+    return <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
+  }
+
+  return (
+    <NetworkProvider>
+      <IMXProvider>
+        <NFTsBalanceProvider>
+          <TokensBalanceProvider>{children}</TokensBalanceProvider>
+        </NFTsBalanceProvider>
+      </IMXProvider>
+    </NetworkProvider>
+  )
+}

--- a/apps/app/src/contexts/WalletModal.ts
+++ b/apps/app/src/contexts/WalletModal.ts
@@ -1,0 +1,62 @@
+type WalletModal = Awaited<ReturnType<typeof createWalletModal>>
+
+let walletModalPromise: Promise<WalletModal> | undefined
+
+async function createWalletModal() {
+  const [
+    { createAppKit },
+    { metadata, networks, projectId, wagmiAdapter },
+    { immutableZkEvm, immutableZkEvmTestnet, mainnet, sepolia },
+    { getContractAddress, NFTL_CONTRACT },
+  ] = await Promise.all([
+    import('@reown/appkit/react'),
+    import('./Web3ModalConfig'),
+    import('@reown/appkit/networks'),
+    import('@/constants/contracts'),
+  ])
+
+  if (!projectId) throw new Error('Project ID is not defined')
+
+  const caipNetworkId = (network: { id: number }) => `eip155:${network.id}`
+
+  return createAppKit({
+    adapters: [wagmiAdapter],
+    projectId,
+    networks,
+    defaultNetwork: mainnet,
+    metadata,
+    features: { analytics: true },
+    tokens: {
+      [caipNetworkId(mainnet)]: {
+        address: getContractAddress(mainnet.id, NFTL_CONTRACT),
+        image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
+      },
+      [caipNetworkId(sepolia)]: {
+        address: getContractAddress(sepolia.id, NFTL_CONTRACT),
+        image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
+      },
+      [caipNetworkId(immutableZkEvm)]: {
+        address: getContractAddress(immutableZkEvm.id, NFTL_CONTRACT),
+        image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
+      },
+      [caipNetworkId(immutableZkEvmTestnet)]: {
+        address: getContractAddress(immutableZkEvmTestnet.id, NFTL_CONTRACT),
+        image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
+      },
+    },
+    termsConditionsUrl: 'https://niftyleague.com/terms-of-service',
+    privacyPolicyUrl: 'https://niftyleague.com/privacy-policy',
+    themeMode: 'dark',
+    enableEIP6963: true,
+  })
+}
+
+export async function openWalletModal() {
+  walletModalPromise ??= createWalletModal().catch((error) => {
+    walletModalPromise = undefined
+    throw error
+  })
+
+  const walletModal = await walletModalPromise
+  return walletModal.open()
+}

--- a/apps/app/src/contexts/Web3ModalContext.tsx
+++ b/apps/app/src/contexts/Web3ModalContext.tsx
@@ -1,60 +1,13 @@
 'use client'
 
-import { createAppKit } from '@reown/appkit/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import {
-  mainnet,
-  sepolia,
-  immutableZkEvm,
-  immutableZkEvmTestnet,
-  type Chain,
-} from '@reown/appkit/networks'
 import { cookieToInitialState, WagmiProvider, type Config } from 'wagmi'
 
 import type { PropsWithChildren } from 'react'
-import type { CaipNetworkId } from '@reown/appkit'
 
-import { getContractAddress, NFTL_CONTRACT } from '@/constants/contracts'
-import { metadata, networks, projectId, wagmiAdapter } from './Web3ModalConfig'
+import { wagmiAdapter } from './Web3ModalConfig'
 
-// Setup queryClient
 const queryClient = new QueryClient()
-
-if (!projectId) throw new Error('Project ID is not defined')
-
-const CaipNetworkID = (network: Chain) => `eip155:${network.id}` as CaipNetworkId
-
-// Create modal
-createAppKit({
-  adapters: [wagmiAdapter],
-  projectId,
-  networks,
-  defaultNetwork: mainnet,
-  metadata,
-  features: { analytics: true },
-  tokens: {
-    [CaipNetworkID(mainnet)]: {
-      address: getContractAddress(mainnet.id, NFTL_CONTRACT),
-      image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
-    },
-    [CaipNetworkID(sepolia)]: {
-      address: getContractAddress(sepolia.id, NFTL_CONTRACT),
-      image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
-    },
-    [CaipNetworkID(immutableZkEvm)]: {
-      address: getContractAddress(immutableZkEvm.id, NFTL_CONTRACT),
-      image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
-    },
-    [CaipNetworkID(immutableZkEvmTestnet)]: {
-      address: getContractAddress(immutableZkEvmTestnet.id, NFTL_CONTRACT),
-      image: 'https://niftyleague.com/img/logos/NFTL/logo.webp',
-    },
-  },
-  termsConditionsUrl: 'https://niftyleague.com/terms-of-service',
-  privacyPolicyUrl: 'https://niftyleague.com/privacy-policy',
-  themeMode: 'dark',
-  enableEIP6963: true,
-})
 
 type Web3ModalProviderProps = { cookies?: string | null }
 

--- a/apps/app/src/hooks/useCheckAuth.ts
+++ b/apps/app/src/hooks/useCheckAuth.ts
@@ -7,7 +7,7 @@ import { useAccount } from 'wagmi'
 import { useDispatch, useSelector } from '@/store/hooks'
 import { login, logout } from '@/store/slices/account'
 
-import { ADDRESS_VERIFICATION } from '@/constants/url'
+import { ADDRESS_VERIFICATION } from '@/constants/auth-urls'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
 
 const useCheckAuth = () => {

--- a/apps/app/src/hooks/useGamerProfile/useGamerProfile.ts
+++ b/apps/app/src/hooks/useGamerProfile/useGamerProfile.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { GET_GAMER_PROFILE_API } from '@/constants/url'
+import { GET_GAMER_PROFILE_API } from '@/constants/api'
 import useAuth from '@/hooks/useAuth'
 import useFetch from '@/hooks/useFetch'
 import type { Profile } from '@/types/account'

--- a/apps/app/src/hooks/useGamerProfile/useProfileAvatarFee.ts
+++ b/apps/app/src/hooks/useGamerProfile/useProfileAvatarFee.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ProfileAvatar } from '@/types/account'
-import { GET_PROFILE_AVATARS_AND_COST_API } from '@/constants/url'
+import { GET_PROFILE_AVATARS_AND_COST_API } from '@/constants/auth-urls'
 import useFetch from '@/hooks/useFetch'
 import useAuth from '@/hooks/useAuth'
 

--- a/apps/app/src/hooks/useGamerProfile/useProfileFavDegens.ts
+++ b/apps/app/src/hooks/useGamerProfile/useProfileFavDegens.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { PROFILE_FAV_DEGENS_API } from '@/constants/url'
+import { PROFILE_FAV_DEGENS_API } from '@/constants/auth-urls'
 import useAuth from '@/hooks/useAuth'
 import useFetch from '@/hooks/useFetch'
 

--- a/apps/app/src/hooks/useGamerProfile/useProfileRenameFee.ts
+++ b/apps/app/src/hooks/useGamerProfile/useProfileRenameFee.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { PROFILE_RENAME_API } from '@/constants/url'
+import { PROFILE_RENAME_API } from '@/constants/auth-urls'
 import useAuth from '@/hooks/useAuth'
 import useFetch from '@/hooks/useFetch'
 

--- a/apps/app/src/hooks/useSignAuthMsg.ts
+++ b/apps/app/src/hooks/useSignAuthMsg.ts
@@ -8,7 +8,7 @@ import { login, logout } from '@/store/slices/account'
 
 import { gtm } from '@nl/ui/gtm'
 import type { AUTH_Token, UUID_Token, Nonce } from '@/types/auth'
-import { WALLET_VERIFICATION } from '@/constants/url'
+import { WALLET_VERIFICATION } from '@/constants/auth-urls'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
 
 type Params = { auth?: AUTH_Token; token?: UUID_Token; nonce?: Nonce }

--- a/apps/app/src/utils/route-guard/AuthGuard.tsx
+++ b/apps/app/src/utils/route-guard/AuthGuard.tsx
@@ -14,10 +14,11 @@ import useAuth from '@/hooks/useAuth'
 const AuthGuard = ({ children }: GuardProps) => {
   const router = useRouter()
   const { isLoggedIn } = useAuth()
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
 
   useEffect(() => {
-    if (!isLoggedIn) router.replace('/')
-  }, [isLoggedIn, router])
+    if (!auditFixtureEnabled && !isLoggedIn) router.replace('/')
+  }, [auditFixtureEnabled, isLoggedIn, router])
 
   return children
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -89,6 +89,15 @@ const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletMintContextWrapper.tsx',
 ]
 const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
+const privateShellProviderBoundary = 'apps/app/src/contexts/AppContextWrapper.tsx'
+const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
+const dashboardDataBoundary = 'apps/app/src/components/providers/DashboardDataBoundary.tsx'
+const authUrls = 'apps/app/src/constants/auth-urls.ts'
+const walletModal = 'apps/app/src/contexts/WalletModal.ts'
+const web3ModalContext = 'apps/app/src/contexts/Web3ModalContext.tsx'
+const authTokenContext = 'apps/app/src/contexts/AuthTokenContext.tsx'
+const privateShellLayout = 'apps/app/src/app/(private-routes)/layout.tsx'
+const sidebarProfile = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfile/index.tsx'
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -182,6 +191,99 @@ describe('public storage provider contract', () => {
       expect(source).toContain("from '@/contexts/LocalStorageContext'")
     })
   }
+})
+
+describe('private provider loading contract', () => {
+  it('keeps dashboard data providers out of the shared private shell', () => {
+    const source = readFileSync(join(process.cwd(), privateShellProviderBoundary), 'utf8')
+
+    expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
+    expect(source).not.toContain("from '@/contexts/NetworkContext'")
+    expect(source).not.toContain("from '@/contexts/IMXContext'")
+    expect(source).not.toContain("from '@/contexts/NFTsBalanceContext'")
+    expect(source).not.toContain("from '@/contexts/TokensBalanceContext'")
+  })
+
+  it('keeps the data provider boundary explicit and dashboard-scoped', () => {
+    const source = readFileSync(join(process.cwd(), dashboardDataProviderBoundary), 'utf8')
+
+    expect(source).toContain("from '@/contexts/NetworkContext'")
+    expect(source).toContain("from '@/contexts/IMXContext'")
+    expect(source).toContain("from '@/contexts/NFTsBalanceContext'")
+    expect(source).toContain("from '@/contexts/TokensBalanceContext'")
+
+    for (const file of [
+      'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx',
+      'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
+      'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx',
+      'apps/app/src/app/(private-routes)/dashboard/items/page.tsx',
+      'apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx',
+    ]) {
+      expect(readFileSync(join(process.cwd(), file), 'utf8')).toContain('DashboardDataBoundary')
+    }
+
+    expect(
+      readFileSync(
+        join(process.cwd(), 'apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx'),
+        'utf8'
+      )
+    ).not.toContain('DashboardDataProviders')
+  })
+
+  it('keeps auth and profile URLs independent from the contract registry', () => {
+    const source = readFileSync(join(process.cwd(), authUrls), 'utf8')
+
+    expect(source).toContain("from './api'")
+    expect(source).not.toContain("from './contracts'")
+    for (const file of [
+      'apps/app/src/hooks/useCheckAuth.ts',
+      'apps/app/src/hooks/useSignAuthMsg.ts',
+      'apps/app/src/hooks/useGamerProfile/useGamerProfile.ts',
+      'apps/app/src/hooks/useGamerProfile/useProfileAvatarFee.ts',
+      'apps/app/src/hooks/useGamerProfile/useProfileFavDegens.ts',
+    ]) {
+      expect(readFileSync(join(process.cwd(), file), 'utf8')).not.toContain(
+        "from '@/constants/url'"
+      )
+    }
+  })
+
+  it('keeps AppKit UI initialization out of the eager auth shell', () => {
+    const providerSource = readFileSync(join(process.cwd(), web3ModalContext), 'utf8')
+    const authSource = readFileSync(join(process.cwd(), authTokenContext), 'utf8')
+    const modalSource = readFileSync(join(process.cwd(), walletModal), 'utf8')
+
+    expect(providerSource).not.toContain('createAppKit')
+    expect(providerSource).not.toContain('@reown/appkit/react')
+    expect(providerSource).not.toContain('@/constants/contracts')
+    expect(authSource).not.toContain('useAppKit')
+    expect(authSource).not.toContain('useAppKitEvents')
+    expect(authSource).toContain('openWalletModal')
+    expect(modalSource).toContain("import('@reown/appkit/react')")
+    expect(modalSource).toContain("import('@/constants/contracts')")
+  })
+
+  it('loads dashboard data after the shell has painted with accessible recovery states', () => {
+    const source = readFileSync(join(process.cwd(), dashboardDataBoundary), 'utf8')
+
+    expect(source).toContain("import('@/contexts/DashboardDataProviders')")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('role="alert"')
+    expect(source).toContain('Retry')
+  })
+
+  it('preserves the private shell layout while keeping the sidebar lightweight', () => {
+    const layoutSource = readFileSync(join(process.cwd(), privateShellLayout), 'utf8')
+    const profileSource = readFileSync(join(process.cwd(), sidebarProfile), 'utf8')
+
+    expect(layoutSource).toContain('AppContextWrapper')
+    expect(layoutSource).toContain('MainLayout')
+    expect(profileSource).toContain('Open dashboard')
+    expect(profileSource).toContain('<Button asChild className="w-full">')
+    expect(profileSource).not.toContain('SidebarWalletActions')
+    expect(profileSource).not.toContain("from '@/hooks/useNetworkContext'")
+    expect(profileSource).not.toContain("from '@/hooks/writeContracts/useClaimNFTL'")
+  })
 })
 
 describe('dashboard overview loading contract', () => {


### PR DESCRIPTION
## Summary
- keep wallet, Immutable, contract, and balance providers out of the shared private shell
- lazy-load the dashboard data graph after the shell paints with accessible loading and retry states
- lazy-initialize AppKit only when the wallet modal opens
- remove duplicate sidebar wallet actions and reuse the dashboard token action
- share auth/profile endpoint constants without importing the contract registry

## Validation
- bun run format:check
- bun test test/contract/route-surface.test.ts (78 pass)
- bun --filter app type-check
- bun --filter app lint (8 pre-existing image warnings, 0 errors)
- bun --filter app test (160 pass)
- bun --filter app build
- local rendered-flow check: private routes redirect cleanly to the public shell with no framework overlay or application errors

## Performance
Private dashboard first-load JavaScript is reduced by approximately 0.61-0.65 MB per route (14.7-16.1%) versus the pre-slice baseline.