### PR TITLE
perf: share deferred dashboard loading and optimize media

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/_dialogs/RenameDegenDialogContent.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from 'react'
 import { parseEther } from 'ethers'
+import Image from 'next/image'
 import { Button } from '@nl/ui/base/button'
 import { DialogContent } from '@nl/ui/base/dialog'
 import { Input } from '@nl/ui/custom/input'
@@ -109,9 +110,12 @@ const RenameDegenDialogContent = ({ degen, onSuccess }: Props): React.ReactNode 
           Rename DEGEN
         </Title>
         <div className="flex flex-col items-center gap-1">
-          <img
+          <Image
             src={`/img/degens/nfts/${degen?.id}.${degen?.background === 'Legendary' ? 'gif' : 'webp'}`}
             alt="degen"
+            width={240}
+            height={240}
+            unoptimized={degen?.background === 'Legendary'}
             style={{
               aspectRatio: '1/1',
               width: '240px',

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.tsx
@@ -1,25 +1,28 @@
 import { memo } from 'react'
 import type { Degen } from '@/types/degens'
 
-type DegenMediaProps = {
-  alt?: string
-  src?: string
-  autoPlay?: boolean
-  loop?: boolean
-  muted?: boolean
-  style?: React.CSSProperties
-}
-
 const DegenInternalImage = memo(({ degen }: { degen: Degen }) => {
-  const setting: DegenMediaProps = {
-    style: { height: 320, objectFit: 'cover', display: 'block' },
-    src: degen?.url,
-    alt: degen?.name,
-  }
+  const style = { height: 320, objectFit: 'cover' as const, display: 'block' }
+  const alt = degen?.name || 'Degen'
+
   if (degen?.background === 'legendary') {
-    return <video {...setting} autoPlay loop muted />
+    return (
+      <video
+        src={degen?.url}
+        style={style}
+        autoPlay
+        loop
+        muted
+        playsInline
+        preload="metadata"
+        aria-label={alt}
+      />
+    )
   }
-  return <img {...setting} />
+
+  // Profile media is API-provided and may come from a host that is not known at build time.
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src={degen?.url} alt={alt} style={style} loading="lazy" decoding="async" />
 })
 
 DegenInternalImage.displayName = 'DegenInternalImage'

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import Image from 'next/image'
 import { Skeleton } from '@nl/ui/base/skeleton'
 
 import DegenImage from '@/components/cards/DegenCard/DegenImage'
@@ -30,10 +31,13 @@ const ImageProfile = ({ degens, avatar, avatarFee }: ImageProfileProps): React.R
     } else {
       if (!degenSelected) {
         return (
-          <img
+          <Image
             src="/img/degens/unavailable-image.webp"
             alt="no avatar"
+            width={730}
+            height={800}
             className="mx-auto max-w-[500px] object-cover"
+            style={{ width: '100%', height: 'auto' }}
           />
         )
       }

--- a/apps/app/src/components/cards/DegenCard/DegenImage.tsx
+++ b/apps/app/src/components/cards/DegenCard/DegenImage.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import Image from 'next/image'
 import { LEGGIES } from '@/constants/degens'
 const IMAGE_HEIGHT = 320
 
@@ -24,12 +25,15 @@ const DegenImage = memo(
     }
 
     return (
-      <img
+      <Image
         className="pixelated"
         src={image}
         alt={`Degen #${tokenId}`}
+        width={584}
+        height={640}
         loading="lazy"
         decoding="async"
+        unoptimized={image.endsWith('.gif')}
         style={{ objectFit: 'cover', height: imageHeight, ...sx }}
         onError={handleImageError}
       />

--- a/apps/app/src/components/cards/ImageCard.tsx
+++ b/apps/app/src/components/cards/ImageCard.tsx
@@ -17,6 +17,9 @@ const ImageCard = ({ image, thumbnail, title, ratio }: ImageCardProps) => {
   return (
     <div style={{ ...styleImage.imageWrapper, paddingBottom: `${ratio * 100}%` }}>
       {thumbnail && (
+        // Marketplace media can be API-provided from arbitrary hosts, so it cannot use
+        // next/image until those hosts are explicitly configured.
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           onLoad={handleImageOnLoad}
           src={thumbnail}
@@ -27,6 +30,9 @@ const ImageCard = ({ image, thumbnail, title, ratio }: ImageCardProps) => {
         />
       )}
       {image && (
+        // Marketplace media can be API-provided from arbitrary hosts, so it cannot use
+        // next/image until those hosts are explicitly configured.
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           onLoad={handleImageOnLoad}
           src={image}

--- a/apps/app/src/components/dialog/BuyArcadeTokensDialog.tsx
+++ b/apps/app/src/components/dialog/BuyArcadeTokensDialog.tsx
@@ -4,6 +4,7 @@ import { FC, useCallback, useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import Link from 'next/link'
+import Image from 'next/image'
 
 import { Dialog, DialogContent, DialogTitle } from '@nl/ui/base/dialog'
 import { Separator } from '@nl/ui/base/separator'
@@ -186,10 +187,11 @@ const BuyArcadeTokensDialog: FC<BuyArcadeTokensDialogProps> = ({ open, onSuccess
                   </span>
                   <span className="flex text-base" style={{ fontWeight: 500 }}>
                     Total:{' '}
-                    <img
+                    <Image
                       src="/icons/currencies/arcade-token.svg"
                       alt="Arcade Token"
                       width={16}
+                      height={16}
                       style={{ margin: '0 4px' }}
                     />{' '}
                     {tokenCount * details.items['arcade-token']} Arcade Tokens

--- a/apps/app/src/components/providers/DeferredDashboardSection.tsx
+++ b/apps/app/src/components/providers/DeferredDashboardSection.tsx
@@ -1,80 +1,11 @@
 'use client'
 
-import type { ComponentType } from 'react'
-import { useEffect, useRef, useState } from 'react'
-import { Button } from '@nl/ui/base/button'
-import { Skeleton } from '@nl/ui/base/skeleton'
-import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+import DeferredSection, { DeferredSectionLoading } from '@nl/ui/custom/deferred-section'
 
-interface DeferredDashboardSectionProps {
-  load: () => Promise<{ default: ComponentType }>
-  label: string
-  rootMargin?: string
-}
-
-export function DashboardSectionLoading({ label }: { label: string }): React.ReactNode {
-  return (
-    <div
-      className="flex min-h-48 flex-col gap-4 rounded-md border border-border bg-muted p-4"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label={`Loading ${label}`}
-    >
-      <Skeleton className="h-6 w-40 rounded" />
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Skeleton className="h-20 w-full rounded" />
-        <Skeleton className="h-20 w-full rounded" />
-      </div>
-      <span className="sr-only">Loading {label}</span>
-    </div>
-  )
-}
-
-/** Loads below-the-fold dashboard content shortly before it enters the viewport. */
-export default function DeferredDashboardSection({
-  load,
-  label,
-  rootMargin = '320px',
-}: DeferredDashboardSectionProps): React.ReactNode {
-  const sectionRef = useRef<HTMLDivElement>(null)
-  const isNearViewport = useOnScreen(sectionRef, rootMargin)
-  const [LoadedSection, setLoadedSection] = useState<ComponentType | null>(null)
-  const [loadError, setLoadError] = useState(false)
-  const [retryCount, setRetryCount] = useState(0)
-
-  useEffect(() => {
-    if (!isNearViewport || LoadedSection) return
-
-    let cancelled = false
-    setLoadError(false)
-    load()
-      .then(({ default: Section }) => {
-        if (!cancelled) setLoadedSection(() => Section)
-      })
-      .catch(() => {
-        if (!cancelled) setLoadError(true)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [isNearViewport, load, LoadedSection, retryCount])
-
-  if (loadError) {
-    return (
-      <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
-        <p>{label} could not be loaded.</p>
-        <Button variant="outline" onClick={() => setRetryCount((count) => count + 1)}>
-          Retry
-        </Button>
-      </div>
-    )
-  }
-
-  return (
-    <div ref={sectionRef} aria-busy={!LoadedSection}>
-      {LoadedSection ? <LoadedSection /> : <DashboardSectionLoading label={label} />}
-    </div>
-  )
-}
+/**
+ * Compatibility adapter for dashboard callers. The deferred loading behavior
+ * and accessible shadcn loading state live in the shared UI package so apps
+ * use one implementation and one visual treatment.
+ */
+export const DashboardSectionLoading = DeferredSectionLoading
+export default DeferredSection

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -537,18 +537,25 @@ describe('dashboard overview loading contract', () => {
   })
 
   it('uses themed shadcn skeletons while dashboard sections load', () => {
-    const source = readFileSync(
+    const adapterSource = readFileSync(
       join(process.cwd(), 'apps/app/src/components/providers/DeferredDashboardSection.tsx'),
       'utf8'
     )
+    const sharedSource = readFileSync(
+      join(process.cwd(), 'packages/ui/src/components/custom/deferred-section/index.tsx'),
+      'utf8'
+    )
 
-    expect(source).toContain("from '@nl/ui/base/skeleton'")
-    expect(source).toContain('role="status"')
-    expect(source).toContain('aria-live="polite"')
-    expect(source).toContain('aria-busy="true"')
-    expect(source).toContain('<Skeleton')
-    expect(source).toContain('role="alert"')
-    expect(source).toContain('Retry')
+    expect(adapterSource).toContain("from '@nl/ui/custom/deferred-section'")
+    expect(adapterSource).toContain('export const DashboardSectionLoading = DeferredSectionLoading')
+    expect(adapterSource).toContain('export default DeferredSection')
+    expect(sharedSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(sharedSource).toContain('role="status"')
+    expect(sharedSource).toContain('aria-live="polite"')
+    expect(sharedSource).toContain('aria-busy="true"')
+    expect(sharedSource).toContain('<Skeleton')
+    expect(sharedSource).toContain('role="alert"')
+    expect(sharedSource).toContain('Retry')
   })
 })
 


### PR DESCRIPTION
## Summary
- replace the app-only dashboard deferred loader with the shared accessible shadcn boundary
- optimize local DEGEN, avatar fallback, rename dialog, and arcade-token assets with `next/image`
- preserve lazy native loading for arbitrary API-hosted marketplace/profile media and document the constraint
- update the route contract to keep shared loading semantics covered

## Validation
- `bun run format:check`
- `bun run lint` (0 errors; existing API/Smashers env warnings)
- `bun run type-check`
- `bun run test` (39 tasks successful; app 160 passing, UI 137 passing)
- `bun --filter app build`
- production smoke: affected public/dashboard routes returned HTTP 200

Targets `staging`.