### PR TITLE
perf: defer app notifications from shell

### DIFF
--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -6,13 +6,12 @@ import { usePathname } from 'next/navigation'
 
 import { cn } from '@nl/ui/utils'
 import { ScrollArea } from '@nl/ui/base/scroll-area'
-import { Toaster } from '@nl/ui/base/sonner'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
 import { openDrawer } from '@/store/slices/menu'
 import { useDispatch, useSelector } from '@/store/hooks'
 import Breadcrumbs from '@/components/extended/Breadcrumbs'
-import Snackbar from '@/components/extended/Snackbar'
+import DeferredNotifications from '@/components/providers/DeferredNotifications'
 import navigation from '@/constants/menu-items'
 import styles from './_MainLayout/MainLayout.module.css'
 
@@ -68,8 +67,7 @@ export default function AppShell({ children, header, sidebar, networkWarning }: 
           )}
         </main>
       </div>
-      <Snackbar />
-      <Toaster position="top-right" closeButton richColors />
+      <DeferredNotifications />
     </>
   )
 }

--- a/apps/app/src/components/providers/DeferredNotifications.tsx
+++ b/apps/app/src/components/providers/DeferredNotifications.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type SnackbarComponent = typeof import('@/components/extended/Snackbar').default
+type ToasterComponent = typeof import('@nl/ui/base/sonner').Toaster
+
+const loadSnackbar = () => import('@/components/extended/Snackbar')
+const loadToaster = () => import('@nl/ui/base/sonner')
+
+export default function DeferredNotifications(): React.ReactNode {
+  const [Snackbar, setSnackbar] = useState<SnackbarComponent | null>(null)
+  const [Toaster, setToaster] = useState<ToasterComponent | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    void Promise.all([loadSnackbar(), loadToaster()])
+      .then(([{ default: nextSnackbar }, { Toaster: nextToaster }]) => {
+        if (!active) return
+        setSnackbar(() => nextSnackbar)
+        setToaster(() => nextToaster)
+      })
+      .catch(() => undefined)
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!Snackbar || !Toaster) return null
+
+  return (
+    <>
+      <Snackbar />
+      <Toaster position="top-right" closeButton richColors />
+    </>
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -143,6 +143,8 @@ const deferredConsoleGameRoutes = [
   'apps/web/src/app/(main)/niftyworld/page.tsx',
   'apps/smashers/src/app/page.tsx',
 ]
+const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
+const deferredNotifications = 'apps/app/src/components/providers/DeferredNotifications.tsx'
 const leaderboardsPage = 'apps/app/src/app/(public-routes)/leaderboards/page.tsx'
 const deferredLeaderboards = 'apps/app/src/components/providers/DeferredLeaderboards.tsx'
 
@@ -175,6 +177,20 @@ describe('public leaderboard loading contract', () => {
     expect(deferredSource).toContain('aria-busy="true"')
     expect(deferredSource).toContain('Retry')
     expect(deferredSource).toContain("from '@nl/ui/base/skeleton'")
+  })
+})
+
+describe('shared notification loading contract', () => {
+  it('keeps toast implementations out of the eager app shell graph', () => {
+    const appShellSource = readFileSync(join(process.cwd(), appShell), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), deferredNotifications), 'utf8')
+
+    expect(appShellSource).toContain('DeferredNotifications')
+    expect(appShellSource).not.toContain("from '@nl/ui/base/sonner'")
+    expect(appShellSource).not.toContain("from '@/components/extended/Snackbar'")
+    expect(deferredSource).toContain("import('@/components/extended/Snackbar')")
+    expect(deferredSource).toContain("import('@nl/ui/base/sonner')")
+    expect(deferredSource).toContain('Promise.all')
   })
 })
 


### PR DESCRIPTION
## Summary
- Remove Sonner and the legacy Snackbar adapter from the eager `AppShell` client graph.
- Load both notification surfaces immediately after hydration through a small native dynamic boundary.
- Preserve the existing notification components, theme, placement, and behavior.

## Measured impact
- `/` initial JavaScript: 804,077 B / 17 scripts -> 768,011 B / 16 scripts.
- `/degens`: 917,046 B / 20 scripts -> 880,980 B / 19 scripts.
- `/leaderboards`: 814,123 B / 18 scripts -> 778,057 B / 17 scripts.
- Reduction: 36,066 B on each route.

## Validation
- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 passed)
- `bun test test/contract/route-surface.test.ts` (107 passed)
- `bun --filter app lint` (0 errors; 8 existing image warnings)
- `bun run format:check`
- `git diff --check`
- Production start smoke: `/`, `/degens`, and `/leaderboards` returned HTTP 200.