### PR TITLE
perf: keep web navbar config server-rendered

### DIFF
--- a/apps/web/src/components/Navbar/index.tsx
+++ b/apps/web/src/components/Navbar/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Navbar as NiftyNavbar, type NavItemData } from '@nl/ui/custom/navbar'
 
 const ACTION_BUTTON = { title: 'Web3 App', href: '/app', external: true }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -166,6 +166,8 @@ const deferredConsoleGameRoutes = [
 ]
 const sharedDeferredSection = 'packages/ui/src/components/custom/deferred-section/index.tsx'
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
+const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
+const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
@@ -738,6 +740,20 @@ describe('shared below-fold loading contract', () => {
     expect(deferredSource).toContain("import('@/components/GameSection')")
     expect(deferredSource).toContain("import('@/components/DegensSection')")
     expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+  })
+})
+
+describe('web public navigation contract', () => {
+  it('keeps static navigation configuration out of the client graph', () => {
+    const navbarSource = readFileSync(join(process.cwd(), webNavbar), 'utf8')
+    const sharedNavbarSource = readFileSync(join(process.cwd(), sharedWebNavbar), 'utf8')
+
+    expect(navbarSource).not.toContain("'use client'")
+    expect(navbarSource).toContain("from '@nl/ui/custom/navbar'")
+    expect(sharedNavbarSource).toContain("import NavbarScrollFrame from './NavbarScrollFrame'")
+    expect(sharedNavbarSource).toContain("import { ActiveNavLink } from './ActiveNavLink'")
+    expect(sharedNavbarSource).toContain('NavigationMenu')
+    expect(sharedNavbarSource).toContain('Sheet')
   })
 })
 


### PR DESCRIPTION
## Summary
- remove the unnecessary client boundary from the web navbar configuration wrapper
- keep the shared shadcn/Radix navigation menu, sheet, active-link, and scroll-frame client behavior intact
- add a route-surface contract preventing static navigation config from re-entering the client graph

## Validation
- `bun --filter web type-check`
- `bun --filter web lint`
- `bun --filter web test`
- `bun --filter web build`
- `bun test test/contract/route-surface.test.ts`
- `bun run test:unit`

Measured home-route client entry: 193,367 bytes -> 186,242 bytes (~3.7% smaller).

Targets staging per repository contribution flow.