### PR TITLE
[codex] perf(app): defer private route shell

### DIFF
--- a/apps/app/src/app/(private-routes)/layout.tsx
+++ b/apps/app/src/app/(private-routes)/layout.tsx
@@ -1,12 +1,10 @@
 import type { PropsWithChildren } from 'react'
+import { headers } from 'next/headers'
 
-import AppContextWrapper from '@/contexts/AppContextWrapper'
-import MainLayout from '@/app/_layout/_MainLayout'
+import PrivateRoutesBoundary from '@/components/providers/PrivateRoutesBoundary'
 
-export default function PrivateRoutesLayout({ children }: PropsWithChildren) {
-  return (
-    <AppContextWrapper>
-      <MainLayout>{children}</MainLayout>
-    </AppContextWrapper>
-  )
+export default async function PrivateRoutesLayout({ children }: PropsWithChildren) {
+  const cookies = (await headers()).get('cookie')
+
+  return <PrivateRoutesBoundary cookies={cookies}>{children}</PrivateRoutesBoundary>
 }

--- a/apps/app/src/components/providers/PrivateRoutesBoundary.tsx
+++ b/apps/app/src/components/providers/PrivateRoutesBoundary.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { PropsWithChildren } from 'react'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+interface PrivateRoutesBoundaryProps extends PropsWithChildren {
+  cookies?: string | null
+}
+
+function PrivateRoutesLoading(): React.ReactNode {
+  return (
+    <div
+      className="flex min-h-screen flex-col gap-6 bg-background p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Skeleton className="h-14 w-full rounded-lg" />
+      <div className="flex min-h-0 flex-1 gap-6">
+        <Skeleton className="hidden w-64 rounded-lg lg:block" />
+        <Skeleton className="min-h-[24rem] flex-1 rounded-lg" />
+      </div>
+      <span className="sr-only">Loading private app</span>
+    </div>
+  )
+}
+
+const PrivateRoutesShell = dynamic(() => import('./PrivateRoutesShell'), {
+  ssr: false,
+  loading: PrivateRoutesLoading,
+})
+
+export default function PrivateRoutesBoundary({ children, cookies }: PrivateRoutesBoundaryProps) {
+  return <PrivateRoutesShell cookies={cookies}>{children}</PrivateRoutesShell>
+}

--- a/apps/app/src/components/providers/PrivateRoutesShell.tsx
+++ b/apps/app/src/components/providers/PrivateRoutesShell.tsx
@@ -1,29 +1,30 @@
-'use server'
+'use client'
 
-// third party
 import type { PropsWithChildren } from 'react'
-import { headers } from 'next/headers'
 
+import MainLayout from '@/app/_layout/_MainLayout'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
 import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 import ReduxProvider from '@/store/ReduxProvider'
 
-const AppContextWrapper = async ({ children }: PropsWithChildren) => {
-  const cookies = (await headers()).get('cookie')
+interface PrivateRoutesShellProps extends PropsWithChildren {
+  cookies?: string | null
+}
 
+export default function PrivateRoutesShell({ children, cookies }: PrivateRoutesShellProps) {
   return (
     <LocalStorageProvider>
       <Web3ModalProvider cookies={cookies}>
         <ReduxProvider>
           <AuthTokenProvider>
-            <FeatureFlagProvider>{children}</FeatureFlagProvider>
+            <FeatureFlagProvider>
+              <MainLayout>{children}</MainLayout>
+            </FeatureFlagProvider>
           </AuthTokenProvider>
         </ReduxProvider>
       </Web3ModalProvider>
     </LocalStorageProvider>
   )
 }
-
-export default AppContextWrapper

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -89,7 +89,8 @@ const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletMintContextWrapper.tsx',
 ]
 const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
-const privateShellProviderBoundary = 'apps/app/src/contexts/AppContextWrapper.tsx'
+const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
+const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
 const dashboardDataBoundary = 'apps/app/src/components/providers/DashboardDataBoundary.tsx'
 const authUrls = 'apps/app/src/constants/auth-urls.ts'
@@ -242,7 +243,7 @@ describe('private provider loading contract', () => {
   })
 
   it('keeps dashboard data providers out of the shared private shell', () => {
-    const source = readFileSync(join(process.cwd(), privateShellProviderBoundary), 'utf8')
+    const source = readFileSync(join(process.cwd(), privateShell), 'utf8')
 
     expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
     expect(source).not.toContain("from '@/contexts/NetworkContext'")
@@ -327,10 +328,19 @@ describe('private provider loading contract', () => {
 
   it('preserves the private shell layout while keeping the sidebar lightweight', () => {
     const layoutSource = readFileSync(join(process.cwd(), privateShellLayout), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), privateShellBoundary), 'utf8')
+    const shellSource = readFileSync(join(process.cwd(), privateShell), 'utf8')
     const profileSource = readFileSync(join(process.cwd(), sidebarProfile), 'utf8')
 
-    expect(layoutSource).toContain('AppContextWrapper')
-    expect(layoutSource).toContain('MainLayout')
+    expect(layoutSource).toContain('PrivateRoutesBoundary')
+    expect(layoutSource).toContain('headers()')
+    expect(boundarySource).toContain("import('./PrivateRoutesShell')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<Skeleton')
+    expect(boundarySource).toContain('role="status"')
+    expect(shellSource).toContain('MainLayout')
+    expect(shellSource).toContain('Web3ModalProvider')
+    expect(shellSource).toContain('AuthTokenProvider')
     expect(profileSource).toContain('Open dashboard')
     expect(profileSource).toContain('<Button asChild className="w-full">')
     expect(profileSource).not.toContain('SidebarWalletActions')


### PR DESCRIPTION
## Summary
- defer the private route shell until client hydration behind an accessible shadcn loading state
- preserve cookie-based Wagmi hydration and provider order
- remove the superseded AppContextWrapper and extend route-surface contracts

## Measured impact
- /dashboard: 2,550,841 -> 2,481,275 bytes of HTML-referenced JavaScript (69,566 bytes, 2.7%)
- /dashboard/rentals: 2,399,097 -> 1,822,422 bytes (576,675 bytes, 24.0%)
- public route payloads were unchanged within build variance

## Validation
- bun test test/contract/route-surface.test.ts
- bun --filter app test
- bun --filter app type-check
- bun --filter app lint (8 existing image warnings)
- bun --filter app build
- bun run format:check
- git diff --check