### PR TITLE
perf: defer dashboard items graph

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsContent.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Separator } from '@nl/ui/base/separator'
+import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
+
+import ComicCard from '@/components/cards/ComicCard'
+import ViewComicDialog from '@/components/dialog/ViewComicDialog'
+import SectionSlider from '@/components/sections/SectionSlider'
+
+import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
+import type { Comic, Item } from '@/types/marketplace'
+import { COMICS_PURCHASE_URL, ITEM_PURCHASE_URL } from '@/constants/url'
+import ComicDetail from '@/components/cards/ComicDetail'
+import ComicPlaceholder from '@/components/cards/Skeleton/ComicPlaceholder'
+import BuyCard from '@/components/cards/BuyCard'
+import WearableItemCard from '@/components/cards/WearableItemCard'
+import WearableSubItemCard from '@/components/cards/WearableSubItemCard'
+import ItemDetail from '@/components/cards/ItemDetail'
+import ViewItemDialog from '@/components/dialog/ViewItemDialog'
+
+const DashboardComicsPageContent = (): React.ReactNode => {
+  const [selectedComic, setSelectedComic] = useState<Comic | null>(null)
+  const [selectedItem, setSelectedItem] = useState<Item | null>(null)
+  const [selectedSubIndex, setSelectedSubIndex] = useState<number>(-1)
+  const { comicsBalances, loadingComics, itemsBalances, loadingItems } = useNFTsBalances()
+  const isSmallScreen = useMediaQuery('(max-width:1280px)')
+
+  const handleViewComic = (comic: Comic) => {
+    setSelectedComic(comic)
+  }
+
+  const handleViewItem = (item: Item) => {
+    removeSubItemSelection()
+    setSelectedItem(item)
+  }
+
+  const handleViewSubItem = (index: number) => {
+    setSelectedSubIndex(index)
+  }
+
+  const removeComicSelection = () => {
+    setSelectedComic(null)
+  }
+
+  const removeItemSelection = () => {
+    setSelectedItem(null)
+    removeSubItemSelection()
+  }
+
+  const removeSubItemSelection = () => {
+    setSelectedSubIndex(-1)
+  }
+
+  const handleCloseComicDialog = () => {
+    removeComicSelection()
+  }
+
+  const handleCloseItemDialog = () => {
+    removeItemSelection()
+  }
+
+  const renderComics = useMemo(() => {
+    if (comicsBalances.length === 0 && loadingComics) {
+      return Array.from({ length: 6 }, (_, index) => (
+        <div key={`comic-placeholder-${index}`}>
+          <ComicPlaceholder />
+        </div>
+      ))
+    } else if (comicsBalances.length > 0) {
+      return comicsBalances.map((comic) => (
+        <div key={comic.id}>
+          <ComicCard
+            data={comic}
+            onViewComic={() => handleViewComic(comic)}
+            isSelected={comic.id === selectedComic?.id}
+          />
+        </div>
+      ))
+    }
+    return null
+  }, [comicsBalances, loadingComics, selectedComic])
+
+  const renderItems = useMemo(() => {
+    if (itemsBalances.length === 0 && loadingItems) {
+      return Array.from({ length: 6 }, (_, index) => (
+        <div key={`item-placeholder-${index}`}>
+          <ComicPlaceholder />
+        </div>
+      ))
+    } else if (itemsBalances.length > 0) {
+      return itemsBalances
+        .filter(
+          (item) =>
+            !selectedItem?.balance || selectedItem?.balance <= 1 || item.id !== selectedItem?.id
+        )
+        .map((item) => (
+          <div key={item.id}>
+            <WearableItemCard
+              data={item}
+              onViewItem={() => handleViewItem(item)}
+              isSelected={item.id === selectedItem?.id}
+            />
+          </div>
+        ))
+    }
+    return null
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemsBalances, loadingItems, selectedItem])
+
+  const renderSubItems = useMemo(() => {
+    if (!selectedItem?.balance || selectedItem?.balance <= 1) return null
+    return Array.from(Array(selectedItem?.balance).keys()).map((itemIndex) => (
+      <div key={`WearableSubItem-${itemIndex}`}>
+        <WearableSubItemCard
+          data={selectedItem}
+          itemIndex={itemIndex}
+          onViewItem={() => handleViewSubItem(itemIndex)}
+          isSelected={itemIndex === selectedSubIndex}
+          sx={{ height: '100%', justifyContent: 'center' }}
+        />
+      </div>
+    ))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedItem, selectedSubIndex])
+
+  return (
+    <>
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-row gap-10">
+          <SectionSlider firstSection title="My Comics" isSlider={false}>
+            <div>
+              <div
+                onClick={removeComicSelection}
+                className="flex flex-wrap gap-4 min-h-[375px] w-full border border-border rounded-md bg-muted px-4 py-6 justify-between sm:justify-normal"
+              >
+                {renderComics}
+                {comicsBalances.length > 0 && (
+                  <div>
+                    <Link href={COMICS_PURCHASE_URL} target="_blank" rel="noreferrer">
+                      <BuyCard
+                        onBuy={() => {}}
+                        isNew={!comicsBalances.some((comic) => comic.balance && comic.balance > 0)}
+                      />
+                    </Link>
+                  </div>
+                )}
+              </div>
+            </div>
+          </SectionSlider>
+          {!isSmallScreen && (
+            <div className="mt-15">
+              <ComicDetail data={selectedComic} />
+            </div>
+          )}
+        </div>
+        <div className="flex flex-row gap-10">
+          <SectionSlider firstSection title="My Items" isSlider={false}>
+            <div>
+              <div
+                onClick={removeItemSelection}
+                className="flex flex-col gap-6 min-h-[375px] w-full border border-border rounded-md bg-muted px-4 pt-8 pb-4"
+              >
+                {selectedItem?.balance && selectedItem?.balance > 1 && (
+                  <div className="flex flex-col gap-8">
+                    <div className="flex flex-col gap-4 md:flex-row md:gap-20">
+                      <WearableItemCard data={selectedItem} />
+                      <div className="flex flex-wrap gap-5">{renderSubItems}</div>
+                    </div>
+                    <Separator className="bg-[#363636] opacity-60" />
+                  </div>
+                )}
+                <div className="flex flex-wrap gap-4 justify-between sm:justify-normal">
+                  {renderItems}
+                  {itemsBalances.length > 0 && (
+                    <div>
+                      <Link href={ITEM_PURCHASE_URL} target="_blank" rel="noreferrer">
+                        <BuyCard
+                          onBuy={() => {}}
+                          isNew={!itemsBalances.some((it) => it.balance && it.balance > 0)}
+                        />
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </SectionSlider>
+          {!isSmallScreen && (
+            <div className="mt-15">
+              <ItemDetail data={selectedItem} subIndex={selectedSubIndex} />
+            </div>
+          )}
+        </div>
+      </div>
+      {isSmallScreen && (
+        <ViewComicDialog
+          comic={selectedComic}
+          open={Boolean(selectedComic)}
+          onClose={handleCloseComicDialog}
+        />
+      )}
+      {isSmallScreen && (
+        <ViewItemDialog
+          item={selectedItem}
+          subIndex={selectedSubIndex}
+          open={
+            Boolean(selectedItem) &&
+            !!selectedItem?.balance &&
+            (selectedItem?.balance === 1 || selectedSubIndex >= 0)
+          }
+          onClose={handleCloseItemDialog}
+        />
+      )}
+    </>
+  )
+}
+
+export default DashboardComicsPageContent

--- a/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
@@ -1,243 +1,36 @@
 'use client'
 
-import { useMemo, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import Link from 'next/link'
-import { v4 as uuidv4 } from 'uuid'
-import { Separator } from '@nl/ui/base/separator'
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
 
 import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-import ComicCard from '@/components/cards/ComicCard'
-import ViewComicDialog from '@/components/dialog/ViewComicDialog'
-import SectionSlider from '@/components/sections/SectionSlider'
 
-import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
-import type { Comic, Item } from '@/types/marketplace'
-import { COMICS_PURCHASE_URL, ITEM_PURCHASE_URL } from '@/constants/url'
-import ComicDetail from '@/components/cards/ComicDetail'
-import ComicPlaceholder from '@/components/cards/Skeleton/ComicPlaceholder'
-import BuyCard from '@/components/cards/BuyCard'
-import WearableItemCard from '@/components/cards/WearableItemCard'
-import WearableSubItemCard from '@/components/cards/WearableSubItemCard'
-import ItemDetail from '@/components/cards/ItemDetail'
-import ViewItemDialog from '@/components/dialog/ViewItemDialog'
-
-const DashboardComicsPageContent = (): React.ReactNode => {
-  const [selectedComic, setSelectedComic] = useState<Comic | null>(null)
-  const [selectedItem, setSelectedItem] = useState<Item | null>(null)
-  const [selectedSubIndex, setSelectedSubIndex] = useState<number>(-1)
-  const { comicsBalances, loadingComics, itemsBalances, loadingItems } = useNFTsBalances()
-  const isSmallScreen = useMediaQuery('(max-width:1280px)')
-  const router = useRouter()
-
-  const handleViewComic = (comic: Comic) => {
-    setSelectedComic(comic)
-  }
-
-  const handleViewItem = (item: Item) => {
-    removeSubItemSelection()
-    setSelectedItem(item)
-  }
-
-  const handleViewSubItem = (index: number) => {
-    setSelectedSubIndex(index)
-  }
-
-  const removeComicSelection = () => {
-    setSelectedComic(null)
-  }
-
-  const removeItemSelection = () => {
-    setSelectedItem(null)
-    removeSubItemSelection()
-  }
-
-  const removeSubItemSelection = () => {
-    setSelectedSubIndex(-1)
-  }
-
-  const handleCloseComicDialog = () => {
-    removeComicSelection()
-  }
-
-  const handleCloseItemDialog = () => {
-    removeItemSelection()
-  }
-
-  const handleLaunchBurner = () => router.push('items/burner')
-
-  const renderComics = useMemo(() => {
-    if (comicsBalances.length === 0 && loadingComics) {
-      return [...Array(6)].map(() => (
-        <div key={uuidv4()}>
-          <ComicPlaceholder />
-        </div>
-      ))
-    } else if (comicsBalances.length > 0) {
-      return comicsBalances.map((comic) => (
-        <div key={comic.id}>
-          <ComicCard
-            data={comic}
-            onViewComic={() => handleViewComic(comic)}
-            isSelected={comic.id === selectedComic?.id}
-          />
-        </div>
-      ))
-    }
-    return null
-  }, [comicsBalances, loadingComics, selectedComic])
-
-  const renderItems = useMemo(() => {
-    if (itemsBalances.length === 0 && loadingItems) {
-      return [...Array(6)].map(() => (
-        <div key={uuidv4()}>
-          <ComicPlaceholder />
-        </div>
-      ))
-    } else if (itemsBalances.length > 0) {
-      return itemsBalances
-        .filter(
-          (item) =>
-            !selectedItem?.balance || selectedItem?.balance <= 1 || item.id !== selectedItem?.id
-        )
-        .map((item) => (
-          <div key={item.id}>
-            <WearableItemCard
-              data={item}
-              onViewItem={() => handleViewItem(item)}
-              isSelected={item.id === selectedItem?.id}
-            />
-          </div>
-        ))
-    }
-    return null
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemsBalances, loadingItems, selectedItem])
-
-  const renderSubItems = useMemo(() => {
-    if (!selectedItem?.balance || selectedItem?.balance <= 1) return null
-    return Array.from(Array(selectedItem?.balance).keys()).map((itemIndex) => (
-      <div key={`WearableSubItem-${itemIndex}`}>
-        <WearableSubItemCard
-          data={selectedItem}
-          itemIndex={itemIndex}
-          onViewItem={() => handleViewSubItem(itemIndex)}
-          isSelected={itemIndex === selectedSubIndex}
-          sx={{ height: '100%', justifyContent: 'center' }}
-        />
+const DashboardItemsPageContent = dynamic(() => import('./DashboardItemsContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[32rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading dashboard comics and items"
+    >
+      <Skeleton className="h-10 w-full rounded" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton key={index} className="h-48 w-full rounded" />
+        ))}
       </div>
-    ))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedItem, selectedSubIndex])
+      <span className="sr-only">Loading dashboard comics and items</span>
+    </div>
+  ),
+})
 
