### PR TITLE
perf: keep marketing pages server-rendered

### DIFF
--- a/apps/web/src/app/(main)/community/page.tsx
+++ b/apps/web/src/app/(main)/community/page.tsx
@@ -1,17 +1,12 @@
-'use client'
-
 import type { NextPage } from 'next'
 import Image from 'next/image'
 
-import { cn } from '@nl/ui/utils'
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import SocialCards from '@/components/SocialCards'
 
 import styles from './index.module.css'
 
 const Community: NextPage = () => {
-  const desktop = useMediaQuery('(min-width:769px)')
   return (
     <>
       <section className="relative min-h-screen">
@@ -102,12 +97,7 @@ const Community: NextPage = () => {
 
       <section className="section flex sliding-nfts relative overflow-hidden">
         <div className="flex flex-col text-center relative p-0">
-          <div
-            className={cn(
-              'relative',
-              `sliding-background-wrapper-${desktop ? 'desktop' : 'mobile'}`
-            )}
-          >
+          <div className="relative sliding-background-wrapper">
             <div className="sliding-background" />
             <div className="dark-gradient-overlay" />
           </div>

--- a/apps/web/src/app/(main)/team/page.tsx
+++ b/apps/web/src/app/(main)/team/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import type { NextPage } from 'next'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'

--- a/packages/ui/src/styles/05_tailwind.animate.css
+++ b/packages/ui/src/styles/05_tailwind.animate.css
@@ -226,21 +226,18 @@
   }
 
   /* ===== Background Slider ===== */
-  .sliding-nfts .sliding-background-wrapper-desktop,
-  .sliding-nfts .sliding-background-wrapper-mobile {
+  .sliding-nfts .sliding-background-wrapper {
     overflow: hidden;
-    background: linear-gradient(128.04deg, var(--color-purple) 0%, var(--color-blue) 46.93%, #ff00c7 100%);
-  }
-  .sliding-nfts .sliding-background-wrapper-desktop {
+    background: linear-gradient(
+      128.04deg,
+      var(--color-purple) 0%,
+      var(--color-blue) 46.93%,
+      #ff00c7 100%
+    );
     min-height: 520px;
   }
-  .sliding-nfts .sliding-background-wrapper-mobile {
-    min-height: 106px;
-    margin: 16px 0;
-  }
 
-  .sliding-background-wrapper-desktop .sliding-background,
-  .sliding-background-wrapper-mobile .sliding-background {
+  .sliding-background-wrapper .sliding-background {
     background: url(/img/degens/site-extras/degen-slider.webp) repeat-x;
     image-rendering: crisp-edges;
     image-rendering: -moz-crisp-edges;
@@ -249,15 +246,20 @@
     -ms-interpolation-mode: nearest-neighbor;
     image-rendering: pixelated;
     width: 5000px;
-  }
-  .sliding-background-wrapper-desktop .sliding-background {
     height: 100%;
     animation: slideBg 60s linear infinite;
   }
-  .sliding-background-wrapper-mobile .sliding-background {
-    height: 106px;
-    animation: slideBg 240s linear infinite;
-    background-size: contain;
+
+  @media (max-width: 768px) {
+    .sliding-nfts .sliding-background-wrapper {
+      min-height: 106px;
+      margin: 16px 0;
+    }
+    .sliding-background-wrapper .sliding-background {
+      height: 106px;
+      animation-duration: 240s;
+      background-size: contain;
+    }
   }
 
   @keyframes slideBg {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -168,6 +168,9 @@ const sharedDeferredSection = 'packages/ui/src/components/custom/deferred-sectio
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
+const webCommunityPage = 'apps/web/src/app/(main)/community/page.tsx'
+const webTeamPage = 'apps/web/src/app/(main)/team/page.tsx'
+const webCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
@@ -754,6 +757,21 @@ describe('web public navigation contract', () => {
     expect(sharedNavbarSource).toContain("import { ActiveNavLink } from './ActiveNavLink'")
     expect(sharedNavbarSource).toContain('NavigationMenu')
     expect(sharedNavbarSource).toContain('Sheet')
+  })
+})
+
+describe('web marketing page boundary contract', () => {
+  it('keeps static marketing pages server-rendered while deferring interaction', () => {
+    const communitySource = readFileSync(join(process.cwd(), webCommunityPage), 'utf8')
+    const teamSource = readFileSync(join(process.cwd(), webTeamPage), 'utf8')
+    const carouselSource = readFileSync(join(process.cwd(), webCarousel), 'utf8')
+
+    expect(communitySource).not.toContain("'use client'")
+    expect(communitySource).not.toContain('useMediaQuery')
+    expect(communitySource).toContain('sliding-background-wrapper')
+    expect(teamSource).not.toContain("'use client'")
+    expect(teamSource).toContain("import Carousel from '@/components/Carousel'")
+    expect(carouselSource).toContain("'use client'")
   })
 })
 


### PR DESCRIPTION
## Summary
- remove unnecessary client boundaries from the web Community and Team pages
- replace the Community media-query hook with equivalent responsive CSS
- keep the existing client-only carousel as the interaction boundary
- add a route contract guarding server-rendered marketing pages

## Validation
- `bun --filter web type-check`
- `bun --filter web lint`
- `bun --filter web test`
- `bun --filter web build`
- `bun test test/contract/route-surface.test.ts`
- `bunx prettier --check ...`

The build prerenders all 16 web routes. Community has no page client module or media-query client module; Team has no page client module and retains only the deferred carousel client boundary.

Targets staging per repository contribution flow.