### PR TITLE
perf: keep notifications out of public shell

### DIFF
--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -9,7 +9,6 @@ import { ScrollArea } from '@nl/ui/base/scroll-area'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
 import Breadcrumbs from '@/components/extended/Breadcrumbs'
-import DeferredNotifications from '@/components/providers/DeferredNotifications'
 import { NavigationProvider, useNavigation } from '@/contexts/NavigationContext'
 import navigation from '@/constants/menu-items'
 import styles from './_MainLayout/MainLayout.module.css'
@@ -75,7 +74,6 @@ function AppShellContent({ children, header, sidebar, networkWarning }: AppShell
           )}
         </main>
       </div>
-      <DeferredNotifications />
     </>
   )
 }

--- a/apps/app/src/components/providers/PrivateRoutesShell.tsx
+++ b/apps/app/src/components/providers/PrivateRoutesShell.tsx
@@ -8,6 +8,7 @@ import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
 import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 import ReduxProvider from '@/store/ReduxProvider'
+import DeferredNotifications from './DeferredNotifications'
 
 interface PrivateRoutesShellProps extends PropsWithChildren {
   cookies?: string | null
@@ -21,6 +22,7 @@ export default function PrivateRoutesShell({ children, cookies }: PrivateRoutesS
           <AuthTokenProvider>
             <FeatureFlagProvider>
               <MainLayout>{children}</MainLayout>
+              <DeferredNotifications />
             </FeatureFlagProvider>
           </AuthTokenProvider>
         </ReduxProvider>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -167,6 +167,7 @@ const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
+const privateRoutesShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
 const deferredNotifications = 'apps/app/src/components/providers/DeferredNotifications.tsx'
 const leaderboardsPage = 'apps/app/src/app/(public-routes)/leaderboards/page.tsx'
 const deferredLeaderboards = 'apps/app/src/components/providers/DeferredLeaderboards.tsx'
@@ -206,11 +207,13 @@ describe('public leaderboard loading contract', () => {
 describe('shared notification loading contract', () => {
   it('keeps toast implementations out of the eager app shell graph', () => {
     const appShellSource = readFileSync(join(process.cwd(), appShell), 'utf8')
+    const privateShellSource = readFileSync(join(process.cwd(), privateRoutesShell), 'utf8')
     const deferredSource = readFileSync(join(process.cwd(), deferredNotifications), 'utf8')
 
-    expect(appShellSource).toContain('DeferredNotifications')
+    expect(appShellSource).not.toContain('DeferredNotifications')
     expect(appShellSource).not.toContain("from '@nl/ui/base/sonner'")
     expect(appShellSource).not.toContain("from '@/components/extended/Snackbar'")
+    expect(privateShellSource).toContain('DeferredNotifications')
     expect(deferredSource).toContain("import('@/components/extended/Snackbar')")
     expect(deferredSource).toContain("import('@nl/ui/base/sonner')")
     expect(deferredSource).toContain('Promise.all')


### PR DESCRIPTION
## Summary\n- remove the Redux-backed deferred notification adapter from the shared public AppShell\n- mount it only inside PrivateRoutesShell, beneath ReduxProvider\n- update the route contract to prevent public-shell regressions\n\n## Validation\n- bun test test/contract/route-surface.test.ts\n- bun --filter app test\n- bun --filter app type-check\n- bun --filter app lint\n- bunx prettier --check apps/app/src/app/_layout/AppShell.tsx apps/app/src/components/providers/PrivateRoutesShell.tsx test/contract/route-surface.test.ts\n- NEXT_PUBLIC_NETWORK=missing NEXT_PUBLIC_FEATURE_FLAGS='{displayMyItems:false,enableEquip:false}' bun --filter app build\n- public route bundle contains no Redux, Sonner, Snackbar, or DeferredNotifications references\n