### PR TITLE
perf(app): defer shared rename dialog

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -25,7 +25,6 @@ import {
   getGridSizeClass,
   applySeventhTribesFix,
 } from '@/components/extended/DegensFilter/utils'
-import RenameDegenDialogContent from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'
 import SectionTitle from '@/components/sections/SectionTitle'
 import { DEGEN_BASE_API_URL, DEGEN_COLLECTION_URL, PROFILE_FAV_DEGENS_API } from '@/constants/url'
 import { useProfileFavDegens } from '@/hooks/useGamerProfile'
@@ -38,6 +37,7 @@ import type { Degen } from '@/types/degens'
 import { v4 as uuidv4 } from 'uuid'
 import EmptyState from '@/components/EmptyState'
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
+import DeferredRenameDegenDialog from '@/components/providers/DeferredRenameDegenDialog'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import DegensTopNav from '@/components/extended/DegensTopNav'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
@@ -406,7 +406,7 @@ const DashboardDegensPageContent = (): React.ReactNode => {
         open={isRenameDegenModalOpen}
         onOpenChange={(open) => !open && setIsRenameDegenModalOpen(false)}
       >
-        <RenameDegenDialogContent
+        <DeferredRenameDegenDialog
           degen={selectedDegen}
           onSuccess={() => setIsRenameDegenModalOpen(false)}
         />

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -15,6 +15,7 @@ import { DEGEN_BASE_API_URL, DEGEN_COLLECTION_URL, PROFILE_FAV_DEGENS_API } from
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
 import EmptyState from '@/components/EmptyState'
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
+import DeferredRenameDegenDialog from '@/components/providers/DeferredRenameDegenDialog'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import useFetch from '@/hooks/useFetch'
 import { useProfileFavDegens } from '@/hooks/useGamerProfile'
@@ -29,18 +30,6 @@ const DegenCard = dynamic(
     ),
   {
     ssr: false,
-  }
-)
-
-const RenameDegenDialogContent = dynamic(
-  () => import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
-        Loading rename form
-      </div>
-    ),
   }
 )
 
@@ -192,7 +181,7 @@ const MyDegens = (): React.ReactNode => {
         onOpenChange={(open) => !open && setIsRenameDegenModalOpen(false)}
       >
         <DialogContent showCloseButton={false}>
-          <RenameDegenDialogContent
+          <DeferredRenameDegenDialog
             degen={selectedDegen}
             onSuccess={() => setIsRenameDegenModalOpen(false)}
           />

--- a/apps/app/src/components/providers/DeferredRenameDegenDialog.tsx
+++ b/apps/app/src/components/providers/DeferredRenameDegenDialog.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { Degen } from '@/types/degens'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+interface DeferredRenameDegenDialogProps {
+  degen?: Degen
+  onSuccess?: () => void
+}
+
+const DeferredRenameDegenDialog = dynamic<DeferredRenameDegenDialogProps>(
+  () => import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="flex min-h-24 items-center justify-center p-4"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <Skeleton className="h-10 w-full max-w-sm" />
+        <span className="sr-only">Loading rename form</span>
+      </div>
+    ),
+  }
+)
+
+export default DeferredRenameDegenDialog

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -79,6 +79,10 @@ const deferredDashboardDialogConsumers = [
   'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
   'apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx',
 ]
+const deferredRenameDegenConsumers = [
+  'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
+]
 
 const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
 const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx']
@@ -93,6 +97,7 @@ const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBou
 const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
 const dashboardDataBoundary = 'apps/app/src/components/providers/DashboardDataBoundary.tsx'
+const deferredRenameDegenDialog = 'apps/app/src/components/providers/DeferredRenameDegenDialog.tsx'
 const authUrls = 'apps/app/src/constants/auth-urls.ts'
 const walletModal = 'apps/app/src/contexts/WalletModal.ts'
 const web3ModalContext = 'apps/app/src/contexts/Web3ModalContext.tsx'
@@ -151,18 +156,27 @@ describe('dashboard dialog loading contract', () => {
   }
 
   it('defers the dashboard rename form until the dialog opens', () => {
-    const source = readFileSync(
-      join(process.cwd(), 'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx'),
-      'utf8'
-    )
+    const source = readFileSync(join(process.cwd(), deferredRenameDegenDialog), 'utf8')
 
     expect(source).toContain(
       "import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent')"
     )
-    expect(source).not.toContain(
-      "from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'"
-    )
+    expect(source).toContain("from '@nl/ui/base/skeleton'")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('aria-live="polite"')
+    expect(source).toContain('aria-busy="true"')
   })
+
+  for (const file of deferredRenameDegenConsumers) {
+    it(`keeps the rename form deferred in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('DeferredRenameDegenDialog')
+      expect(source).not.toContain(
+        "from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'"
+      )
+    })
+  }
 })
 
 describe('auth-only route provider contract', () => {


### PR DESCRIPTION
## Summary
- defer the rename form used by the degens dashboard and overview until the dialog opens
- share one accessible shadcn Skeleton loading boundary across both consumers
- add route-surface contracts preventing static reintroduction

## Measured impact
- `/dashboard/degens` direct HTML-referenced scripts: 2,384,471 -> 2,277,147 bytes (107,324 bytes / 4.5% smaller)
- scripts: 35 -> 32

## Validation
- `bun test test/contract/route-surface.test.ts`
- `bun --filter app test`
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun --filter app build`
- `bun run format:check`
- `git diff --check`

Lint retains 8 existing image warnings and no errors.