### PR TITLE
perf: keep static game cards server-rendered

### DIFF
--- a/apps/app/src/components/cards/ExpandableGameDescription.tsx
+++ b/apps/app/src/components/cards/ExpandableGameDescription.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+
+interface ExpandableGameDescriptionProps {
+  description?: string
+}
+
+export default function ExpandableGameDescription({ description }: ExpandableGameDescriptionProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <>
+      <p
+        className="text-sm text-muted-foreground"
+        style={{
+          whiteSpace: 'pre-wrap',
+          maxHeight: expanded ? 'inherit' : 42,
+          overflowY: 'hidden',
+        }}
+      >
+        {description}
+      </p>
+      {!expanded && (
+        <button
+          type="button"
+          className="cursor-pointer text-left text-sm text-purple"
+          onClick={() => setExpanded(true)}
+        >
+          more..
+        </button>
+      )}
+    </>
+  )
+}

--- a/apps/app/src/components/cards/GameCard.tsx
+++ b/apps/app/src/components/cards/GameCard.tsx
@@ -1,6 +1,3 @@
-'use client'
-
-import { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { Button } from '@nl/ui/base/button'
@@ -8,6 +5,7 @@ import { Card, CardContent } from '@nl/ui/base/card'
 import { Title } from '@nl/ui/custom/typography'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import { cn } from '@nl/ui/utils'
+import ExpandableGameDescription from './ExpandableGameDescription'
 import type { SxProps, Theme } from '@/types'
 
 type CardGameContentProps = {
@@ -33,11 +31,6 @@ const CardGameContent = ({
   showMore,
   title,
 }: CardGameContentProps) => {
-  const [moreStatus, setMoreStatus] = useState(false)
-  const handleMoreStatus = () => {
-    setMoreStatus(!moreStatus)
-  }
-
   return (
     <div className="flex grow flex-col justify-between bg-card">
       <CardContent className="p-6 pb-0">
@@ -53,23 +46,18 @@ const CardGameContent = ({
         </div>
         {isComingSoon && <p className="text-sm text-warning">Coming 2023</p>}
         {required && <p className="text-sm text-warning">{required}</p>}
-        <p
-          className="text-sm text-muted-foreground"
-          style={{
-            whiteSpace: 'pre-wrap',
-            maxHeight: moreStatus ? 'inherit' : 42,
-            overflowY: 'hidden',
-          }}
-        >
-          {description}
-        </p>
-        {showMore && !moreStatus && (
+        {showMore ? (
+          <ExpandableGameDescription description={description} />
+        ) : (
           <p
-            className="cursor-pointer text-sm text-purple"
-            onClick={handleMoreStatus}
-            style={{ whiteSpace: 'pre-wrap' }}
+            className="text-sm text-muted-foreground"
+            style={{
+              whiteSpace: 'pre-wrap',
+              maxHeight: 42,
+              overflowY: 'hidden',
+            }}
           >
-            more..
+            {description}
           </p>
         )}
       </CardContent>

--- a/apps/app/src/components/presentation.test.tsx
+++ b/apps/app/src/components/presentation.test.tsx
@@ -13,8 +13,12 @@ beforeEach(async () => {
     default: ({
       fill: _fill,
       sizes: _sizes,
+      alt,
       ...props
-    }: ComponentProps<'img'> & { fill?: boolean }) => <img {...props} />,
+    }: ComponentProps<'img'> & { fill?: boolean }) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img alt={alt ?? ''} {...props} />
+    ),
   }))
   mock.module('@nl/ui/base/icon', () => ({
     Icon: ({ name }: { name: string }) => <span data-icon={name}>{name}</span>,


### PR DESCRIPTION
## Summary

- keep GameCard server-rendered for static public game listings
- isolate the expandable description interaction in a small client component
- preserve collapsed styling and add a semantic keyboard-accessible button
- keep the existing next/image poster optimization and test coverage

## Validation

- bun --filter app test: 163 passed
- bun --filter app type-check: passed
- bun --filter app lint: passed
- bun run format:check: passed
- NEXT_PUBLIC_NETWORK=missing NEXT_PUBLIC_FEATURE_FLAGS={displayMyItems:false,enableEquip:false} bun --filter app build: passed, 21 routes
- production smoke: / and /games returned HTTP 200
- public entry bundle: 723,610 bytes, with no Redux references

Target: staging.