### PR TITLE
perf: defer below-fold marketing sections

### DIFF
--- a/apps/smashers/src/app/page.tsx
+++ b/apps/smashers/src/app/page.tsx
@@ -1,9 +1,8 @@
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { SocialsFooter } from '@nl/ui/custom/socials-footer'
 
+import { DeferredDegensSection, DeferredGameSection } from '@/components/DeferredHomeSections'
 import HomeInteractive from '@/components/HomeInteractive'
-import DegensSection from '@/components/DegensSection'
-import GameSection from '@/components/GameSection'
 
 type NextSearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
@@ -16,12 +15,12 @@ export default async function Home({ searchParams }: { searchParams: NextSearchP
       </section>
       <section id="game-section" className="container section relative">
         <div className="purple-bg-orb orb-top-left" />
-        <GameSection />
+        <DeferredGameSection />
       </section>
       <section id="degens-section" className="container section relative">
         <div className="purple-bg-orb orb-top-right" />
         <div className="purple-bg-orb orb-bottom-left" />
-        <DegensSection />
+        <DeferredDegensSection />
       </section>
       <SocialsFooter />
     </HomeInteractive>

--- a/apps/smashers/src/components/DeferredHomeSections.tsx
+++ b/apps/smashers/src/components/DeferredHomeSections.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { DeferredSection } from '@nl/ui/custom/deferred-section'
+
+const loadGameSection = () => import('@/components/GameSection')
+const loadDegensSection = () => import('@/components/DegensSection')
+
+export function DeferredGameSection() {
+  return (
+    <DeferredSection
+      label="game details"
+      load={loadGameSection}
+      minHeightClassName="min-h-[34rem]"
+    />
+  )
+}
+
+export function DeferredDegensSection() {
+  return (
+    <DeferredSection
+      label="DEGEN details"
+      load={loadDegensSection}
+      minHeightClassName="min-h-[22rem]"
+    />
+  )
+}

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -5,13 +5,11 @@ import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 
 import BouncingNFTL from '@/components/BouncingNFTL'
 import Carousel from '@/components/Carousel'
+import { DeferredMintOMatic, DeferredSponsors } from '@/components/DeferredHomeSections'
 import MainLayout from '@/components/MainLayout'
-import MintOMatic from '@/components/MintOMatic'
-import Sponsors from '@/components/Sponsors'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
 import { RenderDegen } from '@/components/Carousel/DegenCardItem'
 import { COMMUNITY_DEGEN_LIST, DEGEN_COLLECTION_URL } from '@/constants/degens'
-import { SPONSORS } from '@/constants/sponsors'
 
 import '@/styles/home.css'
 
@@ -417,7 +415,7 @@ const Home = () => {
           />
         </div>
         <div className="relative w-full md:w-1/2">
-          <MintOMatic />
+          <DeferredMintOMatic />
         </div>
       </section>
 
@@ -490,7 +488,7 @@ const Home = () => {
             PROUDLY BACKED BY
           </h2>
         </AnimatedWrapper>
-        <Sponsors sponsors={SPONSORS} />
+        <DeferredSponsors />
         <ThemeBtnGroup
           primary={{ href: '/careers', title: 'JOIN THE TEAM' }}
           secondary={{

--- a/apps/web/src/components/DeferredHomeSections.tsx
+++ b/apps/web/src/components/DeferredHomeSections.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { DeferredSection } from '@nl/ui/custom/deferred-section'
+
+import { SPONSORS } from '@/constants/sponsors'
+
+const loadMintOMatic = () => import('@/components/MintOMatic')
+const loadSponsors = () =>
+  import('@/components/Sponsors').then(({ default: Sponsors }) => ({
+    default: () => <Sponsors sponsors={SPONSORS} />,
+  }))
+
+export function DeferredMintOMatic() {
+  return (
+    <DeferredSection
+      label="NFTL mint animation"
+      load={loadMintOMatic}
+      minHeightClassName="min-h-[28rem]"
+    />
+  )
+}
+
+export function DeferredSponsors() {
+  return <DeferredSection label="sponsors" load={loadSponsors} minHeightClassName="min-h-[22rem]" />
+}

--- a/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
+++ b/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+mock.module('@nl/ui/hooks/useOnScreen', () => ({
+  useOnScreen: () => false,
+}))
+
+describe('DeferredSection', () => {
+  let DeferredSection: typeof import('./index').DeferredSection
+
+  beforeEach(async () => {
+    DeferredSection = (await import('./index')).DeferredSection
+  })
+
+  it('keeps an accessible, themed loading state before content is near the viewport', () => {
+    const { container } = render(
+      <DeferredSection label="Game details" load={async () => ({ default: () => null })} />
+    )
+
+    expect(screen.getByRole('status', { name: 'Loading Game details' })).toBeTruthy()
+    expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
+    expect(screen.getAllByRole('status').length).toBe(1)
+  })
+})

--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+import { Skeleton } from '@nl/ui/base/skeleton'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+interface DeferredSectionProps {
+  label: string
+  load: () => Promise<{ default: ComponentType }>
+  minHeightClassName?: string
+  rootMargin?: string
+}
+
+export function DeferredSectionLoading({
+  label,
+  minHeightClassName = 'min-h-48',
+}: Pick<DeferredSectionProps, 'label' | 'minHeightClassName'>): React.ReactNode {
+  return (
+    <div
+      className={`flex ${minHeightClassName} flex-col gap-4 rounded-md border border-border bg-muted p-4`}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={`Loading ${label}`}
+    >
+      <Skeleton className="h-6 w-40 rounded" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Skeleton className="h-20 w-full rounded" />
+        <Skeleton className="h-20 w-full rounded" />
+      </div>
+      <span className="sr-only">Loading {label}</span>
+    </div>
+  )
+}
+
+export function DeferredSection({
+  label,
+  load,
+  minHeightClassName,
+  rootMargin = '320px',
+}: DeferredSectionProps): React.ReactNode {
+  const sectionRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(sectionRef, rootMargin)
+  const [LoadedSection, setLoadedSection] = useState<ComponentType | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    if (!isNearViewport || LoadedSection) return
+
+    let cancelled = false
+    setLoadError(false)
+
+    load()
+      .then(({ default: Section }) => {
+        if (!cancelled) setLoadedSection(() => Section)
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isNearViewport, load, LoadedSection, retryCount])
+
+  return (
+    <div ref={sectionRef} aria-busy={!LoadedSection && !loadError}>
+      {loadError ? (
+        <div
+          className={`flex ${minHeightClassName ?? 'min-h-48'} flex-col items-center justify-center gap-3`}
+          role="alert"
+        >
+          <p>{label} could not be loaded.</p>
+          <Button variant="outline" onClick={() => setRetryCount((count) => count + 1)}>
+            Retry
+          </Button>
+        </div>
+      ) : LoadedSection ? (
+        <LoadedSection />
+      ) : (
+        <DeferredSectionLoading label={label} minHeightClassName={minHeightClassName} />
+      )}
+    </div>
+  )
+}
+
+export default DeferredSection

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -143,6 +143,11 @@ const deferredConsoleGameRoutes = [
   'apps/web/src/app/(main)/niftyworld/page.tsx',
   'apps/smashers/src/app/page.tsx',
 ]
+const sharedDeferredSection = 'packages/ui/src/components/custom/deferred-section/index.tsx'
+const webHomePage = 'apps/web/src/app/(main)/page.tsx'
+const smashersHomePage = 'apps/smashers/src/app/page.tsx'
+const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
+const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const deferredNotifications = 'apps/app/src/components/providers/DeferredNotifications.tsx'
 const leaderboardsPage = 'apps/app/src/app/(public-routes)/leaderboards/page.tsx'
@@ -560,6 +565,46 @@ describe('shared console game loading contract', () => {
       expect(source).not.toContain("from '@nl/ui/custom/console-game'")
     })
   }
+})
+
+describe('shared below-fold loading contract', () => {
+  it('provides an accessible themed loading state with retry behavior', () => {
+    const source = readFileSync(join(process.cwd(), sharedDeferredSection), 'utf8')
+
+    expect(source).toContain("from '@nl/ui/base/skeleton'")
+    expect(source).toContain("from '@nl/ui/base/button'")
+    expect(source).toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(source).toContain('role="status"')
+    expect(source).toContain('role="alert"')
+    expect(source).toContain('aria-live="polite"')
+    expect(source).toContain('Retry')
+  })
+
+  it('defers below-fold marketing sections in web', () => {
+    const pageSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), webDeferredHomeSections), 'utf8')
+
+    expect(pageSource).toContain('DeferredMintOMatic')
+    expect(pageSource).toContain('DeferredSponsors')
+    expect(pageSource).not.toContain("import('@/components/MintOMatic')")
+    expect(pageSource).not.toContain("import('@/components/Sponsors')")
+    expect(deferredSource).toContain("import('@/components/MintOMatic')")
+    expect(deferredSource).toContain("import('@/components/Sponsors')")
+    expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+  })
+
+  it('defers below-fold marketing sections in Smashers', () => {
+    const pageSource = readFileSync(join(process.cwd(), smashersHomePage), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), smashersDeferredHomeSections), 'utf8')
+
+    expect(pageSource).toContain('DeferredGameSection')
+    expect(pageSource).toContain('DeferredDegensSection')
+    expect(pageSource).not.toContain("import('@/components/GameSection')")
+    expect(pageSource).not.toContain("import('@/components/DegensSection')")
+    expect(deferredSource).toContain("import('@/components/GameSection')")
+    expect(deferredSource).toContain("import('@/components/DegensSection')")
+    expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+  })
 })
 
 const sentryClientBoundaries = [


### PR DESCRIPTION
## Summary
- defer below-fold marketing sections on the web and Smashers home routes
- share an accessible, themed shadcn loading/retry boundary through `@nl/ui`
- preserve route contract coverage for the new client wrappers

## Evidence
- Web home HTML: 201,075 -> 177,894 bytes uncompressed; 21,814 -> 19,844 bytes with gzip
- Smashers home HTML: 62,860 -> 32,499 bytes uncompressed; 11,685 -> 6,361 bytes with gzip
- `bun --filter web build`
- `bun --filter smashers build`
- `bun --filter web test` (13 pass)
- `bun --filter smashers test` (15 pass)
- `bun --filter web lint`
- `bun --filter smashers lint` (0 errors; existing warning only)
- `bun run format:check`
- `bun test test/contract/route-surface.test.ts` (111 pass)
- `bun test packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx` (1 pass)
