### PR TITLE
perf: defer mint route wallet graph

### DIFF
--- a/apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx
+++ b/apps/app/src/app/(public-routes)/mint-o-matic/layout.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
+import { headers } from 'next/headers'
 
-import WalletMintContextWrapper from '@/contexts/WalletMintContextWrapper'
+import DeferredMintProviders from '@/components/providers/DeferredMintProviders'
 
 export const metadata: Metadata = { title: 'Mint-o-Matic' }
 
-export default function Layout({ children }: PropsWithChildren) {
-  return <WalletMintContextWrapper>{children}</WalletMintContextWrapper>
+export default async function Layout({ children }: PropsWithChildren) {
+  const cookies = (await headers()).get('cookie')
+
+  return <DeferredMintProviders cookies={cookies}>{children}</DeferredMintProviders>
 }

--- a/apps/app/src/app/(public-routes)/mint-o-matic/page.tsx
+++ b/apps/app/src/app/(public-routes)/mint-o-matic/page.tsx
@@ -1,70 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import Link from 'next/link'
-import dynamic from 'next/dynamic'
-import { useSearchParams } from 'next/navigation'
-import { Button } from '@nl/ui/base/button'
-import { Title } from '@nl/ui/custom/typography'
+import DeferredMintPage from '@/components/providers/DeferredMintPage'
 
-import { ErrorBoundary } from '@nl/ui/custom/error-boundry'
-import { Preloader } from '@nl/ui/custom/preloader'
-import MintNetworkBoundary from '@/components/providers/MintNetworkBoundary'
-import useAuth from '@/hooks/useAuth'
-import { DEGEN_COLLECTION_URL } from '@/constants/url'
-import { useDegenOwnershipContext } from '@/contexts/DegenOwnershipContext'
-
-const CharacterCreator = dynamic(() => import('./_CharacterCreator'), { ssr: false })
-
-const MintPage = () => {
-  const [isLoaded, setLoaded] = useState(false)
-  const [progress, setProgress] = useState(0)
-  const { isDegenOwner } = useDegenOwnershipContext()
-  const { isConnected, isLoggedIn, handleConnectWallet } = useAuth()
-
-  const searchParams = useSearchParams()
-  const { nifty_artists: isForNiftyArtists } = Object.fromEntries(searchParams.entries())
-
-  if (!isForNiftyArtists) {
-    if (!isLoggedIn) {
-      return (
-        <div className="flex h-full w-full flex-col items-center justify-center">
-          <Title level={3} className="text-center">
-            Please connect your wallet
-          </Title>
-          <Button className="mt-4" onClick={handleConnectWallet}>
-            {isConnected ? 'Log In' : 'Connect Wallet'}
-          </Button>
-        </div>
-      )
-    }
-
-    if (!isDegenOwner) {
-      return (
-        <div className="flex h-full w-full flex-col items-center justify-center">
-          <Title level={3} className="text-center">
-            This page is accessible to DEGEN owners only.
-          </Title>
-          <Button asChild className="mt-4">
-            <Link href={DEGEN_COLLECTION_URL} target="_blank" rel="noreferrer">
-              Buy A DEGEN
-            </Link>
-          </Button>
-        </div>
-      )
-    }
-  }
-
-  return (
-    <div style={{ textAlign: 'center', overflowX: 'hidden' }}>
-      <ErrorBoundary>
-        <Preloader ready={isLoaded} progress={progress} />
-        <MintNetworkBoundary>
-          <CharacterCreator setLoaded={setLoaded} setProgress={setProgress} />
-        </MintNetworkBoundary>
-      </ErrorBoundary>
-    </div>
-  )
+export default function MintPage() {
+  return <DeferredMintPage />
 }
-
-export default MintPage

--- a/apps/app/src/components/providers/DeferredCharacterCreator.tsx
+++ b/apps/app/src/components/providers/DeferredCharacterCreator.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useState, type ComponentType } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+
+import MintNetworkBoundary from './MintNetworkBoundary'
+
+type CharacterCreatorProps = {
+  setLoaded: (loaded: boolean) => void
+  setProgress: (progress: number) => void
+}
+
+type CharacterCreatorComponent = ComponentType<CharacterCreatorProps>
+
+const loadCharacterCreator = () => import('@/app/(public-routes)/mint-o-matic/_CharacterCreator')
+
+interface DeferredCharacterCreatorProps extends CharacterCreatorProps {
+  enabled: boolean
+}
+
+export default function DeferredCharacterCreator({
+  enabled,
+  setLoaded,
+  setProgress,
+}: DeferredCharacterCreatorProps) {
+  const [CharacterCreator, setCharacterCreator] = useState<CharacterCreatorComponent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (!enabled || CharacterCreator) return
+
+    let active = true
+    setLoadError(false)
+
+    loadCharacterCreator()
+      .then(({ default: nextCharacterCreator }) => {
+        if (active) setCharacterCreator(() => nextCharacterCreator)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [enabled, CharacterCreator, retryCount])
+
+  if (!enabled) return null
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
+        <p>Character creator could not be loaded.</p>
+        <Button
+          type="button"
+          variant="link"
+          className="text-primary underline underline-offset-4"
+          onClick={() => {
+            setLoadError(false)
+            setRetryCount((count) => count + 1)
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!CharacterCreator) return null
+
+  return (
+    <MintNetworkBoundary>
+      <CharacterCreator setLoaded={setLoaded} setProgress={setProgress} />
+    </MintNetworkBoundary>
+  )
+}

--- a/apps/app/src/components/providers/DeferredMintPage.tsx
+++ b/apps/app/src/components/providers/DeferredMintPage.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState, type ComponentType } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+type MintPageContent = ComponentType
+
+const loadMintPageContent = () => import('./MintPageContent')
+
+export default function DeferredMintPage() {
+  const [PageContent, setPageContent] = useState<MintPageContent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    setPageContent(null)
+    setLoadError(false)
+
+    loadMintPageContent()
+      .then(({ default: nextPageContent }) => {
+        if (active) setPageContent(() => nextPageContent)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [retryCount])
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
+        <p>Mint page could not be loaded.</p>
+        <Button type="button" variant="link" onClick={() => setRetryCount((count) => count + 1)}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!PageContent) {
+    return (
+      <div className="flex min-h-48 items-center justify-center" role="status" aria-live="polite">
+        <Skeleton className="h-8 w-32" />
+        <span className="sr-only">Loading mint page</span>
+      </div>
+    )
+  }
+
+  return <PageContent />
+}

--- a/apps/app/src/components/providers/DeferredMintProviders.tsx
+++ b/apps/app/src/components/providers/DeferredMintProviders.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState, type ComponentType, type PropsWithChildren } from 'react'
+
+import { WalletProviderError, WalletProviderLoading } from './WalletProviderFallbacks'
+
+type MintProvidersProps = PropsWithChildren<{ cookies?: string | null }>
+type MintProviders = ComponentType<MintProvidersProps>
+
+const loadMintProviders = () => import('./MintProviders')
+
+export default function DeferredMintProviders({ children, cookies }: MintProvidersProps) {
+  const [Providers, setProviders] = useState<MintProviders | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    setProviders(null)
+    setLoadError(false)
+
+    loadMintProviders()
+      .then(({ default: nextProviders }) => {
+        if (active) setProviders(() => nextProviders)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [retryCount])
+
+  if (loadError) {
+    return <WalletProviderError onRetry={() => setRetryCount((count) => count + 1)} />
+  }
+
+  if (!Providers) return <WalletProviderLoading />
+
+  return <Providers cookies={cookies}>{children}</Providers>
+}

--- a/apps/app/src/components/providers/MintNetworkBoundary.tsx
+++ b/apps/app/src/components/providers/MintNetworkBoundary.tsx
@@ -1,25 +1,67 @@
 'use client'
 
-import dynamic from 'next/dynamic'
-import type { PropsWithChildren } from 'react'
+import { useEffect, useState, type ComponentType, type PropsWithChildren } from 'react'
 
+import { Button } from '@nl/ui/base/button'
 import { Skeleton } from '@nl/ui/base/skeleton'
 
-const MintNetworkProvider = dynamic(
-  () => import('@/contexts/NetworkProvider').then(({ NetworkProvider }) => NetworkProvider),
-  {
-    ssr: false,
-    loading: () => (
+type MintNetworkProvider = ComponentType<PropsWithChildren>
+
+const loadMintNetworkProvider = () =>
+  import('@/contexts/NetworkProvider').then(({ NetworkProvider }) => NetworkProvider)
+
+export default function MintNetworkBoundary({ children }: PropsWithChildren) {
+  const [Provider, setProvider] = useState<MintNetworkProvider | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+  const shouldLoadProvider = process.env.NEXT_PUBLIC_AUDIT_FIXTURE !== 'true'
+
+  useEffect(() => {
+    if (!shouldLoadProvider) return
+
+    let active = true
+    setProvider(null)
+    setLoadError(false)
+
+    loadMintNetworkProvider()
+      .then((nextProvider) => {
+        if (active) setProvider(() => nextProvider)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [retryCount, shouldLoadProvider])
+
+  if (!shouldLoadProvider) return children
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
+        <p>Wallet network could not be loaded.</p>
+        <Button
+          type="button"
+          variant="link"
+          className="text-primary underline underline-offset-4"
+          onClick={() => setRetryCount((count) => count + 1)}
+        >
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!Provider) {
+    return (
       <div className="flex min-h-48 items-center justify-center" role="status" aria-live="polite">
         <Skeleton className="h-8 w-32" />
         <span className="sr-only">Loading wallet network</span>
       </div>
-    ),
+    )
   }
-)
 
-export default function MintNetworkBoundary({ children }: PropsWithChildren) {
-  if (process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true') return children
-
-  return <MintNetworkProvider>{children}</MintNetworkProvider>
+  return <Provider>{children}</Provider>
 }

--- a/apps/app/src/components/providers/MintPageContent.tsx
+++ b/apps/app/src/components/providers/MintPageContent.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+
+import { Button } from '@nl/ui/base/button'
+import { Title } from '@nl/ui/custom/typography'
+import { ErrorBoundary } from '@nl/ui/custom/error-boundry'
+import { Preloader } from '@nl/ui/custom/preloader'
+
+import DeferredCharacterCreator from './DeferredCharacterCreator'
+import useAuth from '@/hooks/useAuth'
+import { DEGEN_COLLECTION_URL } from '@/constants/url'
+import { useDegenOwnershipContext } from '@/contexts/DegenOwnershipContext'
+
+export default function MintPageContent() {
+  const [isLoaded, setLoaded] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const { isDegenOwner } = useDegenOwnershipContext()
+  const { isConnected, isLoggedIn, handleConnectWallet } = useAuth()
+
+  const searchParams = useSearchParams()
+  const { nifty_artists: isForNiftyArtists } = Object.fromEntries(searchParams.entries())
+  const canLoadCreator = Boolean(isForNiftyArtists || (isLoggedIn && isDegenOwner))
+
+  if (!isForNiftyArtists) {
+    if (!isLoggedIn) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center">
+          <Title level={3} className="text-center">
+            Please connect your wallet
+          </Title>
+          <Button className="mt-4" onClick={handleConnectWallet}>
+            {isConnected ? 'Log In' : 'Connect Wallet'}
+          </Button>
+        </div>
+      )
+    }
+
+    if (!isDegenOwner) {
+      return (
+        <div className="flex h-full w-full flex-col items-center justify-center">
+          <Title level={3} className="text-center">
+            This page is accessible to DEGEN owners only.
+          </Title>
+          <Button asChild className="mt-4">
+            <Link href={DEGEN_COLLECTION_URL} target="_blank" rel="noreferrer">
+              Buy A DEGEN
+            </Link>
+          </Button>
+        </div>
+      )
+    }
+  }
+
+  return (
+    <div style={{ textAlign: 'center', overflowX: 'hidden' }}>
+      <ErrorBoundary>
+        <Preloader ready={isLoaded} progress={progress} />
+        <DeferredCharacterCreator
+          enabled={canLoadCreator}
+          setLoaded={setLoaded}
+          setProgress={setProgress}
+        />
+      </ErrorBoundary>
+    </div>
+  )
+}

--- a/apps/app/src/components/providers/MintProviders.tsx
+++ b/apps/app/src/components/providers/MintProviders.tsx
@@ -1,7 +1,6 @@
-'use server'
+'use client'
 
 import type { PropsWithChildren } from 'react'
-import { headers } from 'next/headers'
 
 import AuditFixtureMintContextWrapper from '@/contexts/AuditFixtureMintContextWrapper'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
@@ -9,15 +8,9 @@ import { DegenOwnershipProvider } from '@/contexts/DegenOwnershipContext'
 import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 
-/**
- * Wallet boundary for Mint-o-Matic.
- *
- * The mint route needs wallet authentication and DEGEN ownership before the
- * canvas is available. The network and contract provider is loaded by the
- * canvas boundary only after this gate succeeds.
- */
-export default async function WalletMintContextWrapper({ children }: PropsWithChildren) {
-  const cookies = (await headers()).get('cookie')
+type MintProvidersProps = PropsWithChildren<{ cookies?: string | null }>
+
+export default function MintProviders({ children, cookies }: MintProvidersProps) {
   const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
 
   const walletContexts = auditFixtureEnabled ? (

--- a/apps/app/src/components/providers/WalletProviderFallbacks.tsx
+++ b/apps/app/src/components/providers/WalletProviderFallbacks.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { Button } from '@nl/ui/base/button'
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+export function WalletProviderLoading() {
+  return (
+    <div
+      className="flex min-h-screen flex-col gap-6 bg-background p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Skeleton className="h-14 w-full rounded-lg" />
+      <div className="flex min-h-0 flex-1 gap-6">
+        <Skeleton className="hidden w-64 rounded-lg lg:block" />
+        <Skeleton className="min-h-[24rem] flex-1 rounded-lg" />
+      </div>
+      <span className="sr-only">Loading wallet provider</span>
+    </div>
+  )
+}
+
+export function WalletProviderError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background p-6 text-center"
+      role="alert"
+    >
+      <p>Wallet provider could not be loaded.</p>
+      <Button type="button" variant="outline" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  )
+}

--- a/apps/app/src/contexts/Web3ModalContext.tsx
+++ b/apps/app/src/contexts/Web3ModalContext.tsx
@@ -1,49 +1,19 @@
 'use client'
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cookieToInitialState, WagmiProvider, type Config } from 'wagmi'
 
 import type { PropsWithChildren } from 'react'
-import { Button } from '@nl/ui/base/button'
-import { Skeleton } from '@nl/ui/base/skeleton'
+import {
+  WalletProviderError,
+  WalletProviderLoading,
+} from '@/components/providers/WalletProviderFallbacks'
 
 const queryClient = new QueryClient()
 
 type Web3ModalProviderProps = { cookies?: string | null }
 type Web3ModalConfigModule = typeof import('./Web3ModalConfig')
-
-function WalletProviderLoading(): ReactNode {
-  return (
-    <div
-      className="flex min-h-screen flex-col gap-6 bg-background p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-    >
-      <Skeleton className="h-14 w-full rounded-lg" />
-      <div className="flex min-h-0 flex-1 gap-6">
-        <Skeleton className="hidden w-64 rounded-lg lg:block" />
-        <Skeleton className="min-h-[24rem] flex-1 rounded-lg" />
-      </div>
-      <span className="sr-only">Loading wallet provider</span>
-    </div>
-  )
-}
-
-function WalletProviderError({ onRetry }: { onRetry: () => void }): ReactNode {
-  return (
-    <div
-      className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background p-6 text-center"
-      role="alert"
-    >
-      <p>Wallet provider could not be loaded.</p>
-      <Button type="button" variant="outline" onClick={onRetry}>
-        Retry
-      </Button>
-    </div>
-  )
-}
 
 export function Web3ModalProvider({
   children,

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -96,7 +96,7 @@ const publicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.ts
 const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletAuthContextWrapper.tsx',
   'apps/app/src/contexts/WalletFeatureProviders.tsx',
-  'apps/app/src/contexts/WalletMintContextWrapper.tsx',
+  'apps/app/src/components/providers/MintProviders.tsx',
 ]
 const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
@@ -115,7 +115,11 @@ const web3ModalContext = 'apps/app/src/contexts/Web3ModalContext.tsx'
 const authTokenContext = 'apps/app/src/contexts/AuthTokenContext.tsx'
 const mintNetworkBoundary = 'apps/app/src/components/providers/MintNetworkBoundary.tsx'
 const mintPage = 'apps/app/src/app/(public-routes)/mint-o-matic/page.tsx'
-const mintWalletBoundary = 'apps/app/src/contexts/WalletMintContextWrapper.tsx'
+const mintPageContent = 'apps/app/src/components/providers/MintPageContent.tsx'
+const deferredMintPage = 'apps/app/src/components/providers/DeferredMintPage.tsx'
+const mintWalletBoundary = 'apps/app/src/components/providers/MintProviders.tsx'
+const deferredMintWalletBoundary = 'apps/app/src/components/providers/DeferredMintProviders.tsx'
+const walletProviderFallbacks = 'apps/app/src/components/providers/WalletProviderFallbacks.tsx'
 const networkContext = 'apps/app/src/contexts/NetworkContext.tsx'
 const networkProvider = 'apps/app/src/contexts/NetworkProvider.tsx'
 const graphQL = 'apps/app/src/hooks/useGraphQL.ts'
@@ -259,7 +263,7 @@ describe('NFT-only route provider contract', () => {
     it(`keeps dashboard token balances out of ${file}`, () => {
       const source = readFileSync(join(process.cwd(), file), 'utf8')
 
-      expect(source).toContain('WalletMintContextWrapper')
+      expect(source).toContain('DeferredMintProviders')
       expect(source).not.toContain("from '@/contexts/WalletContextWrapper'")
       expect(source).not.toContain("from '@/contexts/AuditFixtureContextWrapper'")
     })
@@ -275,14 +279,28 @@ describe('mint route provider loading contract', () => {
   })
 
   it('loads the network provider only for the mint canvas with an accessible state', () => {
-    const pageSource = readFileSync(join(process.cwd(), mintPage), 'utf8')
+    const pageSource = readFileSync(join(process.cwd(), mintPageContent), 'utf8')
     const boundarySource = readFileSync(join(process.cwd(), mintNetworkBoundary), 'utf8')
 
-    expect(pageSource).toContain('MintNetworkBoundary')
+    expect(pageSource).toContain('DeferredCharacterCreator')
     expect(boundarySource).toContain("import('@/contexts/NetworkProvider')")
     expect(boundarySource).toContain('NEXT_PUBLIC_AUDIT_FIXTURE')
     expect(boundarySource).toContain('role="status"')
     expect(boundarySource).toContain('<Skeleton')
+  })
+
+  it('keeps wallet and mint content out of the initial route client segment', () => {
+    const pageSource = readFileSync(join(process.cwd(), mintPage), 'utf8')
+    const deferredPageSource = readFileSync(join(process.cwd(), deferredMintPage), 'utf8')
+    const deferredProvidersSource = readFileSync(
+      join(process.cwd(), deferredMintWalletBoundary),
+      'utf8'
+    )
+
+    expect(pageSource).toContain('DeferredMintPage')
+    expect(pageSource).not.toContain("from '@/contexts/")
+    expect(deferredPageSource).toContain("import('./MintPageContent')")
+    expect(deferredProvidersSource).toContain("import('./MintProviders')")
   })
 
   it('keeps the network context definition lightweight', () => {
@@ -376,6 +394,7 @@ describe('private provider loading contract', () => {
 
   it('keeps AppKit UI initialization out of the eager auth shell', () => {
     const providerSource = readFileSync(join(process.cwd(), web3ModalContext), 'utf8')
+    const fallbackSource = readFileSync(join(process.cwd(), walletProviderFallbacks), 'utf8')
     const authSource = readFileSync(join(process.cwd(), authTokenContext), 'utf8')
     const modalSource = readFileSync(join(process.cwd(), walletModal), 'utf8')
 
@@ -384,9 +403,9 @@ describe('private provider loading contract', () => {
     expect(providerSource).not.toContain('createAppKit')
     expect(providerSource).not.toContain('@reown/appkit/react')
     expect(providerSource).not.toContain('@/constants/contracts')
-    expect(providerSource).toContain('<Skeleton')
-    expect(providerSource).toContain('role="status"')
-    expect(providerSource).toContain('role="alert"')
+    expect(fallbackSource).toContain('<Skeleton')
+    expect(fallbackSource).toContain('role="status"')
+    expect(fallbackSource).toContain('role="alert"')
     expect(providerSource).toContain('Retry')
     expect(authSource).not.toContain('useAppKit')
     expect(authSource).not.toContain('useAppKitEvents')


### PR DESCRIPTION
## Summary
- keep the mint route page and wallet providers out of the initial client segment
- load wallet/auth/ownership providers and mint content after hydration with shared accessible shadcn loading/error states
- remove the superseded mint wallet wrapper and update route contracts

## Measured impact
- `/mint-o-matic` initial JavaScript: 1,773,472 B -> 815,634 B (-957,838 B, 54.0%)
- initial scripts: 26 -> 19
- app home initial JavaScript unchanged at 803,982 B
- heavy wallet/contract chunks absent from the initial mint script set

## Validation
- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 passed)
- `bun --filter app lint` (0 errors; 8 pre-existing image warnings)
- `bun test test/contract/route-surface.test.ts` (104 passed)
- `bun run format:check`
- `git diff --check`
- production start smoke: `/mint-o-matic` returned HTTP 200