### PR TITLE
perf(web): defer shared navbar interactions

### DIFF
--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -167,18 +167,16 @@ describe('Navbar', () => {
     expect(screen.getAllByRole('link', { name: /About/ })[0]?.getAttribute('data-active')).toBe(
       'true'
     )
-    fireEvent.click(screen.getByRole('button', { name: 'Products' }))
+    fireEvent.click(screen.getByText('Products'))
     expect(screen.getAllByRole('link', { name: /Docs/ })[0]?.getAttribute('target')).toBe('_blank')
     expect(screen.getByRole('link', { name: 'Game' })?.getAttribute('rel')).toBe('noreferrer')
-    expect(screen.getByRole('button', { name: /Open Nav Menu/ })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Open navigation' })).not.toBeNull()
   })
 
   it('switches the navbar backdrop after the scroll sentinel leaves view', () => {
     state.intersecting = false
     const { container } = render(<Navbar navItems={navItems} />)
-    expect(container.querySelector('[data-slot="navigation-menu"]')?.className).toContain(
-      'bg-background/90'
-    )
+    expect(container.querySelector('header')?.className).toContain('bg-background/90')
   })
 })
 

--- a/packages/ui/src/components/custom/external-icon/index.tsx
+++ b/packages/ui/src/components/custom/external-icon/index.tsx
@@ -1,12 +1,15 @@
-import { Icon, type IconProps } from '@nl/ui/base/icon'
+import { ExternalLink } from 'lucide-react'
+
+import type { IconProps } from '@nl/ui/base/icon'
 import { cn } from '@nl/ui/utils'
 
 export function ExternalIcon({ className = '', size = 'xs', ...props }: Omit<IconProps, 'name'>) {
+  const iconSize = typeof size === 'number' ? size : size === 'xs' ? 14 : size === 'sm' ? 18 : 20
+
   return (
-    <Icon
-      name="external-link"
-      size={size}
-      className={cn('size-3 inline-block flex-shrink-0 cursor-pointer ml-1 mb-1.5', className)}
+    <ExternalLink
+      size={iconSize}
+      className={cn('ml-1 mb-1.5 inline-block size-3 flex-shrink-0 cursor-pointer', className)}
       aria-hidden="true"
       {...props}
     />

--- a/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
+++ b/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
@@ -3,17 +3,21 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
-import { NavigationMenuLink } from '@nl/ui/base/navigation-menu'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
+import { cn } from '@nl/ui/utils'
 
-export interface ActiveNavLinkProps extends React.ComponentProps<typeof NavigationMenuLink> {
+export interface ActiveNavLinkProps extends Omit<
+  React.ComponentProps<typeof Link>,
+  'children' | 'href'
+> {
   description?: string
   external?: boolean
   href: string
   title: string
 }
 
-export function ActiveNavLink({
+export default function ActiveNavLink({
+  className,
   description,
   external,
   href,
@@ -21,24 +25,31 @@ export function ActiveNavLink({
   ...props
 }: ActiveNavLinkProps) {
   const pathname = usePathname()
+  const isActive = href === pathname
 
   return (
-    <NavigationMenuLink asChild data-active={href === pathname} {...props}>
-      <Link
-        href={href}
-        target={external ? '_blank' : undefined}
-        rel={external ? 'noreferrer' : undefined}
-      >
-        <div className="w-full leading-none">
-          {title}
-          {external && <ExternalIcon />}
-        </div>
-        {description && (
-          <p className="w-full text-xs leading-snug text-muted-foreground line-clamp-2">
-            {description}
-          </p>
-        )}
-      </Link>
-    </NavigationMenuLink>
+    <Link
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+      data-active={isActive}
+      aria-current={isActive ? 'page' : undefined}
+      className={cn(
+        'bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 flex flex-col gap-1 rounded-sm px-3 py-2 outline-none transition-colors',
+        isActive && 'bg-primary/40 text-primary-foreground',
+        className
+      )}
+      {...props}
+    >
+      <span className="w-full leading-none">
+        {title}
+        {external && <ExternalIcon />}
+      </span>
+      {description && (
+        <span className="w-full text-xs leading-snug text-muted-foreground line-clamp-2">
+          {description}
+        </span>
+      )}
+    </Link>
   )
 }

--- a/packages/ui/src/components/custom/navbar/MobileNavMenu.tsx
+++ b/packages/ui/src/components/custom/navbar/MobileNavMenu.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import Link from 'next/link'
+import { Fragment } from 'react'
+
+import { Button } from '@nl/ui/base/button'
+import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from '@nl/ui/base/navigation-menu'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@nl/ui/base/sheet'
+import { Separator } from '@nl/ui/base/separator'
+
+import ActiveNavLink from './ActiveNavLink'
+import type { NavItemData, NavbarActionButton } from './index'
+
+interface MobileNavMenuProps {
+  actionButton?: NavbarActionButton
+  navItems: NavItemData[]
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}
+
+function MobileMenuGroup({ group, pages }: Extract<NavItemData, { type: 'group' }>) {
+  return (
+    <NavigationMenuItem value={group.toLowerCase()} className="w-full">
+      <h3 className="text-base tracking-wider text-muted-foreground uppercase">{group}</h3>
+      <ul className="flex w-full flex-col">
+        {pages.map((page) => (
+          <li key={page.title}>
+            <SheetClose asChild>
+              <ActiveNavLink className="text-base font-medium" {...page} />
+            </SheetClose>
+          </li>
+        ))}
+      </ul>
+    </NavigationMenuItem>
+  )
+}
+
+function MobileMenuItem({ type: _type, ...page }: Extract<NavItemData, { type: 'single' }>) {
+  return (
+    <NavigationMenuItem value={page.title.toLowerCase()} className="w-full">
+      <SheetClose asChild>
+        <ActiveNavLink className="text-base font-medium" {...page} />
+      </SheetClose>
+    </NavigationMenuItem>
+  )
+}
+
+export default function MobileNavMenu({
+  actionButton,
+  navItems,
+  onOpenChange,
+  open,
+}: MobileNavMenuProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent id="nifty-mobile-navigation" className="bg-popover">
+        <SheetHeader>
+          <SheetTitle className="sr-only">Primary navigation</SheetTitle>
+          <SheetDescription className="sr-only">Mobile website navigation menu</SheetDescription>
+        </SheetHeader>
+        <div className="overflow-y-auto px-8 pb-4">
+          <NavigationMenu
+            viewport={false}
+            aria-label="Primary navigation"
+            className="max-w-none flex-col items-stretch"
+          >
+            <NavigationMenuList className="flex flex-col gap-4" data-orientation="vertical">
+              {navItems.map((item) => (
+                <Fragment key={item.type === 'single' ? item.title : item.group}>
+                  {item.type === 'single' ? (
+                    <MobileMenuItem {...item} />
+                  ) : (
+                    <MobileMenuGroup {...item} />
+                  )}
+                </Fragment>
+              ))}
+            </NavigationMenuList>
+          </NavigationMenu>
+          {actionButton && (
+            <>
+              <Separator orientation="horizontal" className="my-6" />
+              <Link
+                href={actionButton.href}
+                target={actionButton.external ? '_blank' : undefined}
+                rel={actionButton.external ? 'noreferrer' : undefined}
+              >
+                <Button variant="outline" className="w-full cursor-pointer text-foreground">
+                  Launch {actionButton.title}
+                </Button>
+              </Link>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx
+++ b/packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { Menu } from 'lucide-react'
+import { useState } from 'react'
+
+import type { NavItemData, NavbarActionButton } from './index'
+
+const MobileNavMenu = dynamic(() => import('./MobileNavMenu'), { ssr: false })
+
+interface MobileNavTriggerProps {
+  actionButton?: NavbarActionButton
+  navItems: NavItemData[]
+}
+
+export default function MobileNavTrigger({ actionButton, navItems }: MobileNavTriggerProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex md:hidden">
+      <button
+        type="button"
+        aria-controls="nifty-mobile-navigation"
+        aria-expanded={open}
+        aria-label={open ? 'Close navigation' : 'Open navigation'}
+        className="inline-flex size-10 cursor-pointer items-center justify-center rounded-md text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+        onClick={() => setOpen(true)}
+      >
+        <Menu aria-hidden="true" className="size-7" />
+      </button>
+      {open ? (
+        <MobileNavMenu
+          actionButton={actionButton}
+          navItems={navItems}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { NavigationMenu } from '@nl/ui/base/navigation-menu'
 import { useScrollDetection } from '@nl/ui/hooks/useScrollDetection'
 import { cn } from '@nl/ui/utils'
 
@@ -8,14 +7,13 @@ export default function NavbarScrollFrame({
   children,
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenu>) {
+}: React.ComponentPropsWithoutRef<'header'>) {
   const { ref: scrollSentinelRef, isIntersecting } = useScrollDetection()
 
   return (
     <>
-      <div ref={scrollSentinelRef} className="absolute inset-x-0 top-0 h-px" />
-      <NavigationMenu
-        viewport={false}
+      <div ref={scrollSentinelRef} aria-hidden="true" className="absolute inset-x-0 top-0 h-px" />
+      <header
         {...props}
         className={cn(
           'fixed inset-x-0 top-0 z-50 h-20 transition-all duration-500',
@@ -24,7 +22,7 @@ export default function NavbarScrollFrame({
         )}
       >
         {children}
-      </NavigationMenu>
+      </header>
     </>
   )
 }

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -2,70 +2,51 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Fragment } from 'react'
 
-import { Button } from '@nl/ui/base/button'
-import { Icon } from '@nl/ui/base/icon'
-import { Separator } from '@nl/ui/base/separator'
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from '@nl/ui/base/navigation-menu'
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@nl/ui/base/sheet'
-import { ActiveNavLink } from './ActiveNavLink'
+import { ExternalIcon } from '@nl/ui/custom/external-icon'
+import { cn } from '@nl/ui/utils'
+
+import ActiveNavLink from './ActiveNavLink'
+import MobileNavTrigger from './MobileNavTrigger'
 import NavbarScrollFrame from './NavbarScrollFrame'
 
-interface Page {
+export interface NavPage {
   title: string
   href: string
   description?: string
   external?: boolean
 }
 
-interface SingleMenuItemData extends Page {
+interface SingleMenuItemData extends NavPage {
   type: 'single'
 }
 
 interface GroupedMenuItemData {
   type: 'group'
-  group: string // The main title for the group (e.g., "Products")
-  pages: Page[] // The sub-pages within this group
+  group: string
+  pages: NavPage[]
 }
 
 export type NavItemData = SingleMenuItemData | GroupedMenuItemData
+export type NavbarActionButton = Omit<NavPage, 'description'>
 
-interface NavbarProps {
-  actionButton?: Omit<Page, 'description'>
+export interface NavbarProps {
+  actionButton?: NavbarActionButton
   navItems: NavItemData[]
+  className?: string
 }
 
-/* ==============================|| DESKTOP NAV ||============================== */
+const DESKTOP_LINK_CLASS =
+  'inline-flex h-9 w-max items-center justify-center rounded-md bg-transparent px-3 py-2 text-lg font-bold uppercase outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none'
 
-function ListItem({
-  description,
-  external,
-  href,
-  title,
-  ...props
-}: React.ComponentPropsWithoutRef<'li'> & Page) {
+function ListItem({ page }: { page: NavPage }) {
   return (
-    <li {...props}>
+    <li>
       <ActiveNavLink
         className="text-base font-medium"
-        description={description}
-        external={external}
-        href={href}
-        title={title}
+        description={page.description}
+        external={page.external}
+        href={page.href}
+        title={page.title}
       />
     </li>
   )
@@ -73,141 +54,75 @@ function ListItem({
 
 function DropdownMenuItem({ group, pages }: GroupedMenuItemData) {
   return (
-    <NavigationMenuItem value={group.toLowerCase()}>
-      <NavigationMenuTrigger>{group}</NavigationMenuTrigger>
-      <NavigationMenuContent>
-        <ul className="flex flex-col w-[300px] max-w-max">
-          {pages.map((page) => (
-            <ListItem key={page.title} {...page} />
-          ))}
-        </ul>
-      </NavigationMenuContent>
-    </NavigationMenuItem>
-  )
-}
-
-function SingleMenuItem({ type, ...page }: SingleMenuItemData) {
-  return (
-    <NavigationMenuItem value={page.title.toLowerCase()}>
-      <ActiveNavLink className={navigationMenuTriggerStyle()} {...page} />
-    </NavigationMenuItem>
-  )
-}
-
-function DesktopNavMenu({
-  actionButton,
-  navItems,
-  ...props
-}: React.ComponentProps<typeof NavigationMenuList> & NavbarProps) {
-  return (
-    <NavigationMenuList className="hidden md:flex" {...props}>
-      {navItems.map((item) => (
-        <Fragment key={item.type === 'single' ? item.title : item.group}>
-          {item.type === 'single' && <SingleMenuItem {...item} />}
-          {item.type === 'group' && <DropdownMenuItem {...item} />}
-        </Fragment>
-      ))}
-      {actionButton && (
-        <a
-          href={actionButton.href}
-          target={actionButton.external ? '_blank' : undefined}
-          rel={actionButton.external ? 'noreferrer' : undefined}
-          className="theme-btn-primary theme-btn-rounded max-w-fit ml-3"
+    <li>
+      <details className="group relative">
+        <summary
+          className={cn(
+            DESKTOP_LINK_CLASS,
+            'cursor-pointer list-none [&::-webkit-details-marker]:hidden'
+          )}
         >
-          {actionButton.title}
-        </a>
-      )}
-    </NavigationMenuList>
+          {group}
+          <span
+            aria-hidden="true"
+            className="ml-1 inline-block text-sm transition-transform group-open:rotate-180"
+          >
+            ▾
+          </span>
+        </summary>
+        <div className="absolute top-full left-1/2 z-50 mt-1.5 -translate-x-1/2 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow">
+          <ul className="flex w-[300px] max-w-max flex-col p-2">
+            {pages.map((page) => (
+              <ListItem key={page.title} page={page} />
+            ))}
+          </ul>
+        </div>
+      </details>
+    </li>
   )
 }
 
-/* ==============================|| MOBILE NAV ||=============================== */
-
-function MobileMenuGroup({ group, pages }: GroupedMenuItemData) {
+function SingleMenuItem({ type: _type, ...page }: SingleMenuItemData) {
   return (
-    <NavigationMenuItem value={group.toLowerCase()} className="w-full">
-      <h3 className="text-base text-muted-foreground uppercase tracking-wider">{group}</h3>
-      <ul className="flex flex-col w-full">
-        {pages.map((page) => (
-          <li key={page.title}>
-            <SheetClose asChild>
-              <ActiveNavLink className="text-base font-medium" {...page} />
-            </SheetClose>
-          </li>
+    <li>
+      <ActiveNavLink className={DESKTOP_LINK_CLASS} {...page} />
+    </li>
+  )
+}
+
+function DesktopNavMenu({ actionButton, navItems }: NavbarProps) {
+  return (
+    <nav aria-label="Primary navigation" className="hidden md:block">
+      <ul className="flex list-none items-center justify-center gap-1">
+        {navItems.map((item) => (
+          <Fragment key={item.type === 'single' ? item.title : item.group}>
+            {item.type === 'single' ? <SingleMenuItem {...item} /> : <DropdownMenuItem {...item} />}
+          </Fragment>
         ))}
+        {actionButton && (
+          <li>
+            <Link
+              href={actionButton.href}
+              target={actionButton.external ? '_blank' : undefined}
+              rel={actionButton.external ? 'noreferrer' : undefined}
+              className="theme-btn-primary theme-btn-rounded ml-3 max-w-fit"
+            >
+              {actionButton.title}
+            </Link>
+          </li>
+        )}
       </ul>
-    </NavigationMenuItem>
+    </nav>
   )
 }
 
-function MobileMenuItem({ type, ...page }: SingleMenuItemData) {
-  return (
-    <NavigationMenuItem value={page.title.toLowerCase()} className="w-full">
-      <SheetClose asChild>
-        <ActiveNavLink className="text-base font-medium" {...page} />
-      </SheetClose>
-    </NavigationMenuItem>
+export function Navbar({ actionButton, navItems, className }: NavbarProps) {
+  const desktopNavItems = navItems.filter(
+    (item) => item.type === 'group' || (item.type === 'single' && item.title !== 'Home')
   )
-}
 
-function MobileNavMenu({
-  actionButton,
-  navItems,
-  ...props
-}: React.ComponentProps<typeof Sheet> & NavbarProps) {
   return (
-    <div className="flex md:hidden">
-      <Sheet {...props}>
-        <SheetTrigger asChild>
-          <Button variant="ghost" size="icon" className="size-10 cursor-pointer">
-            <span className="sr-only">Open Nav Menu</span>
-            <Icon name="menu" aria-hidden="true" className="text-foreground size-7" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent className="bg-popover">
-          <SheetHeader>
-            <SheetTitle className="hidden">Navigation</SheetTitle>
-            <SheetDescription className="hidden">Mobile Website Navigation Menu</SheetDescription>
-          </SheetHeader>
-          <div className="flex flex-col gap-6 px-8 pb-4 overflow-y-auto">
-            <NavigationMenuList className="flex flex-col gap-4" data-orientation="vertical">
-              {navItems.map((item) => (
-                <Fragment key={item.type === 'single' ? item.title : item.group}>
-                  {item.type === 'single' && <MobileMenuItem {...item} />}
-                  {item.type === 'group' && <MobileMenuGroup {...item} />}
-                </Fragment>
-              ))}
-            </NavigationMenuList>
-            {actionButton && (
-              <>
-                <Separator orientation="horizontal" className="px-8" />
-                <Link
-                  href={actionButton.href}
-                  target={actionButton.external ? '_blank' : undefined}
-                  rel={actionButton.external ? 'noreferrer' : undefined}
-                >
-                  <Button variant="outline" className="w-full text-foreground cursor-pointer">
-                    Launch {actionButton.title}
-                  </Button>
-                </Link>
-              </>
-            )}
-          </div>
-        </SheetContent>
-      </Sheet>
-    </div>
-  )
-}
-
-/* ================================|| NAVBAR ||================================= */
-
-export function Navbar({
-  actionButton,
-  navItems,
-  ...props
-}: React.ComponentProps<typeof NavigationMenu> & NavbarProps) {
-  return (
-    <NavbarScrollFrame {...props}>
+    <NavbarScrollFrame className={className}>
       <div className="flex h-full w-screen items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex-shrink-0">
           <Image
@@ -220,14 +135,8 @@ export function Navbar({
           />
         </Link>
 
-        <DesktopNavMenu
-          actionButton={actionButton}
-          navItems={navItems.filter(
-            (item) => item.type === 'group' || (item.type === 'single' && item?.title !== 'Home')
-          )}
-        />
-
-        <MobileNavMenu actionButton={actionButton} navItems={navItems} />
+        <DesktopNavMenu actionButton={actionButton} navItems={desktopNavItems} />
+        <MobileNavTrigger actionButton={actionButton} navItems={navItems} />
       </div>
     </NavbarScrollFrame>
   )

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -169,6 +169,8 @@ const sharedDeferredSection = 'packages/ui/src/components/custom/deferred-sectio
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
+const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
+const sharedWebMobileTrigger = 'packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx'
 const webCommunityPage = 'apps/web/src/app/(main)/community/page.tsx'
 const webTeamPage = 'apps/web/src/app/(main)/team/page.tsx'
 const webCarousel = 'apps/web/src/components/Carousel/index.tsx'
@@ -801,13 +803,23 @@ describe('web public navigation contract', () => {
   it('keeps static navigation configuration out of the client graph', () => {
     const navbarSource = readFileSync(join(process.cwd(), webNavbar), 'utf8')
     const sharedNavbarSource = readFileSync(join(process.cwd(), sharedWebNavbar), 'utf8')
+    const mobileTriggerSource = readFileSync(join(process.cwd(), sharedWebMobileTrigger), 'utf8')
+    const mobileNavbarSource = readFileSync(join(process.cwd(), sharedWebMobileNavbar), 'utf8')
 
     expect(navbarSource).not.toContain("'use client'")
     expect(navbarSource).toContain("from '@nl/ui/custom/navbar'")
     expect(sharedNavbarSource).toContain("import NavbarScrollFrame from './NavbarScrollFrame'")
-    expect(sharedNavbarSource).toContain("import { ActiveNavLink } from './ActiveNavLink'")
-    expect(sharedNavbarSource).toContain('NavigationMenu')
-    expect(sharedNavbarSource).toContain('Sheet')
+    expect(sharedNavbarSource).toContain("import ActiveNavLink from './ActiveNavLink'")
+    expect(sharedNavbarSource).toContain('<details')
+    expect(sharedNavbarSource).not.toContain("from '@nl/ui/base/navigation-menu'")
+    expect(sharedNavbarSource).not.toContain("from '@nl/ui/base/sheet'")
+    expect(mobileTriggerSource).toContain("import('./MobileNavMenu')")
+    expect(mobileTriggerSource).toContain('ssr: false')
+    expect(mobileTriggerSource).toContain('aria-controls="nifty-mobile-navigation"')
+    expect(mobileNavbarSource).toContain("from '@nl/ui/base/sheet'")
+    expect(mobileNavbarSource).toContain('<SheetTitle')
+    expect(mobileNavbarSource).toContain('<SheetDescription')
+    expect(mobileNavbarSource).toContain('id="nifty-mobile-navigation"')
   })
 })
 


### PR DESCRIPTION
## Summary
- server-render the shared desktop navbar with semantic links and native disclosure menus
- defer the shadcn mobile Sheet until the mobile navigation is opened
- avoid pulling the full shared icon registry into the public web route graph
- preserve theme classes, active-link state, keyboard access, and accessible Sheet labels

## Measured impact
From the generated web route bundle report:
- `/`: 664,089 -> 566,361 bytes (-14.7%)
- standard marketing routes: approximately 637,913 -> 555,073 bytes (-13.0%)
- `/gltf/[tokenId]`: 672,069 -> 589,068 bytes (-12.3%)

## Validation
- `bun run test:unit` — 873 pass, 6 skipped live API tests, 0 fail
- UI package lint, type-check, and tests — pass (137 tests)
- web/app/smashers type-check — pass
- web lint — pass
- web/app/smashers production builds — pass
- fresh desktop/mobile browser smoke — pass; mobile drawer has accessible dialog title/description and no fresh console errors

This is intentionally a draft so hosted CI/Vercel spend remains deferred until the milestone is ready for review. The branch targets `staging`.
