### PR TITLE
perf: defer comics burner graph

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerContent.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useCallback, useEffect, useState, useMemo } from 'react'
+import { type AddressLike } from 'ethers'
+import { useRouter } from 'next/navigation'
+import { Button } from '@nl/ui/base/button'
+
+import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
+import useNetworkContext from '@/hooks/useNetworkContext'
+import { COMICS_BURNER_CONTRACT, MARKETPLACE_CONTRACT } from '@/constants/contracts'
+import { DEBUG } from '@/constants/index'
+import type { Comic } from '@/types/marketplace'
+
+import Machine from './_components/machine'
+import MachineButton from './_components/machine-button'
+import HelpDialog from './_components/help-dialog'
+import ComicsGrid from './_components/comics-grid'
+import SatoshiAnimations from './_components/satoshi-animations'
+import ItemsGrid from './_components/items-grid'
+
+// TODO: Config Signer for MARKETPLACE_CONTRACT or add to writeContracts
+
+const ComicsBurnerContent = () => {
+  const router = useRouter()
+  const { itemsBalances, refreshItemsBalances } = useNFTsBalances()
+  const { address, tx, writeContracts } = useNetworkContext()
+  const [isApprovedForAll, setIsApprovedForAll] = useState(false)
+  const [helpDialogOpen, setHelpDialogOpen] = useState(false)
+  const [selectedComics, setSelectedComics] = useState<Comic[]>([])
+  const [burnCount, setBurnCount] = useState([0, 0, 0, 0, 0, 0])
+  const [burning, setBurning] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const burnDisabled = burning || selectedComics.length < 1 || burnCount.every((c) => !c)
+
+  const itemCounts = useMemo(() => {
+    if (itemsBalances.length) {
+      return itemsBalances.map((it) => it.balance || 0)
+    }
+    return [0, 0, 0, 0, 0, 0, 0]
+  }, [itemsBalances])
+
+  useEffect(() => {
+    const getAllowance = async () => {
+      const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
+      const burnContractAddress = await burnContract.getAddress()
+      const comicsContract = writeContracts[MARKETPLACE_CONTRACT]
+      const approved = (await comicsContract.isApprovedForAll(
+        address as AddressLike,
+        burnContractAddress
+      )) as boolean
+      setIsApprovedForAll(approved)
+    }
+    if (
+      writeContracts &&
+      writeContracts[COMICS_BURNER_CONTRACT] &&
+      writeContracts[MARKETPLACE_CONTRACT]
+    ) {
+      // eslint-disable-next-line no-void
+      void getAllowance()
+    }
+  }, [address, writeContracts])
+
+  const handleSetApproval = useCallback(async () => {
+    const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
+    if (!isApprovedForAll) {
+      const burnContractAddress = await burnContract.getAddress()
+      const comicsContract = writeContracts[MARKETPLACE_CONTRACT]
+      await tx(comicsContract.setApprovalForAll(burnContractAddress, true))
+    }
+  }, [isApprovedForAll, tx, writeContracts])
+
+  const handleBurn = useCallback(async () => {
+    if (!isApprovedForAll) await handleSetApproval()
+    setBurning(true)
+    // eslint-disable-next-line no-console
+    if (DEBUG) console.log('burn comics', burnCount)
+    const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
+    const res = await tx(burnContract.burnComics(burnCount))
+    setBurning(false)
+    if (res) {
+      setSelectedComics([])
+      refreshItemsBalances()
+      setBurnCount([0, 0, 0, 0, 0, 0])
+      setTimeout(() => setRefreshKey((key) => key + 1), 5000)
+    }
+  }, [burnCount, handleSetApproval, isApprovedForAll, refreshItemsBalances, tx, writeContracts])
+
+  const handleReturnPage = () => router.push('/dashboard/items')
+
+  return (
+    <>
+      <Button variant="default" className="h-7" onClick={handleReturnPage}>
+        ← Back to Comics &amp; Items
+      </Button>
+      <Machine burnDisabled={burnDisabled} selectedComics={selectedComics} />
+      <HelpDialog open={helpDialogOpen} setOpen={setHelpDialogOpen} />
+      <MachineButton
+        height={20}
+        name="Help Button"
+        onClick={() => setHelpDialogOpen(true)}
+        width={120}
+        top={100}
+        left={220}
+      />
+      <ComicsGrid
+        selectedComics={selectedComics}
+        setBurnCount={setBurnCount}
+        burnCount={burnCount}
+        setSelectedComics={setSelectedComics}
+        refreshKey={refreshKey}
+      />
+      <SatoshiAnimations burning={burning} />
+      <MachineButton
+        disabled={burnDisabled}
+        height={48}
+        name="Burn Button"
+        onClick={handleBurn}
+        width={360}
+        top={850}
+        left={0}
+      />
+      <ItemsGrid itemCounts={itemCounts} />
+    </>
+  )
+}
+
+export default ComicsBurnerContent

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
@@ -1,134 +1,37 @@
 'use client'
 
