### PR TITLE
perf: defer dashboard overview sections

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/index.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/index.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import ArcadeBalance from './ArcadeBalance'
+import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
 import DegenBalance from './DegenBalance'
 import GameBalance from './GameBalance'
 import TitleSection from './TitleSection'
 import WalletBalances from './WalletBalances'
+
+const loadArcadeBalance = () => import('./ArcadeBalance')
 
 const MyNFTL = (): React.ReactNode => (
   <div className="grid grid-cols-12 gap-4">
@@ -23,7 +25,7 @@ const MyNFTL = (): React.ReactNode => (
       </div>
     </div>
     <div className="col-span-12">
-      <ArcadeBalance />
+      <DeferredDashboardSection label="Arcade balance" load={loadArcadeBalance} />
     </div>
   </div>
 )

--- a/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
@@ -2,27 +2,27 @@
 
 import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
-import MyDegens from './MyDegens'
-import MyNFTL from './_MyNFTL'
-import MyStats from './MyStats'
 
 const loadMyComics = () => import('./MyComics')
 const loadMyItems = () => import('./MyItems')
+const loadMyDegens = () => import('./MyDegens')
+const loadMyNFTL = () => import('./_MyNFTL')
+const loadMyStats = () => import('./MyStats')
 
 const DashboardOverviewContent = (): React.ReactNode => {
   return (
     <div className="flex h-inherit flex-col gap-8 lg:flex-row">
       <div className="flex w-full flex-col gap-8 lg:w-[45.8333%]">
         <div className="w-full">
-          <MyNFTL />
+          <DeferredDashboardSection label="My Tokens" load={loadMyNFTL} />
         </div>
         <div className="w-full">
-          <MyStats />
+          <DeferredDashboardSection label="My Stats" load={loadMyStats} />
         </div>
       </div>
       <div className="flex w-full flex-col gap-8 lg:w-[54.1667%]">
         <div className="w-full">
-          <MyDegens />
+          <DeferredDashboardSection label="My DEGENs" load={loadMyDegens} />
         </div>
         <div className="w-full">
           <DeferredDashboardSection label="My Comics" load={loadMyComics} />

--- a/apps/app/src/components/providers/DeferredDashboardSection.tsx
+++ b/apps/app/src/components/providers/DeferredDashboardSection.tsx
@@ -2,6 +2,8 @@
 
 import type { ComponentType } from 'react'
 import { useEffect, useRef, useState } from 'react'
+import { Button } from '@nl/ui/base/button'
+import { Skeleton } from '@nl/ui/base/skeleton'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
 interface DeferredDashboardSectionProps {
@@ -13,12 +15,17 @@ interface DeferredDashboardSectionProps {
 export function DashboardSectionLoading({ label }: { label: string }): React.ReactNode {
   return (
     <div
-      className="min-h-48"
+      className="flex min-h-48 flex-col gap-4 rounded-md border border-border bg-muted p-4"
       role="status"
       aria-live="polite"
       aria-busy="true"
       aria-label={`Loading ${label}`}
     >
+      <Skeleton className="h-6 w-40 rounded" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Skeleton className="h-20 w-full rounded" />
+        <Skeleton className="h-20 w-full rounded" />
+      </div>
       <span className="sr-only">Loading {label}</span>
     </div>
   )
@@ -33,21 +40,37 @@ export default function DeferredDashboardSection({
   const sectionRef = useRef<HTMLDivElement>(null)
   const isNearViewport = useOnScreen(sectionRef, rootMargin)
   const [LoadedSection, setLoadedSection] = useState<ComponentType | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
 
   useEffect(() => {
     if (!isNearViewport || LoadedSection) return
 
     let cancelled = false
+    setLoadError(false)
     load()
       .then(({ default: Section }) => {
         if (!cancelled) setLoadedSection(() => Section)
       })
-      .catch(console.error)
+      .catch(() => {
+        if (!cancelled) setLoadError(true)
+      })
 
     return () => {
       cancelled = true
     }
-  }, [isNearViewport, load, LoadedSection])
+  }, [isNearViewport, load, LoadedSection, retryCount])
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
+        <p>{label} could not be loaded.</p>
+        <Button variant="outline" onClick={() => setRetryCount((count) => count + 1)}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
 
   return (
     <div ref={sectionRef} aria-busy={!LoadedSection}>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -482,16 +482,50 @@ describe('private provider loading contract', () => {
 })
 
 describe('dashboard overview loading contract', () => {
-  it('defers below-the-fold comic and item sections', () => {
+  it('defers dashboard sections behind the shared loading boundary', () => {
     const source = readFileSync(join(process.cwd(), dashboardOverview), 'utf8')
+    const nftlSource = readFileSync(
+      join(process.cwd(), 'apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/index.tsx'),
+      'utf8'
+    )
 
     expect(source).toContain('import DeferredDashboardSection')
     expect(source).toContain("const loadMyComics = () => import('./MyComics')")
     expect(source).toContain("const loadMyItems = () => import('./MyItems')")
+    expect(source).toContain("const loadMyDegens = () => import('./MyDegens')")
+    expect(source).toContain("const loadMyNFTL = () => import('./_MyNFTL')")
+    expect(source).toContain("const loadMyStats = () => import('./MyStats')")
     expect(source).toContain("import('./MyComics')")
     expect(source).toContain("import('./MyItems')")
+    expect(source).toContain("import('./MyDegens')")
+    expect(source).toContain("import('./_MyNFTL')")
+    expect(source).toContain("import('./MyStats')")
+    expect(source).toContain('<DeferredDashboardSection label="My Tokens" load={loadMyNFTL} />')
+    expect(source).toContain('<DeferredDashboardSection label="My DEGENs" load={loadMyDegens} />')
     expect(source).toContain('<DeferredDashboardSection label="My Comics" load={loadMyComics} />')
     expect(source).toContain('<DeferredDashboardSection label="My Items" load={loadMyItems} />')
+    expect(source).toContain('<DeferredDashboardSection label="My Stats" load={loadMyStats} />')
+    expect(nftlSource).toContain('DeferredDashboardSection')
+    expect(nftlSource).toContain("const loadArcadeBalance = () => import('./ArcadeBalance')")
+    expect(nftlSource).toContain("import('./ArcadeBalance')")
+    expect(nftlSource).toContain(
+      '<DeferredDashboardSection label="Arcade balance" load={loadArcadeBalance} />'
+    )
+  })
+
+  it('uses themed shadcn skeletons while dashboard sections load', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'apps/app/src/components/providers/DeferredDashboardSection.tsx'),
+      'utf8'
+    )
+
+    expect(source).toContain("from '@nl/ui/base/skeleton'")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('aria-live="polite"')
+    expect(source).toContain('aria-busy="true"')
+    expect(source).toContain('<Skeleton')
+    expect(source).toContain('role="alert"')
+    expect(source).toContain('Retry')
   })
 })
 


### PR DESCRIPTION
## Summary
- defer the dashboard overview token, DEGEN, stats, and arcade sections behind the shared viewport-aware boundary
- replace the blank deferred state with themed shadcn Skeleton loading UI and an accessible retry state
- add route-surface contracts for the split and loading semantics

## Impact
The production dashboard overview first-load report fell from 2,360,666 bytes on staging to 1,143,094 bytes on this branch (51.6% reduction). Generated HTML loads 1,255,688 bytes across 19 scripts.

## Validation
- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 passed)
- `bun test test/contract/route-surface.test.ts` (108 passed)
- `bun --filter app lint` (0 errors; 8 existing image warnings)
- `bun run format:check`
- production smoke: `/dashboard`, `/dashboard/overview`, `/`, `/degens`, `/leaderboards` returned 200

## Notes
The two existing untracked SEO files `assets/robots.txt` and `assets/sitemap.xml` were intentionally excluded.