### PR TITLE
perf: defer console game client boundary

### DIFF
--- a/apps/smashers/src/app/page.tsx
+++ b/apps/smashers/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { ConsoleGame } from '@nl/ui/custom/console-game'
+import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { SocialsFooter } from '@nl/ui/custom/socials-footer'
 
 import HomeInteractive from '@/components/HomeInteractive'
@@ -12,7 +12,7 @@ export default async function Home({ searchParams }: { searchParams: NextSearchP
   return (
     <HomeInteractive hasReferral={Boolean(referral)}>
       <section id="console-game">
-        <ConsoleGame src="/video/smashers-960p.mp4" />
+        <DeferredConsoleGame src="/video/smashers-960p.mp4" />
       </section>
       <section id="game-section" className="container section relative">
         <div className="purple-bg-orb orb-top-left" />

--- a/apps/web/src/app/(main)/degens/page.tsx
+++ b/apps/web/src/app/(main)/degens/page.tsx
@@ -2,7 +2,7 @@ import type { NextPage } from 'next'
 import Image from 'next/image'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
-import { ConsoleGame } from '@nl/ui/custom/console-game'
+import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { DegenSpecialsTable } from '@nl/ui/custom/degen-specials-table'
 import { cn } from '@nl/ui/utils'
 
@@ -13,7 +13,7 @@ import styles from './index.module.css'
 const Degens: NextPage = () => (
   <>
     <section className="relative xl:-top-20 2xl:-top-35">
-      <ConsoleGame src="/video/unboxing.mp4" />
+      <DeferredConsoleGame src="/video/unboxing.mp4" />
     </section>
 
     <div className="container">

--- a/apps/web/src/app/(main)/niftyworld/page.tsx
+++ b/apps/web/src/app/(main)/niftyworld/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import type { NextPage } from 'next'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
-import { ConsoleGame } from '@nl/ui/custom/console-game'
+import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 
 import { NIFTYWORLD_PROPERTIES } from '@/constants/niftyworld'
@@ -12,7 +12,7 @@ const NiftyWorld: NextPage = () => {
   return (
     <>
       <section className="relative xl:-top-20 2xl:-top-35">
-        <ConsoleGame src="/video/mansion_showcase.mp4" />
+        <DeferredConsoleGame src="/video/mansion_showcase.mp4" />
 
         <ThemeBtnGroup
           className="absolute bottom-0 sm:bottom-4"

--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -18,7 +18,7 @@ describe('home page', () => {
     mock.module('@/components/MintOMatic', () => ({ default: () => null }))
     mock.module('@/components/Sponsors', () => ({ default: () => null }))
     mock.module('@/components/ThemeBtnGroup', () => ({ default: () => null }))
-    mock.module('@nl/ui/custom/console-game', () => ({ ConsoleGame: () => null }))
+    mock.module('@nl/ui/custom/deferred-console-game', () => ({ DeferredConsoleGame: () => null }))
     // The home page renders the interactive DEGEN carousel through a shared
     // wrapper; stub the heavy carousel library out for these markup-level
     // assertions (it is unchanged by this tranche).

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
-import { ConsoleGame } from '@nl/ui/custom/console-game'
+import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 
 import BouncingNFTL from '@/components/BouncingNFTL'
 import Carousel from '@/components/Carousel'
@@ -196,7 +196,7 @@ const Home = () => {
           </h2>
         </AnimatedWrapper>
 
-        <ConsoleGame src="/video/smashers.mp4" />
+        <DeferredConsoleGame src="/video/smashers.mp4" />
 
         <ThemeBtnGroup
           className="absolute bottom-0 sm:bottom-4"

--- a/packages/ui/src/components/custom/deferred-console-game/deferred-console-game.test.tsx
+++ b/packages/ui/src/components/custom/deferred-console-game/deferred-console-game.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+mock.module('@nl/ui/hooks/useOnScreen', () => ({
+  useOnScreen: () => false,
+}))
+
+describe('DeferredConsoleGame', () => {
+  let DeferredConsoleGame: typeof import('./index').DeferredConsoleGame
+
+  beforeEach(async () => {
+    DeferredConsoleGame = (await import('./index')).DeferredConsoleGame
+  })
+
+  it('keeps an accessible, layout-preserving loading state before the preview is near the viewport', () => {
+    const { container } = render(<DeferredConsoleGame src="/video/example.mp4" />)
+    const loadingState = screen.getByRole('img', { name: 'Loading game preview' })
+
+    expect(loadingState).toBeTruthy()
+    expect(container.firstElementChild?.className).toContain('aspect-video')
+  })
+})

--- a/packages/ui/src/components/custom/deferred-console-game/index.tsx
+++ b/packages/ui/src/components/custom/deferred-console-game/index.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { ComponentType } from 'react'
+import { Skeleton } from '@nl/ui/base/skeleton'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+interface DeferredConsoleGameProps {
+  src: string
+}
+
+type ConsoleGameComponent = ComponentType<DeferredConsoleGameProps>
+
+const DeferredConsoleGame = ({ src }: DeferredConsoleGameProps) => {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(rootRef, '200px')
+  const [ConsoleGame, setConsoleGame] = useState<ConsoleGameComponent | null>(null)
+
+  useEffect(() => {
+    if (!isNearViewport) return
+
+    let cancelled = false
+    void import('../console-game').then(({ ConsoleGame: LoadedConsoleGame }) => {
+      if (!cancelled) setConsoleGame(() => LoadedConsoleGame)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isNearViewport])
+
+  return (
+    <div ref={rootRef} className="relative aspect-video overflow-hidden">
+      {ConsoleGame ? (
+        <ConsoleGame src={src} />
+      ) : (
+        <Skeleton
+          role="img"
+          aria-label="Loading game preview"
+          className="absolute inset-0 h-full w-full rounded-none"
+        />
+      )}
+    </div>
+  )
+}
+
+export { DeferredConsoleGame }
+export default DeferredConsoleGame

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -133,6 +133,12 @@ const analyticsLayouts = [
   'apps/smashers/src/app/layout.tsx',
   'apps/app/src/app/layout.tsx',
 ]
+const deferredConsoleGameRoutes = [
+  'apps/web/src/app/(main)/page.tsx',
+  'apps/web/src/app/(main)/degens/page.tsx',
+  'apps/web/src/app/(main)/niftyworld/page.tsx',
+  'apps/smashers/src/app/page.tsx',
+]
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -453,6 +459,17 @@ describe('shared analytics loading contract', () => {
       expect(source).toContain('DeferredAnalytics')
       expect(source).not.toContain('import { GoogleTagManager')
       expect(source).not.toContain('import { WebVitals')
+    })
+  }
+})
+
+describe('shared console game loading contract', () => {
+  for (const file of deferredConsoleGameRoutes) {
+    it(`defers the console game client boundary in ${file}`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain('DeferredConsoleGame')
+      expect(source).not.toContain("from '@nl/ui/custom/console-game'")
     })
   }
 })


### PR DESCRIPTION
## What changed

- add shared `DeferredConsoleGame` with a 16:9 layout-preserving shadcn Skeleton fallback
- load the interactive console/video client boundary only when it is within 200px of the viewport
- use the shared wrapper on web home, Degens, NiftyWorld, and Smashers home routes
- add an accessible fallback test and route-surface loading contracts

## Why

The console video already avoided eager media playback, but its client interaction code still shipped on public routes before the section was near view. The shared boundary keeps the initial page stable while deferring the specialized video controls and animation code.

## Validation

- `bun --filter @nl/ui type-check`\n- `bun --filter @nl/ui test` — 136 passed\n- `bun --filter web test` — 13 passed\n- `bun --filter smashers test` — 15 passed\n- `bun test test/contract/route-surface.test.ts` — 103 passed\n- `bun --filter web build`\n- `bun --filter smashers build`\n- `bun --filter web lint`\n- `bun --filter smashers lint` — 0 errors, 1 existing warning\n- `bun run format:check`\n- production `next start` route measurement: web home is 5,910 bytes less HTML and 2,343 bytes less initial JS; Smashers home is 5,570 bytes less HTML and 4,917 bytes less initial JS