-import { useCallback, useEffect, useState, useMemo } from 'react'
-import { type AddressLike } from 'ethers'
-import { useRouter } from 'next/navigation'
-import { Button } from '@nl/ui/base/button'
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
 
 import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
-import useNetworkContext from '@/hooks/useNetworkContext'
-import { COMICS_BURNER_CONTRACT, MARKETPLACE_CONTRACT } from '@/constants/contracts'
-import { DEBUG } from '@/constants/index'
-import type { Comic } from '@/types/marketplace'
 
-import Machine from './_components/machine'
-import MachineButton from './_components/machine-button'
-import HelpDialog from './_components/help-dialog'
-import ComicsGrid from './_components/comics-grid'
-import SatoshiAnimations from './_components/satoshi-animations'
-import ItemsGrid from './_components/items-grid'
+const ComicsBurnerContent = dynamic(() => import('./ComicsBurnerContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[40rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading comics burner"
+    >
+      <Skeleton className="h-8 w-48 rounded" />
+      <Skeleton className="h-96 w-full rounded" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full rounded" />
+        ))}
+      </div>
+      <span className="sr-only">Loading comics burner</span>
+    </div>
+  ),
+})
 
-// TODO: Config Signer for MARKETPLACE_CONTRACT or add to writeContracts
-
-const ComicsBurnerContent = () => {
-  const router = useRouter()
-  const { itemsBalances, refreshItemsBalances } = useNFTsBalances()
-  const { address, tx, writeContracts } = useNetworkContext()
-  const [isApprovedForAll, setIsApprovedForAll] = useState(false)
-  const [helpDialogOpen, setHelpDialogOpen] = useState(false)
-  const [selectedComics, setSelectedComics] = useState<Comic[]>([])
-  const [burnCount, setBurnCount] = useState([0, 0, 0, 0, 0, 0])
-  const [burning, setBurning] = useState(false)
-  const [refreshKey, setRefreshKey] = useState(0)
-  const burnDisabled = burning || selectedComics.length < 1 || burnCount.every((c) => !c)
-
-  const itemCounts = useMemo(() => {
-    if (itemsBalances.length) {
-      return itemsBalances.map((it) => it.balance || 0)
-    }
-    return [0, 0, 0, 0, 0, 0, 0]
-  }, [itemsBalances])
-
-  useEffect(() => {
-    const getAllowance = async () => {
-      const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
-      const burnContractAddress = await burnContract.getAddress()
-      const comicsContract = writeContracts[MARKETPLACE_CONTRACT]
-      const approved = (await comicsContract.isApprovedForAll(
-        address as AddressLike,
-        burnContractAddress
-      )) as boolean
-      setIsApprovedForAll(approved)
-    }
-    if (
-      writeContracts &&
-      writeContracts[COMICS_BURNER_CONTRACT] &&
-      writeContracts[MARKETPLACE_CONTRACT]
-    ) {
-      // eslint-disable-next-line no-void
-      void getAllowance()
-    }
-  }, [address, writeContracts])
-
-  const handleSetApproval = useCallback(async () => {
-    const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
-    if (!isApprovedForAll) {
-      const burnContractAddress = await burnContract.getAddress()
-      const comicsContract = writeContracts[MARKETPLACE_CONTRACT]
-      await tx(comicsContract.setApprovalForAll(burnContractAddress, true))
-    }
-  }, [isApprovedForAll, tx, writeContracts])
-
-  const handleBurn = useCallback(async () => {
-    if (!isApprovedForAll) await handleSetApproval()
-    setBurning(true)
-    // eslint-disable-next-line no-console
-    if (DEBUG) console.log('burn comics', burnCount)
-    const burnContract = writeContracts[COMICS_BURNER_CONTRACT]
-    const res = await tx(burnContract.burnComics(burnCount))
-    setBurning(false)
-    if (res) {
-      setSelectedComics([])
-      refreshItemsBalances()
-      setBurnCount([0, 0, 0, 0, 0, 0])
-      setTimeout(() => setRefreshKey(Math.random() + 1), 5000)
-    }
-  }, [burnCount, handleSetApproval, isApprovedForAll, refreshItemsBalances, tx, writeContracts])
-
-  const handleReturnPage = () => router.push('/dashboard/items')
-
+export default function ComicsBurnerPage() {
   return (
-    <>
-      <Button variant="default" className="h-7" onClick={handleReturnPage}>
-        ← Back to Comics &amp; Items
-      </Button>
-      <Machine burnDisabled={burnDisabled} selectedComics={selectedComics} />
-      <HelpDialog open={helpDialogOpen} setOpen={setHelpDialogOpen} />
-      <MachineButton
-        height={20}
-        name="Help Button"
-        onClick={() => setHelpDialogOpen(true)}
-        width={120}
-        top={100}
-        left={220}
-      />
-      <ComicsGrid
-        selectedComics={selectedComics}
-        setBurnCount={setBurnCount}
-        burnCount={burnCount}
-        setSelectedComics={setSelectedComics}
-        refreshKey={refreshKey}
-      />
-      <SatoshiAnimations burning={burning} />
-      <MachineButton
-        disabled={burnDisabled}
-        height={48}
-        name="Burn Button"
-        onClick={handleBurn}
-        width={360}
-        top={850}
-        left={0}
-      />
-      <ItemsGrid itemCounts={itemCounts} />
-    </>
+    <DashboardDataBoundary>
+      <ComicsBurnerContent />
+    </DashboardDataBoundary>
   )
 }
-
-const ComicsBurner = () => (
-  <DashboardDataBoundary>
-    <ComicsBurnerContent />
-  </DashboardDataBoundary>
-)
-
-export default ComicsBurner

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -68,6 +68,8 @@ const appRouteContracts: Record<string, string[]> = {
     'src/app/(public-routes)/leaderboards/page.tsx',
     'src/app/(public-routes)/mint-o-matic/page.tsx',
     'src/app/(private-routes)/dashboard/page.tsx',
+    'src/app/(private-routes)/dashboard/items/page.tsx',
+    'src/app/(private-routes)/dashboard/items/burner/page.tsx',
     'src/app/(private-routes)/dashboard/rentals/page.tsx',
     'src/app/(private-routes)/dashboard/degens/page.tsx',
     'src/app/(private-routes)/dashboard/overview/page.tsx',
@@ -105,6 +107,9 @@ const dashboardDegensContent =
 const dashboardItems = 'apps/app/src/app/(private-routes)/dashboard/items/page.tsx'
 const dashboardItemsContent =
   'apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsContent.tsx'
+const dashboardBurner = 'apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx'
+const dashboardBurnerContent =
+  'apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerContent.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
 const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
@@ -572,6 +577,26 @@ describe('dashboard items loading contract', () => {
     expect(contentSource).toContain("from '@/components/cards/ComicCard'")
     expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).toContain('DashboardComicsPageContent')
+  })
+})
+
+describe('dashboard burner loading contract', () => {
+  it('keeps the burner machine and wallet graph behind the route loading boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), dashboardBurner), 'utf8')
+    const contentSource = readFileSync(join(process.cwd(), dashboardBurnerContent), 'utf8')
+
+    expect(pageSource).toContain("dynamic(() => import('./ComicsBurnerContent')")
+    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(pageSource).toContain('role="status"')
+    expect(pageSource).toContain('aria-live="polite"')
+    expect(pageSource).toContain('aria-busy="true"')
+    expect(pageSource).not.toContain("from 'ethers'")
+    expect(pageSource).not.toContain("from './_components/machine'")
+    expect(pageSource).not.toContain("from '@/hooks/useNetworkContext'")
+    expect(contentSource).toContain("from 'ethers'")
+    expect(contentSource).toContain("from './_components/machine'")
+    expect(contentSource).toContain("from '@/hooks/useNetworkContext'")
+    expect(contentSource).toContain('setRefreshKey((key) => key + 1)')
   })
 })
 


### PR DESCRIPTION
## Summary

- move the comics burner machine and wallet graph behind a route-level dynamic boundary
- keep the private data boundary and a themed shadcn skeleton in the initial route entry
- replace the random post-burn refresh key with a stable increment and add route contracts

## Impact

The `/dashboard/items/burner` first-load JavaScript diagnostic drops from 2,023,510 bytes to 1,139,208 bytes (884,302 bytes / 43.7%) against the current staging baseline. The existing burner machine, approval flow, comic selection, animations, and item grid remain in the deferred content graph.

## Validation

- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 pass)
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun test test/contract/route-surface.test.ts` (116 pass)
- `bun run format:check`
- `git diff --check`
- production smoke: dashboard routes returned HTTP 200
