### PR TITLE
perf(smashers): defer PlayFab auth form

### DIFF
--- a/apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx
+++ b/apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx
@@ -1,11 +1,27 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
 import type { User } from '@nl/playfab/types'
-import PlayFabAuthForm from '@nl/playfab/components/PlayFabAuthForm'
+import { Skeleton } from '@nl/ui/base/skeleton'
 import BackButton from '@/components/Header/BackButton'
 import useFlags from '@/hooks/useFlags'
 import SearchParamsHandler from './SearchParamsHandler'
+
+const PlayFabAuthForm = dynamic(() => import('@nl/playfab/components/PlayFabAuthForm'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-screen w-full items-center justify-center px-4"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Skeleton className="h-[30rem] w-full max-w-[600px]" />
+      <span className="sr-only">Loading sign-in form</span>
+    </div>
+  ),
+})
 
 interface SessionData {
   user: User | null

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -104,6 +104,7 @@ const networkProvider = 'apps/app/src/contexts/NetworkProvider.tsx'
 const graphQL = 'apps/app/src/hooks/useGraphQL.ts'
 const publicCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const interactivePublicCarousel = 'apps/web/src/components/Carousel/InteractiveCarousel.tsx'
+const smashersLoginClient = 'apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx'
 const privateShellLayout = 'apps/app/src/app/(private-routes)/layout.tsx'
 const sidebarProfile = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfile/index.tsx'
 
@@ -368,6 +369,17 @@ describe('deferred Sentry client contract', () => {
 })
 
 describe('public route dependency contract', () => {
+  it('defers the Smashers PlayFab auth form behind an accessible loading boundary', () => {
+    const source = readFileSync(join(process.cwd(), smashersLoginClient), 'utf8')
+
+    expect(source).toContain("dynamic(() => import('@nl/playfab/components/PlayFabAuthForm')")
+    expect(source).toContain('ssr: false')
+    expect(source).toContain("from '@nl/ui/base/skeleton'")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('aria-live="polite"')
+    expect(source).not.toContain("from '@nl/playfab/components/PlayFabAuthForm'")
+  })
+
   it('defers the public carousel library until its cards approach the viewport', () => {
     const shell = readFileSync(join(process.cwd(), publicCarousel), 'utf8')
     const interactive = readFileSync(join(process.cwd(), interactivePublicCarousel), 'utf8')


### PR DESCRIPTION
## Summary
- defer the PlayFab authentication form until the Smashers login route needs it
- show a themed, accessible shadcn Skeleton while the form loads
- add a route contract preventing the auth form from becoming an eager dependency again

## Impact
The Smashers `/login` first-load bundle drops from 1,029,076 bytes to 669,128 bytes (35.0%, 359,948 bytes) while preserving the rendered login form and theme.

## Validation
- `bun --filter smashers type-check`
- `bun --filter smashers test` (15 pass)
- `bun --filter smashers lint`
- `bun --filter smashers build`
- `bun test test/contract/route-surface.test.ts` (83 pass)
- `bun run format:check`
- local browser QA: login form rendered with accessible labels and no console errors