### PR TITLE
perf: defer archived leaderboards client graph

### DIFF
--- a/apps/app/src/app/(public-routes)/leaderboards/page.tsx
+++ b/apps/app/src/app/(public-routes)/leaderboards/page.tsx
@@ -1,5 +1,5 @@
 import { Title } from '@nl/ui/custom/typography'
-import LeaderBoards from '@/components/leaderboards'
+import DeferredLeaderboards from '@/components/providers/DeferredLeaderboards'
 
 const LeaderboardPage = () => {
   return (
@@ -7,7 +7,7 @@ const LeaderboardPage = () => {
       <Title level={2} className="mb-4">
         Leaderboards (Archived)
       </Title>
-      <LeaderBoards />
+      <DeferredLeaderboards />
     </>
   )
 }

--- a/apps/app/src/components/providers/DeferredLeaderboards.tsx
+++ b/apps/app/src/components/providers/DeferredLeaderboards.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+type LeaderBoardsComponent = typeof import('@/components/leaderboards').default
+
+const loadLeaderBoards = () => import('@/components/leaderboards')
+
+export function LeaderboardsLoading(): React.ReactNode {
+  return (
+    <div
+      className="space-y-4"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading leaderboards"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Skeleton className="h-10 w-full sm:w-40" />
+        <Skeleton className="h-10 w-full sm:w-32" />
+        <Skeleton className="h-10 w-full sm:w-24" />
+      </div>
+      <Skeleton className="h-96 w-full" />
+      <span className="sr-only">Loading leaderboards</span>
+    </div>
+  )
+}
+
+function LeaderboardsLoadError({ onRetry }: { onRetry: () => void }): React.ReactNode {
+  return (
+    <div className="flex min-h-48 flex-col items-center justify-center gap-2" role="alert">
+      <span>Leaderboards could not be loaded.</span>
+      <Button type="button" variant="link" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  )
+}
+
+export default function DeferredLeaderboards(): React.ReactNode {
+  const [LeaderBoards, setLeaderBoards] = useState<LeaderBoardsComponent | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (LeaderBoards) return
+
+    let active = true
+    setLoadError(false)
+
+    void loadLeaderBoards()
+      .then(({ default: nextLeaderBoards }) => {
+        if (active) setLeaderBoards(() => nextLeaderBoards)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [LeaderBoards, retryCount])
+
+  if (LeaderBoards) return <LeaderBoards />
+  if (loadError) {
+    return <LeaderboardsLoadError onRetry={() => setRetryCount((count) => count + 1)} />
+  }
+  return <LeaderboardsLoading />
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -143,6 +143,8 @@ const deferredConsoleGameRoutes = [
   'apps/web/src/app/(main)/niftyworld/page.tsx',
   'apps/smashers/src/app/page.tsx',
 ]
+const leaderboardsPage = 'apps/app/src/app/(public-routes)/leaderboards/page.tsx'
+const deferredLeaderboards = 'apps/app/src/components/providers/DeferredLeaderboards.tsx'
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -157,6 +159,23 @@ describe('external route surface contract', () => {
       }
     })
   }
+})
+
+describe('public leaderboard loading contract', () => {
+  it('keeps the archived leaderboard client graph out of the initial route entry', () => {
+    const pageSource = readFileSync(join(process.cwd(), leaderboardsPage), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), deferredLeaderboards), 'utf8')
+
+    expect(pageSource).toContain('DeferredLeaderboards')
+    expect(pageSource).not.toContain("from '@/components/leaderboards'")
+    expect(deferredSource).toContain("import('@/components/leaderboards')")
+    expect(deferredSource).toContain('LeaderboardsLoading')
+    expect(deferredSource).toContain('role="status"')
+    expect(deferredSource).toContain('role="alert"')
+    expect(deferredSource).toContain('aria-busy="true"')
+    expect(deferredSource).toContain('Retry')
+    expect(deferredSource).toContain("from '@nl/ui/base/skeleton'")
+  })
 })
 
 /**


### PR DESCRIPTION
## Summary
- Defer the archived `/leaderboards` client graph until after the initial route shell paints.
- Keep the existing title, theme, selector, wallet/table behavior, and route surface unchanged.
- Use shadcn Skeleton loading plus accessible retry/error states.

## Measured impact
- `/leaderboards` initial JavaScript: 906,849 B / 21 scripts -> 814,123 B / 18 scripts.
- Reduction: 92,726 B (10.2%).
- `/` remains 804,077 B; `/degens` remains 917,046 B.

## Validation
- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 passed)
- `bun test test/contract/route-surface.test.ts` (106 passed)
- `bun --filter app lint` (0 errors; 8 existing image warnings)
- `bun run format:check`
- `git diff --check`
- Production start smoke: `/`, `/degens`, and `/leaderboards` returned HTTP 200.