### PR TITLE
perf: defer dashboard rentals graph

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsContent.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import MyRentalsDataGrid from './MyRentalsDataGrid'
+
+import {
+  ALL_RENTAL_API_URL,
+  ALL_RENTAL_API_URL_INACTIVE,
+  MY_RENTAL_API_URL,
+  MY_RENTAL_API_URL_INACTIVE,
+  RENTED_FROM_ME_API_URL,
+} from '@/constants/url'
+import type { Rentals, RentalType } from '@/types/rentals'
+import SearchRental from './SearchRental'
+
+import { Label } from '@nl/ui/base/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
+import { getUniqueListBy } from '@/utils/array'
+import useTeminateRental from '@/hooks/useTeminateRental'
+import useAuth from '@/hooks/useAuth'
+
+const DashboardRentalPage = (): React.ReactNode => {
+  const { authToken } = useAuth()
+  const headers = { authorizationToken: authToken || '' }
+  const [searchTerm, setSearchTerm] = useState('')
+  const [category, setCategory] = useState<RentalType>('all')
+  const terminalRental = useTeminateRental()
+
+  const getFetchUrl = (): string[] => {
+    switch (category) {
+      case 'all':
+        return [
+          ALL_RENTAL_API_URL,
+          ALL_RENTAL_API_URL_INACTIVE,
+          RENTED_FROM_ME_API_URL,
+          MY_RENTAL_API_URL,
+          MY_RENTAL_API_URL_INACTIVE,
+        ]
+      case 'owned-sponsorship':
+      case 'non-owned-sponsorship':
+        return [ALL_RENTAL_API_URL, ALL_RENTAL_API_URL_INACTIVE]
+      case 'direct-rental':
+      case 'recruited':
+        return [MY_RENTAL_API_URL, MY_RENTAL_API_URL_INACTIVE]
+      case 'direct-renter':
+        return [RENTED_FROM_ME_API_URL]
+      default:
+        return [ALL_RENTAL_API_URL, ALL_RENTAL_API_URL_INACTIVE]
+    }
+  }
+
+  const fetchRentals = async (): Promise<Rentals[]> => {
+    const urls = getFetchUrl()
+    const responses = await Promise.all(urls.map((url) => fetch(url, { method: 'GET', headers })))
+    const rentalArrays = await Promise.all(responses.map((response) => response.json()))
+    const totalRentals = rentalArrays.reduce((flattened, arr) => [...flattened, ...arr])
+    return getUniqueListBy<Rentals>(totalRentals, 'id')
+  }
+
+  const { data, isLoading, isFetching, refetch } = useQuery<Rentals[]>({
+    queryKey: ['rentals'],
+    queryFn: fetchRentals,
+    // TODO: enable if query needed
+    enabled: false,
+  })
+
+  const rentals = useMemo(() => {
+    if (!data) return []
+    if (searchTerm.trim() === '') return data
+
+    const lowercasedValue = searchTerm.toLowerCase()
+    return data.filter(
+      (rental: Rentals) =>
+        rental?.accounts?.player?.address?.toLowerCase().includes(lowercasedValue) ||
+        rental?.degen?.id?.toLowerCase().includes(lowercasedValue) ||
+        rental?.accounts?.player?.name?.toLowerCase().includes(lowercasedValue)
+    )
+  }, [data, searchTerm])
+
+  const terminateRentalById = async (rentalId: string) => {
+    try {
+      const result = await terminalRental(rentalId)
+      if (result && !result.ok) {
+        const errMsg = await result.text()
+        toast.error(`Can not terminate the rental: ${errMsg}`)
+        return
+      }
+      const res = await result?.json()
+      if (res) {
+        toast.success('Terminate rental successfully!')
+        refetch()
+      }
+    } catch (error) {
+      toast.error(`Can not terminate the rental: ${error}`)
+    }
+  }
+
+  const updateRentalName = () => {
+    refetch()
+  }
+
+  const handleSearch = (currentValue: string) => {
+    setSearchTerm(currentValue)
+  }
+
+  const handleChangeCategory = (value: string) => {
+    const newCategory = value as RentalType
+    if (newCategory !== category) {
+      setCategory(newCategory)
+    } else {
+      refetch()
+    }
+  }
+
+  useEffect(() => {
+    if (!authToken) {
+      return
+    }
+
+    refetch()
+  }, [authToken, category, refetch])
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <span className="text-2xl font-bold">My Rentals</span>
+        {/* Header form */}
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="min-w-[200px]">
+            <Label htmlFor="category" className="mb-1 block text-xs text-muted-foreground">
+              Category
+            </Label>
+            <Select value={category} onValueChange={handleChangeCategory}>
+              <SelectTrigger id="category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="direct-rental">Direct Rental</SelectItem>
+                <SelectItem value="recruited">Recruited</SelectItem>
+                <SelectItem value="owned-sponsorship">Owned Sponsorship</SelectItem>
+                <SelectItem value="non-owned-sponsorship">Non-Owned Sponsorship</SelectItem>
+                <SelectItem value="direct-renter">Direct Renter</SelectItem>
+                <SelectItem value="terminated">Terminated</SelectItem>
+                <SelectItem value="full-history">Full History</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <SearchRental handleSearch={handleSearch} />
+        </div>
+      </div>
+      <div className="h-[calc(100vh-208px)]">
+        <MyRentalsDataGrid
+          loading={isLoading || isFetching}
+          rows={rentals}
+          category={category}
+          onTerminateRental={terminateRentalById}
+          updateRentalName={updateRentalName}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default DashboardRentalPage

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx
@@ -1,168 +1,35 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { toast } from 'sonner'
-import MyRentalsDataGrid from './MyRentalsDataGrid'
+import dynamic from 'next/dynamic'
 
-import {
-  ALL_RENTAL_API_URL,
-  ALL_RENTAL_API_URL_INACTIVE,
-  MY_RENTAL_API_URL,
-  MY_RENTAL_API_URL_INACTIVE,
-  RENTED_FROM_ME_API_URL,
-} from '@/constants/url'
-import type { Rentals, RentalType } from '@/types/rentals'
-import SearchRental from './SearchRental'
+import { Skeleton } from '@nl/ui/base/skeleton'
 
-import { Label } from '@nl/ui/base/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
-import { getUniqueListBy } from '@/utils/array'
-import useTeminateRental from '@/hooks/useTeminateRental'
-import useAuth from '@/hooks/useAuth'
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
 
-const DashboardRentalPage = (): React.ReactNode => {
-  const { authToken } = useAuth()
-  const headers = { authorizationToken: authToken || '' }
-  const [searchTerm, setSearchTerm] = useState('')
-  const [category, setCategory] = useState<RentalType>('all')
-  const terminalRental = useTeminateRental()
-
-  const getFetchUrl = (): string[] => {
-    switch (category) {
-      case 'all':
-        return [
-          ALL_RENTAL_API_URL,
-          ALL_RENTAL_API_URL_INACTIVE,
-          RENTED_FROM_ME_API_URL,
-          MY_RENTAL_API_URL,
-          MY_RENTAL_API_URL_INACTIVE,
-        ]
-      case 'owned-sponsorship':
-      case 'non-owned-sponsorship':
-        return [ALL_RENTAL_API_URL, ALL_RENTAL_API_URL_INACTIVE]
-      case 'direct-rental':
-      case 'recruited':
-        return [MY_RENTAL_API_URL, MY_RENTAL_API_URL_INACTIVE]
-      case 'direct-renter':
-        return [RENTED_FROM_ME_API_URL]
-      default:
-        return [ALL_RENTAL_API_URL, ALL_RENTAL_API_URL_INACTIVE]
-    }
-  }
-
-  const fetchRentals = async (): Promise<Rentals[]> => {
-    const urls = getFetchUrl()
-    const responses = await Promise.all(urls.map((url) => fetch(url, { method: 'GET', headers })))
-    const rentalArrays = await Promise.all(responses.map((response) => response.json()))
-    const totalRentals = rentalArrays.reduce((flattened, arr) => [...flattened, ...arr])
-    return getUniqueListBy<Rentals>(totalRentals, 'id')
-  }
-
-  const { data, isLoading, isFetching, refetch } = useQuery<Rentals[]>({
-    queryKey: ['rentals'],
-    queryFn: fetchRentals,
-    // TODO: enable if query needed
-    enabled: false,
-  })
-
-  const rentals = useMemo(() => {
-    if (!data) return []
-    if (searchTerm.trim() === '') return data
-
-    const lowercasedValue = searchTerm.toLowerCase()
-    return data.filter(
-      (rental: Rentals) =>
-        rental?.accounts?.player?.address?.toLowerCase().includes(lowercasedValue) ||
-        rental?.degen?.id?.toLowerCase().includes(lowercasedValue) ||
-        rental?.accounts?.player?.name?.toLowerCase().includes(lowercasedValue)
-    )
-  }, [data, searchTerm])
-
-  const terminateRentalById = async (rentalId: string) => {
-    try {
-      const result = await terminalRental(rentalId)
-      if (result && !result.ok) {
-        const errMsg = await result.text()
-        toast.error(`Can not terminate the rental: ${errMsg}`)
-        return
-      }
-      const res = await result?.json()
-      if (res) {
-        toast.success('Terminate rental successfully!')
-        refetch()
-      }
-    } catch (error) {
-      toast.error(`Can not terminate the rental: ${error}`)
-    }
-  }
-
-  const updateRentalName = () => {
-    refetch()
-  }
-
-  const handleSearch = (currentValue: string) => {
-    setSearchTerm(currentValue)
-  }
-
-  const handleChangeCategory = (value: string) => {
-    const newCategory = value as RentalType
-    if (newCategory !== category) {
-      setCategory(newCategory)
-    } else {
-      refetch()
-    }
-  }
-
-  useEffect(() => {
-    if (!authToken) {
-      return
-    }
-
-    refetch()
-  }, [authToken, category, refetch])
-
-  return (
-    <div className="flex flex-col gap-6">
-      {/* Header */}
+const DashboardRentalsPageContent = dynamic(() => import('./DashboardRentalsContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading rentals"
+    >
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <span className="text-2xl font-bold">My Rentals</span>
-        {/* Header form */}
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="min-w-[200px]">
-            <Label htmlFor="category" className="mb-1 block text-xs text-muted-foreground">
-              Category
-            </Label>
-            <Select value={category} onValueChange={handleChangeCategory}>
-              <SelectTrigger id="category">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                <SelectItem value="direct-rental">Direct Rental</SelectItem>
-                <SelectItem value="recruited">Recruited</SelectItem>
-                <SelectItem value="owned-sponsorship">Owned Sponsorship</SelectItem>
-                <SelectItem value="non-owned-sponsorship">Non-Owned Sponsorship</SelectItem>
-                <SelectItem value="direct-renter">Direct Renter</SelectItem>
-                <SelectItem value="terminated">Terminated</SelectItem>
-                <SelectItem value="full-history">Full History</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <SearchRental handleSearch={handleSearch} />
-        </div>
+        <Skeleton className="h-8 w-40 rounded" />
+        <Skeleton className="h-10 w-64 rounded" />
       </div>
-      <div className="h-[calc(100vh-208px)]">
-        <MyRentalsDataGrid
-          loading={isLoading || isFetching}
-          rows={rentals}
-          category={category}
-          onTerminateRental={terminateRentalById}
-          updateRentalName={updateRentalName}
-        />
-      </div>
+      <Skeleton className="h-[calc(100vh-320px)] w-full rounded" />
+      <span className="sr-only">Loading rentals</span>
     </div>
+  ),
+})
+
+export default function DashboardRentalsPage() {
+  return (
+    <DashboardDataBoundary>
+      <DashboardRentalsPageContent />
+    </DashboardDataBoundary>
   )
 }
-
-export default DashboardRentalPage

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -114,6 +114,9 @@ const dashboardBurnerContent =
 const gamerProfile = 'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx'
 const gamerProfileContent =
   'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx'
+const dashboardRentals = 'apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx'
+const dashboardRentalsContent =
+  'apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsContent.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
 const privateShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const dashboardDataProviderBoundary = 'apps/app/src/contexts/DashboardDataProviders.tsx'
@@ -620,6 +623,24 @@ describe('gamer profile loading contract', () => {
     expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).not.toContain('defaultValue')
     expect(contentSource).toContain('GamerProfileProvider')
+  })
+})
+
+describe('dashboard rentals loading contract', () => {
+  it('keeps the rental grid and auth query graph behind the route loading boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), dashboardRentals), 'utf8')
+    const contentSource = readFileSync(join(process.cwd(), dashboardRentalsContent), 'utf8')
+
+    expect(pageSource).toContain("dynamic(() => import('./DashboardRentalsContent')")
+    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(pageSource).toContain('role="status"')
+    expect(pageSource).toContain('aria-live="polite"')
+    expect(pageSource).toContain('aria-busy="true"')
+    expect(pageSource).not.toContain("from './MyRentalsDataGrid'")
+    expect(pageSource).not.toContain("from '@tanstack/react-query'")
+    expect(contentSource).toContain("from './MyRentalsDataGrid'")
+    expect(contentSource).toContain("from '@tanstack/react-query'")
+    expect(contentSource).toContain('My Rentals')
   })
 })
 


### PR DESCRIPTION
## Summary

- move the rental query, auth, filtering, and data-grid graph behind a route-level dynamic boundary
- keep the private data boundary and a themed shadcn skeleton in the initial route entry
- add route-surface and loading-boundary contracts

## Impact

The `/dashboard/rentals` first-load JavaScript diagnostic drops from 1,628,952 bytes to 1,139,025 bytes (489,927 bytes / 30.1%) against the current staging baseline. Existing rental filtering, category selection, termination, rename refresh, dialogs, and themed layout remain in the deferred content graph.

## Validation

- `bun --filter app build`
- `bun --filter app type-check`
- `bun --filter app test` (160 pass)
- `bun --filter app lint` (0 errors; existing image warnings only)
- `bun test test/contract/route-surface.test.ts` (119 pass)
- `bun run format:check`
- `git diff --check`
- production smoke: dashboard routes returned HTTP 200
