### PR TITLE
perf: defer gamer profile graph

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useAccount } from 'wagmi'
+import merge from 'lodash/merge'
+
+import { Title } from '@nl/ui/custom/typography'
+
+import { useGamerProfile, useProfileAvatarFee } from '@/hooks/useGamerProfile'
+import useFetch from '@/hooks/useFetch'
+
+import SectionSlider from '@/components/sections/SectionSlider'
+import ImageProfile from './_ImageProfile'
+import RightInfo from './_Stats/RightInfo'
+import LeftInfo from './_Stats/LeftInfo'
+import TopInfo from './_Stats/TopInfo'
+import EmptyState from '@/components/EmptyState'
+import BottomInfo from './_Stats/BottomInfo'
+
+import { DEGEN_BASE_API_URL } from '@/constants/url'
+import type { Degen } from '@/types/degens'
+import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
+import { GamerProfileProvider } from '@/contexts/GamerProfileContext'
+
+const GamerProfileContent = (): React.ReactNode => {
+  const { profile, error, loadingProfile } = useGamerProfile()
+  const { address } = useAccount()
+  const { avatarsAndFee } = useProfileAvatarFee()
+  const { data } = useFetch<Degen[]>(`${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`)
+
+  const { comicsBalances, degenCount, degensBalances, itemsBalances } = useNFTsBalances()
+
+  const filteredDegens: Degen[] = useMemo(() => {
+    if (degensBalances?.length && data) {
+      const mapDegens = degensBalances.map((degen) => data[Number(degen.id)]) as Degen[]
+      return mapDegens
+    }
+    return []
+  }, [degensBalances, data])
+
+  const filteredComics = useMemo(
+    () => comicsBalances.filter((comic) => comic.balance && comic.balance > 0),
+    [comicsBalances]
+  )
+
+  const filteredItems = useMemo(
+    () =>
+      itemsBalances.filter(
+        (item) => !item.title.includes('Key') && item.balance && item.balance > 0
+      ),
+    [itemsBalances]
+  )
+  const filteredKeys = useMemo(
+    () =>
+      itemsBalances.filter(
+        (item) => item.title.includes('Key') && item.balance && item.balance > 0
+      ),
+    [itemsBalances]
+  )
+
+  const renderEmptyProfile = () => {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState message="You don't own any Gamer Profile yet." />
+      </div>
+    )
+  }
+
+  const renderTopProfile = () => {
+    return (
+      <div className="flex flex-wrap gap-6 rounded-md bg-muted p-8">
+        <div className="w-full shrink-0 lg:w-[calc(29.1667%_-_12px)]">
+          <ImageProfile
+            avatar={profile?.avatar}
+            avatarFee={avatarsAndFee?.price}
+            degens={
+              filteredDegens &&
+              avatarsAndFee?.avatars &&
+              merge(filteredDegens, avatarsAndFee?.avatars)
+            }
+          />
+        </div>
+        <div className="w-full min-w-0 lg:flex-1">
+          {address && <TopInfo profile={profile} walletAddress={address} />}
+          <hr className="mb-4" />
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col">
+              <Title level={3}>Nifty League Player Stats</Title>
+            </div>
+            <div className="flex flex-row gap-10">
+              <LeftInfo data={profile?.stats?.total} />
+              <RightInfo
+                comicCount={filteredComics?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
+                degenCount={degenCount}
+                itemCount={filteredItems?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
+                keyCount={filteredKeys?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
+                rentalCount={filteredDegens.length - degenCount}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const renderBottomProfile = () => {
+    const sliderSettingsOverride = {
+      slidesToShow: 3,
+      responsive: [
+        { breakpoint: 1536, settings: { slidesToShow: 3 } },
+        { breakpoint: 1280, settings: { slidesToShow: 3 } },
+        { breakpoint: 1024, settings: { slidesToShow: 2 } },
+        { breakpoint: 768, settings: { slidesToShow: 1 } },
+        { breakpoint: 640, settings: { slidesToShow: 1 } },
+      ],
+    }
+    return (
+      <SectionSlider
+        firstSection
+        variant="h3"
+        title="Player Stats by Web3 Game"
+        isSlider={false}
+        sliderSettingsOverride={sliderSettingsOverride}
+        styles={{ root: { width: '100%' } }}
+      >
+        <BottomInfo
+          nifty_smashers={profile?.stats?.nifty_smashers}
+          wen_game={profile?.stats?.wen_game}
+          crypto_winter={profile?.stats?.crypto_winter}
+        />
+      </SectionSlider>
+    )
+  }
+
+  const renderGamerProfile = () => {
+    return (
+      <GamerProfileProvider>
+        {renderTopProfile()}
+        {renderBottomProfile()}
+      </GamerProfileProvider>
+    )
+  }
+  return (
+    <div className="mb-6 flex flex-col gap-8">
+      {error && !profile && !loadingProfile && renderEmptyProfile()}
+      {(profile || loadingProfile) && renderGamerProfile()}
+    </div>
+  )
+}
+
+export default GamerProfileContent

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
@@ -1,165 +1,35 @@
 'use client'
 
-import { useMemo } from 'react'
-import { useAccount } from 'wagmi'
-import merge from 'lodash/merge'
+import dynamic from 'next/dynamic'
 
-import { Title } from '@nl/ui/custom/typography'
+import { Skeleton } from '@nl/ui/base/skeleton'
 
 import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-import { useGamerProfile, useProfileAvatarFee } from '@/hooks/useGamerProfile'
-import useFetch from '@/hooks/useFetch'
-import useIMXContext from '@/hooks/useIMXContext'
 
-import SectionSlider from '@/components/sections/SectionSlider'
-import ImageProfile from './_ImageProfile'
-import RightInfo from './_Stats/RightInfo'
-import LeftInfo from './_Stats/LeftInfo'
-import TopInfo from './_Stats/TopInfo'
-import EmptyState from '@/components/EmptyState'
-import BottomInfo from './_Stats/BottomInfo'
-
-import { DEGEN_BASE_API_URL } from '@/constants/url'
-import type { Degen } from '@/types/degens'
-import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
-import { GamerProfileProvider } from '@/contexts/GamerProfileContext'
-
-const defaultValue: {
-  isLoadingProfile: boolean | undefined
-  isLoadingDegens: boolean | undefined
-  isLoadingComics: boolean | undefined
-} = { isLoadingProfile: true, isLoadingDegens: true, isLoadingComics: true }
-
-const GamerProfileContent = (): React.ReactNode => {
-  const { profile, error, loadingProfile } = useGamerProfile()
-  const { address } = useAccount()
-  const { avatarsAndFee } = useProfileAvatarFee()
-  const { data } = useFetch<Degen[]>(`${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`)
-
-  const { comicsBalances, degenCount, degensBalances, itemsBalances } = useNFTsBalances()
-
-  const filteredDegens: Degen[] = useMemo(() => {
-    if (degensBalances?.length && data) {
-      const mapDegens = degensBalances.map((degen) => data[Number(degen.id)]) as Degen[]
-      return mapDegens
-    }
-    return []
-  }, [degensBalances, data])
-
-  const filteredComics = useMemo(
-    () => comicsBalances.filter((comic) => comic.balance && comic.balance > 0),
-    [comicsBalances]
-  )
-
-  const filteredItems = useMemo(
-    () =>
-      itemsBalances.filter(
-        (item) => !item.title.includes('Key') && item.balance && item.balance > 0
-      ),
-    [itemsBalances]
-  )
-  const filteredKeys = useMemo(
-    () =>
-      itemsBalances.filter(
-        (item) => item.title.includes('Key') && item.balance && item.balance > 0
-      ),
-    [itemsBalances]
-  )
-
-  const renderEmptyProfile = () => {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <EmptyState message="You don't own any Gamer Profile yet." />
+const GamerProfilePageContent = dynamic(() => import('./GamerProfileContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading gamer profile"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <Skeleton className="h-56 w-full rounded lg:w-1/3" />
+        <Skeleton className="h-56 w-full rounded lg:flex-1" />
       </div>
-    )
-  }
-
-  const renderTopProfile = () => {
-    return (
-      <div className="flex flex-wrap gap-6 rounded-md bg-muted p-8">
-        <div className="w-full shrink-0 lg:w-[calc(29.1667%_-_12px)]">
-          <ImageProfile
-            avatar={profile?.avatar}
-            avatarFee={avatarsAndFee?.price}
-            degens={
-              filteredDegens &&
-              avatarsAndFee?.avatars &&
-              merge(filteredDegens, avatarsAndFee?.avatars)
-            }
-          />
-        </div>
-        <div className="w-full min-w-0 lg:flex-1">
-          {address && <TopInfo profile={profile} walletAddress={address} />}
-          <hr className="mb-4" />
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col">
-              <Title level={3}>Nifty League Player Stats</Title>
-            </div>
-            <div className="flex flex-row gap-10">
-              <LeftInfo data={profile?.stats?.total} />
-              <RightInfo
-                comicCount={filteredComics?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
-                degenCount={degenCount}
-                itemCount={filteredItems?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
-                keyCount={filteredKeys?.reduce((prev, cur) => prev + Number(cur?.balance), 0)}
-                rentalCount={filteredDegens.length - degenCount}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  const renderBottomProfile = () => {
-    const sliderSettingsOverride = {
-      slidesToShow: 3,
-      responsive: [
-        { breakpoint: 1536, settings: { slidesToShow: 3 } },
-        { breakpoint: 1280, settings: { slidesToShow: 3 } },
-        { breakpoint: 1024, settings: { slidesToShow: 2 } },
-        { breakpoint: 768, settings: { slidesToShow: 1 } },
-        { breakpoint: 640, settings: { slidesToShow: 1 } },
-      ],
-    }
-    return (
-      <SectionSlider
-        firstSection
-        variant="h3"
-        title="Player Stats by Web3 Game"
-        isSlider={false}
-        sliderSettingsOverride={sliderSettingsOverride}
-        styles={{ root: { width: '100%' } }}
-      >
-        <BottomInfo
-          nifty_smashers={profile?.stats?.nifty_smashers}
-          wen_game={profile?.stats?.wen_game}
-          crypto_winter={profile?.stats?.crypto_winter}
-        />
-      </SectionSlider>
-    )
-  }
-
-  const renderGamerProfile = () => {
-    return (
-      <GamerProfileProvider>
-        {renderTopProfile()}
-        {renderBottomProfile()}
-      </GamerProfileProvider>
-    )
-  }
-  return (
-    <div className="mb-6 flex flex-col gap-8">
-      {error && !profile && !loadingProfile && renderEmptyProfile()}
-      {(profile || loadingProfile) && renderGamerProfile()}
+      <Skeleton className="h-48 w-full rounded" />
+      <span className="sr-only">Loading gamer profile</span>
     </div>
+  ),
+})
+
+export default function GamerProfilePage() {
+  return (
+    <DashboardDataBoundary>
+      <GamerProfilePageContent />
+    </DashboardDataBoundary>
   )
 }
-
-const GamerProfile = (): React.ReactNode => (
-  <DashboardDataBoundary>
-    <GamerProfileContent />
-  </DashboardDataBoundary>
-)
-
-export default GamerProfile

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -70,6 +70,7 @@ const appRouteContracts: Record<string, string[]> = {
     'src/app/(private-routes)/dashboard/page.tsx',
     'src/app/(private-routes)/dashboard/items/page.tsx',
     'src/app/(private-routes)/dashboard/items/burner/page.tsx',
+    'src/app/(private-routes)/dashboard/gamer-profile/page.tsx',
     'src/app/(private-routes)/dashboard/rentals/page.tsx',
     'src/app/(private-routes)/dashboard/degens/page.tsx',
     'src/app/(private-routes)/dashboard/overview/page.tsx',
@@ -110,6 +111,9 @@ const dashboardItemsContent =
 const dashboardBurner = 'apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx'
 const dashboardBurnerContent =
   'apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerContent.tsx'
+const gamerProfile = 'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx'
+const gamerProfileContent =
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
 const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
@@ -597,6 +601,25 @@ describe('dashboard burner loading contract', () => {
     expect(contentSource).toContain("from './_components/machine'")
     expect(contentSource).toContain("from '@/hooks/useNetworkContext'")
     expect(contentSource).toContain('setRefreshKey((key) => key + 1)')
+  })
+})
+
+describe('gamer profile loading contract', () => {
+  it('keeps profile, wallet, and inventory graphs behind the route loading boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), gamerProfile), 'utf8')
+    const contentSource = readFileSync(join(process.cwd(), gamerProfileContent), 'utf8')
+
+    expect(pageSource).toContain("dynamic(() => import('./GamerProfileContent')")
+    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(pageSource).toContain('role="status"')
+    expect(pageSource).toContain('aria-live="polite"')
+    expect(pageSource).toContain('aria-busy="true"')
+    expect(pageSource).not.toContain("from 'wagmi'")
+    expect(pageSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(contentSource).toContain("from 'wagmi'")
+    expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(contentSource).not.toContain('defaultValue')
+    expect(contentSource).toContain('GamerProfileProvider')
   })
 })
 


### PR DESCRIPTION
## Summary

- move the gamer profile wallet, inventory, rental, and avatar graph behind a route-level dynamic boundary
- keep the private data boundary and a themed shadcn skeleton in the initial route entry
- remove the unused IMX hook import and stale default loading object
- add route-surface and loading-boundary contracts

## Impact

The `/dashboard/gamer-profile` first-load JavaScript diagnostic drops from 1,996,917 bytes to 1,139,124 bytes (857,793 bytes / 43.0%) against the current staging baseline. Existing profile layout, theme classes, provider, stats, dialogs, and inventory rendering remain in the deferred content graph.

## Validation

- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 pass)
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun test test/contract/route-surface.test.ts` (118 pass)
- `bun run format:check`
- `git diff --check`
- production smoke: dashboard routes returned HTTP 200
