### PR TITLE
perf(app): defer gamer profile dialogs

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx
@@ -4,8 +4,8 @@ import { useMemo } from 'react'
 import { Skeleton } from '@nl/ui/base/skeleton'
 
 import DegenImage from '@/components/cards/DegenCard/DegenImage'
+import DeferredProfileImageDialog from '@/components/providers/DeferredProfileImageDialog'
 import { useGamerProfileContext } from '@/hooks/useGamerProfile'
-import ProfileImageDialog from './ProfileImageDialog'
 
 import type { Degen } from '@/types/degens'
 import type { ProfileAvatar } from '@/types/account'
@@ -46,7 +46,7 @@ const ImageProfile = ({ degens, avatar, avatarFee }: ImageProfileProps): React.R
       <div className="relative [&_img]:rounded-[var(--radius-default)]">
         {renderImage()}
         {degens && degens.length > 0 && (
-          <ProfileImageDialog
+          <DeferredProfileImageDialog
             onChangeAvatar={handleChangeAvatar}
             degens={degens}
             avatarFee={avatarFee}

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_Stats/TopInfo.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_Stats/TopInfo.tsx
@@ -10,7 +10,7 @@ import { useGamerProfileContext } from '@/hooks/useGamerProfile'
 import type { Profile } from '@/types/account'
 
 import ProgressGamer from './ProgressGamer'
-import ChangeProfileNameDialog from './ChangeProfileNameDialog'
+import DeferredProfileNameDialog from '@/components/providers/DeferredProfileNameDialog'
 import TopInfoSkeleton from './TopInfoSkeleton'
 
 interface TopInfoProps {
@@ -34,7 +34,7 @@ const TopInfo = ({ profile, walletAddress }: TopInfoProps): React.ReactNode => {
         <div className="flex flex-row items-center gap-10">
           <div className="w-1/2">
             <Title level={2}>
-              {profileName} <ChangeProfileNameDialog handleUpdateNewName={handleUpdateNewName} />
+              {profileName} <DeferredProfileNameDialog handleUpdateNewName={handleUpdateNewName} />
             </Title>
           </div>
           <div className="w-1/2">{total && <ProgressGamer data={total} />}</div>

--- a/apps/app/src/components/providers/DeferredDialogLoading.tsx
+++ b/apps/app/src/components/providers/DeferredDialogLoading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+interface DeferredDialogLoadingProps {
+  label: string
+}
+
+const DeferredDialogLoading = ({ label }: DeferredDialogLoadingProps): React.ReactNode => (
+  <div
+    className="flex min-h-24 items-center justify-center p-4"
+    role="status"
+    aria-live="polite"
+    aria-busy="true"
+  >
+    <Skeleton className="h-10 w-full max-w-sm" />
+    <span className="sr-only">{label}</span>
+  </div>
+)
+
+export default DeferredDialogLoading

--- a/apps/app/src/components/providers/DeferredProfileImageDialog.tsx
+++ b/apps/app/src/components/providers/DeferredProfileImageDialog.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import type { Degen } from '@/types/degens'
+import DeferredDialogLoading from './DeferredDialogLoading'
+
+interface DeferredProfileImageDialogProps {
+  degens: Degen[] | undefined
+  onChangeAvatar: (degenId: string) => void
+  avatarFee?: number
+}
+
+const DeferredProfileImageDialog = dynamic<DeferredProfileImageDialogProps>(
+  () => import('@/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/ProfileImageDialog'),
+  {
+    ssr: false,
+    loading: () => <DeferredDialogLoading label="Loading profile image picker" />,
+  }
+)
+
+export default DeferredProfileImageDialog

--- a/apps/app/src/components/providers/DeferredProfileNameDialog.tsx
+++ b/apps/app/src/components/providers/DeferredProfileNameDialog.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import DeferredDialogLoading from './DeferredDialogLoading'
+
+interface DeferredProfileNameDialogProps {
+  handleUpdateNewName: (newName: string) => void
+}
+
+const DeferredProfileNameDialog = dynamic<DeferredProfileNameDialogProps>(
+  () => import('@/app/(private-routes)/dashboard/gamer-profile/_Stats/ChangeProfileNameDialog'),
+  {
+    ssr: false,
+    loading: () => <DeferredDialogLoading label="Loading profile name form" />,
+  }
+)
+
+export default DeferredProfileNameDialog

--- a/apps/app/src/components/providers/DeferredRenameDegenDialog.tsx
+++ b/apps/app/src/components/providers/DeferredRenameDegenDialog.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic'
 import type { Degen } from '@/types/degens'
 
-import { Skeleton } from '@nl/ui/base/skeleton'
+import DeferredDialogLoading from './DeferredDialogLoading'
 
 interface DeferredRenameDegenDialogProps {
   degen?: Degen
@@ -14,17 +14,7 @@ const DeferredRenameDegenDialog = dynamic<DeferredRenameDegenDialogProps>(
   () => import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'),
   {
     ssr: false,
-    loading: () => (
-      <div
-        className="flex min-h-24 items-center justify-center p-4"
-        role="status"
-        aria-live="polite"
-        aria-busy="true"
-      >
-        <Skeleton className="h-10 w-full max-w-sm" />
-        <span className="sr-only">Loading rename form</span>
-      </div>
-    ),
+    loading: () => <DeferredDialogLoading label="Loading rename form" />,
   }
 )
 

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -83,6 +83,10 @@ const deferredRenameDegenConsumers = [
   'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
   'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
 ]
+const deferredProfileDialogConsumers = [
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/_Stats/TopInfo.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx',
+]
 
 const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
 const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx']
@@ -98,6 +102,10 @@ const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
 const dashboardDataBoundary = 'apps/app/src/components/providers/DashboardDataBoundary.tsx'
 const deferredRenameDegenDialog = 'apps/app/src/components/providers/DeferredRenameDegenDialog.tsx'
+const deferredDialogLoading = 'apps/app/src/components/providers/DeferredDialogLoading.tsx'
+const deferredProfileNameDialog = 'apps/app/src/components/providers/DeferredProfileNameDialog.tsx'
+const deferredProfileImageDialog =
+  'apps/app/src/components/providers/DeferredProfileImageDialog.tsx'
 const authUrls = 'apps/app/src/constants/auth-urls.ts'
 const walletModal = 'apps/app/src/contexts/WalletModal.ts'
 const web3ModalContext = 'apps/app/src/contexts/Web3ModalContext.tsx'
@@ -161,10 +169,7 @@ describe('dashboard dialog loading contract', () => {
     expect(source).toContain(
       "import('@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent')"
     )
-    expect(source).toContain("from '@nl/ui/base/skeleton'")
-    expect(source).toContain('role="status"')
-    expect(source).toContain('aria-live="polite"')
-    expect(source).toContain('aria-busy="true"')
+    expect(source).toContain('DeferredDialogLoading')
   })
 
   for (const file of deferredRenameDegenConsumers) {
@@ -175,6 +180,40 @@ describe('dashboard dialog loading contract', () => {
       expect(source).not.toContain(
         "from '@/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent'"
       )
+    })
+  }
+
+  it('shares an accessible loading boundary across deferred dialog wrappers', () => {
+    const source = readFileSync(join(process.cwd(), deferredDialogLoading), 'utf8')
+
+    expect(source).toContain("from '@nl/ui/base/skeleton'")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('aria-live="polite"')
+    expect(source).toContain('aria-busy="true"')
+  })
+
+  const deferredProfileDialogs = [
+    [deferredProfileNameDialog, 'ChangeProfileNameDialog'],
+    [deferredProfileImageDialog, 'ProfileImageDialog'],
+  ] as const
+
+  for (const [file, component] of deferredProfileDialogs) {
+    it(`defers ${component} behind a shared loading boundary`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain(`import('@/app/(private-routes)/dashboard/gamer-profile/`)
+      expect(source).toContain(`DeferredDialogLoading`)
+      expect(source).toContain('ssr: false')
+    })
+  }
+
+  for (const file of deferredProfileDialogConsumers) {
+    it(`keeps profile dialogs deferred in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('DeferredProfile')
+      expect(source).not.toContain("from './ChangeProfileNameDialog'")
+      expect(source).not.toContain("from './ProfileImageDialog'")
     })
   }
 })


### PR DESCRIPTION
## Summary
- defer the gamer profile name form and avatar picker until their dialogs open
- share one accessible shadcn Skeleton loading boundary across deferred dialogs
- add route-surface contracts preventing static reintroduction

## Measured impact
- `/dashboard/gamer-profile` direct HTML-referenced scripts: 2,270,914 -> 2,118,278 bytes (152,636 bytes / 6.7% smaller)
- scripts: 33 -> 29

## Validation
- `bun test test/contract/route-surface.test.ts`
- `bun --filter app test`
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun --filter app build`
- `bun run format:check`
- `git diff --check`

Lint retains 8 existing image warnings and no errors.