### PR TITLE
perf(app): defer rental nickname dialog

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
@@ -15,8 +15,8 @@ import { Countdown } from '@nl/ui/base/countdown'
 import useLocalStorage from '@/hooks/useLocalStorage'
 
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
+import DeferredChangeNicknameDialog from '@/components/providers/DeferredChangeNicknameDialog'
 import { RentalDataGrid } from '@/types/rentalDataGrid'
-import ChangeNicknameDialog from './ChangeNicknameDialog'
 
 const RENTAL_COLUMN_VISIBILITY = 'rental-column-visibility-model'
 const PAGE_SIZE_OPTIONS = [10, 25, 100]
@@ -492,7 +492,7 @@ const MyRentalsDataGrid = ({
           showCloseButton={false}
           className="max-w-[380px] md:max-w-[380px] lg:max-w-[380px]"
         >
-          <ChangeNicknameDialog
+          <DeferredChangeNicknameDialog
             updateNickname={handleUpdateNickname}
             rental={selectedRowForEditing}
           />

--- a/apps/app/src/components/providers/DeferredChangeNicknameDialog.tsx
+++ b/apps/app/src/components/providers/DeferredChangeNicknameDialog.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import type { RentalDataGrid } from '@/types/rentalDataGrid'
+import DeferredDialogLoading from './DeferredDialogLoading'
+
+interface DeferredChangeNicknameDialogProps {
+  rental: RentalDataGrid
+  updateNickname: (name: string, id: string) => void
+}
+
+const DeferredChangeNicknameDialog = dynamic<DeferredChangeNicknameDialogProps>(
+  () => import('@/app/(private-routes)/dashboard/rentals/ChangeNicknameDialog'),
+  {
+    ssr: false,
+    loading: () => <DeferredDialogLoading label="Loading nickname form" />,
+  }
+)
+
+export default DeferredChangeNicknameDialog

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -87,6 +87,8 @@ const deferredProfileDialogConsumers = [
   'apps/app/src/app/(private-routes)/dashboard/gamer-profile/_Stats/TopInfo.tsx',
   'apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx',
 ]
+const deferredNicknameDialogConsumer =
+  'apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx'
 
 const authOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/verification/layout.tsx']
 const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx']
@@ -106,6 +108,7 @@ const deferredDialogLoading = 'apps/app/src/components/providers/DeferredDialogL
 const deferredProfileNameDialog = 'apps/app/src/components/providers/DeferredProfileNameDialog.tsx'
 const deferredProfileImageDialog =
   'apps/app/src/components/providers/DeferredProfileImageDialog.tsx'
+const deferredNicknameDialog = 'apps/app/src/components/providers/DeferredChangeNicknameDialog.tsx'
 const authUrls = 'apps/app/src/constants/auth-urls.ts'
 const walletModal = 'apps/app/src/contexts/WalletModal.ts'
 const web3ModalContext = 'apps/app/src/contexts/Web3ModalContext.tsx'
@@ -192,20 +195,28 @@ describe('dashboard dialog loading contract', () => {
     expect(source).toContain('aria-busy="true"')
   })
 
-  const deferredProfileDialogs = [
-    [deferredProfileNameDialog, 'ChangeProfileNameDialog'],
-    [deferredProfileImageDialog, 'ProfileImageDialog'],
+  const deferredDialogWrappers = [
+    [deferredProfileNameDialog, 'ChangeProfileNameDialog', 'dashboard/gamer-profile/'],
+    [deferredProfileImageDialog, 'ProfileImageDialog', 'dashboard/gamer-profile/'],
+    [deferredNicknameDialog, 'ChangeNicknameDialog', 'dashboard/rentals/'],
   ] as const
 
-  for (const [file, component] of deferredProfileDialogs) {
+  for (const [file, component, route] of deferredDialogWrappers) {
     it(`defers ${component} behind a shared loading boundary`, () => {
       const source = readFileSync(join(process.cwd(), file), 'utf8')
 
-      expect(source).toContain(`import('@/app/(private-routes)/dashboard/gamer-profile/`)
+      expect(source).toContain(`import('@/app/(private-routes)/${route}`)
       expect(source).toContain(`DeferredDialogLoading`)
       expect(source).toContain('ssr: false')
     })
   }
+
+  it('keeps the rental nickname form deferred until its dialog opens', () => {
+    const source = readFileSync(join(process.cwd(), deferredNicknameDialogConsumer), 'utf8')
+
+    expect(source).toContain('DeferredChangeNicknameDialog')
+    expect(source).not.toContain("from './ChangeNicknameDialog'")
+  })
 
   for (const file of deferredProfileDialogConsumers) {
     it(`keeps profile dialogs deferred in ${file}`, () => {


### PR DESCRIPTION
## Summary
- defer the rental nickname form until the nickname dialog opens
- reuse the shared accessible shadcn Skeleton loading boundary
- add route-surface contracts preventing static reintroduction

## Measured impact
- `/dashboard/rentals` direct HTML-referenced scripts: 1,822,569 -> 1,750,046 bytes (72,523 bytes / 4.0% smaller)
- scripts: 29 -> 26

## Validation
- `bun test test/contract/route-surface.test.ts`
- `bun --filter app test`
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun --filter app build`
- `bun run format:check`
- `git diff --check`

Lint retains 8 existing image warnings and no errors.