### PR TITLE
perf(smashers): code split profile route

### DIFF
--- a/apps/smashers/src/app/(auth_routes)/profile/ProfileRoute.tsx
+++ b/apps/smashers/src/app/(auth_routes)/profile/ProfileRoute.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+import type { User } from '@nl/playfab/types'
+
+type SessionData = {
+  user: User
+}
+
+const ProfileClient = dynamic(() => import('./ProfileClient'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-screen items-center justify-center p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading profile</span>
+      <Skeleton aria-hidden="true" className="h-[28rem] w-full max-w-[800px] rounded-xl" />
+    </div>
+  ),
+})
+
+export default function ProfileRoute({ sessionData }: { sessionData: SessionData }) {
+  return <ProfileClient sessionData={sessionData} />
+}

--- a/apps/smashers/src/app/(auth_routes)/profile/page.tsx
+++ b/apps/smashers/src/app/(auth_routes)/profile/page.tsx
@@ -1,8 +1,6 @@
-import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { getSession } from '@/utils/session'
-import { Loading } from '@nl/ui/custom/loading'
-import ProfileClient from './ProfileClient'
+import ProfileRoute from './ProfileRoute'
 
 export default async function ProfilePage() {
   const session = await getSession()
@@ -18,9 +16,5 @@ export default async function ProfilePage() {
     // Add any other necessary session data here, but avoid methods
   }
 
-  return (
-    <Suspense fallback={<Loading />}>
-      <ProfileClient sessionData={sessionData} />
-    </Suspense>
-  )
+  return <ProfileRoute sessionData={sessionData} />
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -146,6 +146,8 @@ const graphQL = 'apps/app/src/hooks/useGraphQL.ts'
 const publicCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const interactivePublicCarousel = 'apps/web/src/components/Carousel/InteractiveCarousel.tsx'
 const smashersLoginClient = 'apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx'
+const smashersProfilePage = 'apps/smashers/src/app/(auth_routes)/profile/page.tsx'
+const smashersProfileRoute = 'apps/smashers/src/app/(auth_routes)/profile/ProfileRoute.tsx'
 const smashersRootLayout = 'apps/smashers/src/app/layout.tsx'
 const smashersAuthLayout = 'apps/smashers/src/app/(auth_routes)/layout.tsx'
 const staleSmashersUnityDialog = 'apps/smashers/src/components/UnityDialog/index.tsx'
@@ -267,6 +269,24 @@ describe('Smashers public shell contract', () => {
     expect(rootLayoutSource).not.toContain('FeatureFlagProvider')
     expect(authLayoutSource).toContain('FeatureFlagProvider')
     expect(existsSync(join(process.cwd(), staleSmashersUnityDialog))).toBe(false)
+  })
+})
+
+describe('Smashers profile loading contract', () => {
+  it('keeps the interactive profile graph behind an accessible route boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), smashersProfilePage), 'utf8')
+    const routeSource = readFileSync(join(process.cwd(), smashersProfileRoute), 'utf8')
+
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './ProfileRoute'")
+    expect(pageSource).toContain('getSession')
+    expect(pageSource).toContain("redirect('/login')")
+    expect(routeSource).toContain("dynamic(() => import('./ProfileClient')")
+    expect(routeSource).toContain('ssr: false')
+    expect(routeSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(routeSource).toContain('role="status"')
+    expect(routeSource).toContain('aria-live="polite"')
+    expect(routeSource).toContain('aria-busy="true"')
   })
 })
 


### PR DESCRIPTION
## Summary
- keep Smashers profile authentication and anonymous redirect on the server
- move the interactive ProfileClient behind a client-only dynamic boundary
- use the shared shadcn Skeleton with accessible loading status semantics

## Measured impact
- Smashers `/profile` route bundle: 701,727 -> 621,840 bytes
- reduction: 79,887 bytes (11.4%)

## Validation
- `bun test test/contract/route-surface.test.ts` (131 passed)
- `bun --filter smashers type-check`
- `bun --filter smashers test` (15 passed)
- `bun --filter smashers build`
- Prettier check and `git diff --check`
- local runtime smoke verified `/login` theme and `/profile` anonymous redirect marker

Targets `staging`. Ready to promote after local validation and the reduced ready-PR checks pass.