### PR TITLE
perf: defer public degen modules

### DIFF
--- a/apps/app/src/app/(public-routes)/degens/page.tsx
+++ b/apps/app/src/app/(public-routes)/degens/page.tsx
@@ -11,7 +11,6 @@ import { Icon } from '@nl/ui/base/icon'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
-import DegensFilter from '@/components/extended/DegensFilter'
 import DEFAULT_STATIC_FILTER from '@/components/extended/DegensFilter/constants'
 import {
   tranformDataByFilter,
@@ -28,12 +27,13 @@ import usePagination from '@/hooks/usePagination'
 import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
 import DegensTopNav from '@/components/extended/DegensTopNav'
-import PublicDegenDialog from '@/components/dialog/PublicDegenDialog'
+import DeferredDegenCard from '@/components/providers/DeferredDegenCard'
+import DeferredDegensFilter from '@/components/providers/DeferredDegensFilter'
+import DeferredPublicDegenDialog from '@/components/providers/DeferredPublicDegenDialog'
 
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
 })
-const DegenCard = dynamic(() => import('@/components/cards/DegenCard'), { ssr: false })
 
 const AllDegensPage = (): React.ReactNode => {
   const [degens, setDegens] = useState<Degen[]>([])
@@ -143,7 +143,7 @@ const AllDegensPage = (): React.ReactNode => {
   const renderDrawer = useCallback(
     () =>
       !isEmpty(defaultValues) && (
-        <DegensFilter
+        <DeferredDegensFilter
           onFilter={handleFilter}
           defaultFilterValues={defaultValues as DegenFilter}
           searchTerm={searchTerm}
@@ -155,7 +155,7 @@ const AllDegensPage = (): React.ReactNode => {
   const renderDegen = useCallback(
     (degen: Degen) => (
       <div key={degen.id} className={getGridSizeClass(isGridView, isDrawerOpen)}>
-        <DegenCard
+        <DeferredDegenCard
           degen={degen}
           size={isGridView ? 'normal' : 'small'}
           onClickDetail={() => handleViewTraits(degen)}
@@ -270,7 +270,11 @@ const AllDegensPage = (): React.ReactNode => {
         />
       </div>
       {isDegenModalOpen && (
-        <PublicDegenDialog open degen={selectedDegen} onClose={() => setIsDegenModalOpen(false)} />
+        <DeferredPublicDegenDialog
+          open
+          degen={selectedDegen}
+          onClose={() => setIsDegenModalOpen(false)}
+        />
       )}
     </>
   )

--- a/apps/app/src/components/providers/DeferredDegenCard.tsx
+++ b/apps/app/src/components/providers/DeferredDegenCard.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useRef, useState, type ComponentType } from 'react'
+
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
+import type { DegenCardProps } from '@/components/cards/DegenCard'
+
+type DegenCardComponent = ComponentType<DegenCardProps>
+
+const loadDegenCard = () => import('@/components/cards/DegenCard')
+
+export default function DeferredDegenCard({ size = 'normal', ...props }: DegenCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(cardRef, '320px')
+  const [DegenCard, setDegenCard] = useState<DegenCardComponent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+
+  useEffect(() => {
+    if (!isNearViewport || DegenCard) return
+
+    let active = true
+    loadDegenCard()
+      .then(({ default: nextDegenCard }) => {
+        if (active) setDegenCard(() => nextDegenCard)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [DegenCard, isNearViewport])
+
+  return (
+    <div ref={cardRef} aria-busy={!DegenCard && !loadError}>
+      {loadError ? (
+        <div className="flex min-h-48 items-center justify-center" role="alert">
+          <span>DEGEN card could not be loaded.</span>
+        </div>
+      ) : DegenCard ? (
+        <DegenCard size={size} {...props} />
+      ) : (
+        <SkeletonDegenPlaceholder size={size} />
+      )}
+    </div>
+  )
+}

--- a/apps/app/src/components/providers/DeferredDegensFilter.tsx
+++ b/apps/app/src/components/providers/DeferredDegensFilter.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState, type ComponentType } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+
+import type { DegenFilter } from '@/types/degenFilter'
+import DeferredDialogLoading from './DeferredDialogLoading'
+
+interface DegensFilterProps {
+  onFilter: (filter: DegenFilter) => void
+  defaultFilterValues: DegenFilter
+  searchTerm?: string
+}
+
+type DegensFilterComponent = ComponentType<DegensFilterProps>
+
+const loadDegensFilter = () => import('@/components/extended/DegensFilter')
+
+export default function DeferredDegensFilter(props: DegensFilterProps) {
+  const [Filter, setFilter] = useState<DegensFilterComponent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (Filter) return
+
+    let active = true
+    setLoadError(false)
+
+    loadDegensFilter()
+      .then(({ default: nextFilter }) => {
+        if (active) setFilter(() => nextFilter)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [Filter, retryCount])
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-24 flex-col items-center justify-center gap-2" role="alert">
+        <span>DEGEN filters could not be loaded.</span>
+        <Button type="button" variant="link" onClick={() => setRetryCount((count) => count + 1)}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!Filter) return <DeferredDialogLoading label="Loading degen filters" />
+
+  return <Filter {...props} />
+}

--- a/apps/app/src/components/providers/DeferredPublicDegenDialog.tsx
+++ b/apps/app/src/components/providers/DeferredPublicDegenDialog.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useState, type ComponentType } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+
+import type { Degen } from '@/types/degens'
+import DeferredDialogLoading from './DeferredDialogLoading'
+
+interface PublicDegenDialogProps {
+  open: boolean
+  degen?: Degen
+  onClose: () => void
+}
+
+type PublicDegenDialogComponent = ComponentType<PublicDegenDialogProps>
+
+const loadPublicDegenDialog = () => import('@/components/dialog/PublicDegenDialog')
+
+export default function DeferredPublicDegenDialog({
+  open,
+  degen,
+  onClose,
+}: PublicDegenDialogProps) {
+  const [Dialog, setDialog] = useState<PublicDegenDialogComponent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (!open || Dialog) return
+
+    let active = true
+    setLoadError(false)
+
+    loadPublicDegenDialog()
+      .then(({ default: nextDialog }) => {
+        if (active) setDialog(() => nextDialog)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [Dialog, open, retryCount])
+
+  if (!open) return null
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-24 flex-col items-center justify-center gap-2" role="alert">
+        <span>DEGEN details could not be loaded.</span>
+        <Button type="button" variant="link" onClick={() => setRetryCount((count) => count + 1)}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!Dialog) return <DeferredDialogLoading label="Loading degen details" />
+
+  return <Dialog open={open} degen={degen} onClose={onClose} />
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -562,11 +562,34 @@ describe('public route dependency contract', () => {
       'utf8'
     )
 
-    expect(page).toContain('PublicDegenDialog')
+    const deferredDialog = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/providers/DeferredPublicDegenDialog.tsx'),
+      'utf8'
+    )
+
+    expect(page).toContain('DeferredPublicDegenDialog')
     expect(page).not.toContain('WalletDegenDialog')
     expect(dialog).toContain("from '@nl/ui/base/dialog'")
     expect(dialog).not.toContain('WalletFeatureProviders')
     expect(dialog).not.toContain('useNetworkContext')
+    expect(deferredDialog).toContain("import('@/components/dialog/PublicDegenDialog')")
+    expect(deferredDialog).toContain('DeferredDialogLoading')
+  })
+
+  it('defers the public degen filter behind an accessible loading boundary', () => {
+    const page = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(public-routes)/degens/page.tsx'),
+      'utf8'
+    )
+    const deferredFilter = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/providers/DeferredDegensFilter.tsx'),
+      'utf8'
+    )
+
+    expect(page).toContain('DeferredDegensFilter')
+    expect(page).not.toContain("from '@/components/extended/DegensFilter'")
+    expect(deferredFilter).toContain("import('@/components/extended/DegensFilter')")
+    expect(deferredFilter).toContain('DeferredDialogLoading')
   })
 
   it('keeps wallet-backed game providers out of public game cards', () => {


### PR DESCRIPTION
## Summary
- defer public Degen cards until they approach the viewport
- defer the filter module until the filter drawer mounts
- defer the public details dialog until a user opens it
- keep shared Skeleton/dialog loading states and wallet-free public behavior

## Measured impact
- `/degens` initial JavaScript: 958,689 B -> 917,046 B (-41,643 B, 4.3%)
- initial route bundle stats: 846,095 B -> 804,452 B
- app home initial JavaScript remains 804,077 B

## Validation
- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 passed)
- `bun --filter app lint` (0 errors; 8 pre-existing image warnings)
- `bun test test/contract/route-surface.test.ts` (105 passed)
- `bun run format:check`
- `git diff --check`
- production start smoke: `/degens` returned HTTP 200