+export default function DashboardItemsPage() {
   return (
-    <>
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-row gap-10">
-          <SectionSlider
-            firstSection
-            title="My Comics"
-            isSlider={false}
-            // actions={
-            //   <Box>
-            //     <Button variant="contained" sx={{ height: 28 }} onClick={handleLaunchBurner}>
-            //       Launch Comics Burner
-            //     </Button>
-            //   </Box>
-            // }
-          >
-            <div>
-              <div
-                onClick={removeComicSelection}
-                className="flex flex-wrap gap-4 min-h-[375px] w-full border border-border rounded-md bg-muted px-4 py-6 justify-between sm:justify-normal"
-              >
-                {renderComics}
-                {comicsBalances.length > 0 && (
-                  <div>
-                    <Link href={COMICS_PURCHASE_URL} target="_blank" rel="noreferrer">
-                      <BuyCard
-                        onBuy={() => {}}
-                        isNew={!comicsBalances.some((comic) => comic.balance && comic.balance > 0)}
-                      />
-                    </Link>
-                  </div>
-                )}
-              </div>
-            </div>
-          </SectionSlider>
-          {!isSmallScreen && (
-            <div className="mt-15">
-              <ComicDetail data={selectedComic} />
-            </div>
-          )}
-        </div>
-        <div className="flex flex-row gap-10">
-          <SectionSlider firstSection title="My Items" isSlider={false}>
-            <div>
-              <div
-                onClick={removeItemSelection}
-                className="flex flex-col gap-6 min-h-[375px] w-full border border-border rounded-md bg-muted px-4 pt-8 pb-4"
-              >
-                {selectedItem?.balance && selectedItem?.balance > 1 && (
-                  <div className="flex flex-col gap-8">
-                    <div className="flex flex-col gap-4 md:flex-row md:gap-20">
-                      <WearableItemCard data={selectedItem} />
-                      <div className="flex flex-wrap gap-5">{renderSubItems}</div>
-                    </div>
-                    <Separator className="bg-[#363636] opacity-60" />
-                  </div>
-                )}
-                <div className="flex flex-wrap gap-4 justify-between sm:justify-normal">
-                  {renderItems}
-                  {itemsBalances.length > 0 && (
-                    <div>
-                      <Link href={ITEM_PURCHASE_URL} target="_blank" rel="noreferrer">
-                        <BuyCard
-                          onBuy={() => {}}
-                          isNew={!itemsBalances.some((it) => it.balance && it.balance > 0)}
-                        />
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </SectionSlider>
-          {!isSmallScreen && (
-            <div className="mt-15">
-              <ItemDetail data={selectedItem} subIndex={selectedSubIndex} />
-            </div>
-          )}
-        </div>
-      </div>
-      {isSmallScreen && (
-        <ViewComicDialog
-          comic={selectedComic}
-          open={Boolean(selectedComic)}
-          onClose={handleCloseComicDialog}
-        />
-      )}
-      {isSmallScreen && (
-        <ViewItemDialog
-          item={selectedItem}
-          subIndex={selectedSubIndex}
-          open={
-            Boolean(selectedItem) &&
-            !!selectedItem?.balance &&
-            (selectedItem?.balance === 1 || selectedSubIndex >= 0)
-          }
-          onClose={handleCloseItemDialog}
-        />
-      )}
-    </>
+    <DashboardDataBoundary>
+      <DashboardItemsPageContent />
+    </DashboardDataBoundary>
   )
 }
-
-const DashboardComicsPage = (): React.ReactNode => (
-  <DashboardDataBoundary>
-    <DashboardComicsPageContent />
-  </DashboardDataBoundary>
-)
-
-export default DashboardComicsPage

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -102,6 +102,9 @@ const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/
 const dashboardDegens = 'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx'
 const dashboardDegensContent =
   'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx'
+const dashboardItems = 'apps/app/src/app/(private-routes)/dashboard/items/page.tsx'
+const dashboardItemsContent =
+  'apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsContent.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
 const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
@@ -551,6 +554,24 @@ describe('dashboard DEGEN loading contract', () => {
     expect(contentSource).toContain("import('@/components/cards/DegenCard/DashboardDegenCard')")
     expect(contentSource).toContain("from '@/components/extended/DegensFilter'")
     expect(contentSource).toContain('DashboardDegensPageContent')
+  })
+})
+
+describe('dashboard items loading contract', () => {
+  it('keeps the comic and item graph behind the route loading boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), dashboardItems), 'utf8')
+    const contentSource = readFileSync(join(process.cwd(), dashboardItemsContent), 'utf8')
+
+    expect(pageSource).toContain("dynamic(() => import('./DashboardItemsContent')")
+    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(pageSource).toContain('role="status"')
+    expect(pageSource).toContain('aria-live="polite"')
+    expect(pageSource).toContain('aria-busy="true"')
+    expect(pageSource).not.toContain("from '@/components/cards/ComicCard'")
+    expect(pageSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(contentSource).toContain("from '@/components/cards/ComicCard'")
+    expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(contentSource).toContain('DashboardComicsPageContent')
   })
 })
 


### PR DESCRIPTION
## Summary

- move the dashboard items/comics client graph behind a route-level dynamic boundary
- keep the private data boundary and a themed shadcn skeleton in the initial route entry
- remove the unused burner router handler, commented action, and random placeholder UUID keys
- add a route contract protecting the loading boundary

## Impact

The `/dashboard/items` first-load JavaScript diagnostic drops from 2,033,805 bytes to 1,139,145 bytes (894,660 bytes / 44.0%) against the current staging baseline. Existing visual structure, theme classes, dashboard data boundary, and item/comic interactions remain unchanged after the deferred content loads.

## Validation

- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 pass)
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun test test/contract/route-surface.test.ts` (113 pass)
- `bun run format:check`
- `git diff --check`
- production smoke: dashboard routes returned HTTP 200
