### PR TITLE
chore(ci): defer hosted builds until ready

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,17 +153,20 @@ Keep pull requests focused and reviewable. Include screenshots or recordings for
 
 ## Workflow and check behavior
 
-| Event                                              | Expected automation                                                                   |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Pull request targeting `staging`                   | Fast validation: CI plus unit tests, ending in `Validation / Gate`                    |
-| Ordinary pull request targeting `main`             | Audit validation: CI, full tests, Security, and CodeQL, ending in `Validation / Gate` |
-| Exact Release Please pull request targeting `main` | Release-policy validation only, ending in `Validation / Gate`                         |
-| Scheduled or manual validation                     | Full audit tier                                                                       |
-| Push to a working branch                           | Draft PR workflow                                                                     |
-| Push to `staging`                                  | Promotion PR workflow; canonical validation waits for the PR event                    |
-| Push to `main`                                     | Release workflow; canonical validation already ran on the merged PR                   |
+| Event                                              | Expected automation                                                                    |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Draft pull request targeting `staging`             | No hosted validation; run local checks, then mark ready when the milestone is complete |
+| Ready pull request targeting `staging`             | Fast validation: CI plus unit tests, ending in `Validation / Gate`                     |
+| Ordinary pull request targeting `main`             | Audit validation: CI, full tests, Security, and CodeQL, ending in `Validation / Gate`  |
+| Exact Release Please pull request targeting `main` | Release-policy validation only, ending in `Validation / Gate`                          |
+| Scheduled or manual validation                     | Full audit tier                                                                        |
+| Push to a working branch                           | Draft PR workflow; Vercel deployments are disabled                                     |
+| Push to `staging`                                  | Promotion PR workflow; canonical validation waits for the PR event                     |
+| Push to `main`                                     | Release workflow; canonical validation already ran on the merged PR                    |
 
 The single validation caller keys concurrency by event and pull-request head. A newer update to the same pull request cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
+
+Draft feature work is intentionally cost-aware: local validation is the feedback loop while a pull request is draft. Marking the pull request ready for review starts hosted validation. Vercel projects disable Git-triggered deployments on feature branches through the versioned `git.deploymentEnabled` policy in `apps/*/vercel.json` and continue on `staging` and `main`; manual deployments remain available.
 
 Required checks are enforced by branch protection rulesets/branch protection. Do not duplicate their checklists in the pull request description; document validation commands and results instead.
 

--- a/.github/workflows/opencode-security.yml
+++ b/.github/workflows/opencode-security.yml
@@ -13,7 +13,10 @@ jobs:
     name: OpenCode Security / Detect
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+      (
+        github.event.pull_request.draft != true &&
+        startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+      )
     runs-on: ubuntu-slim
     outputs:
       enabled: ${{ steps.detect.outputs.enabled }}

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -16,9 +16,6 @@ on:
     branches:
       - main
       - staging
-  pull_request:
-    branches:
-      - staging
 
 jobs:
   search:
@@ -34,7 +31,7 @@ jobs:
         working-directory: apps/docs
         run: |
           docker run \
-            --env ALGOLIA_APP_ID=${ALGOLIA_APP_ID} \
-            --env ALGOLIA_API_KEY=${ALGOLIA_API_KEY} \
+            --env "ALGOLIA_APP_ID=${ALGOLIA_APP_ID}" \
+            --env "ALGOLIA_API_KEY=${ALGOLIA_API_KEY}" \
             --env "CONFIG=$(cat algolia-config.json | jq -r tostring)" \
             algolia/docsearch-scraper

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   mode:
     name: Mode
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -2,7 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "**": true
+      "**": false,
+      "main": true,
+      "staging": true
     }
   },
   "buildCommand": "bun --filter api build",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": {
+      "**": false,
+      "main": true,
+      "staging": true
+    }
   }
 }

--- a/test/contract/vercel-build-policy.test.ts
+++ b/test/contract/vercel-build-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const projectRoots = ['apps/web', 'apps/app', 'apps/smashers', 'apps/api', 'apps/docs']
+const deploymentEnabled = { '**': false, main: true, staging: true }
+
+describe('Vercel build cost policy', () => {
+  for (const projectRoot of projectRoots) {
+    it(`limits ${projectRoot} automatic deployments to release branches`, () => {
+      const configPath = join(process.cwd(), projectRoot, 'vercel.json')
+      const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+        git?: { deploymentEnabled?: Record<string, boolean> }
+        ignoreCommand?: string
+      }
+
+      expect(config.git?.deploymentEnabled).toEqual(deploymentEnabled)
+      expect(config.ignoreCommand).toBeUndefined()
+    })
+  }
+
+  it('keeps every Vercel-connected app on the shared policy', () => {
+    expect(projectRoots).toHaveLength(5)
+  })
+})


### PR DESCRIPTION
## Summary\n\n- Skip Code Foundry hosted validation while a pull request is draft.\n- Run hosted validation when the pull request becomes ready for review.\n- Remove PR-triggered Algolia search runs.\n- Disable Git-triggered Vercel deployments on feature branches for web, app, Smashers, API, and Docs; keep staging and main enabled.\n\n## Local validation\n\n- actionlint: passed\n- Prettier checks: passed\n- Vercel policy contract: 6 passed\n- Route-surface contracts: 122 passed\n- Unit suite: 864 passed, 6 skipped, 0 failed\n\nThe existing API Vercel build, function, and rewrite settings are preserved.