### PR TITLE
perf(smashers): code split login route

### DIFF
--- a/apps/smashers/src/app/(auth_routes)/login/LoginRoute.tsx
+++ b/apps/smashers/src/app/(auth_routes)/login/LoginRoute.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { User } from '@nl/playfab/types'
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+const LoginClient = dynamic(() => import('./LoginClient'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-screen w-full items-center justify-center px-4"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Skeleton aria-hidden="true" className="h-[30rem] w-full max-w-[600px]" />
+      <span className="sr-only">Loading sign-in form</span>
+    </div>
+  ),
+})
+
+interface SessionData {
+  user: User | null
+}
+
+export default function LoginRoute({ sessionData }: { sessionData: SessionData }) {
+  return <LoginClient sessionData={sessionData} />
+}

--- a/apps/smashers/src/app/(auth_routes)/login/page.tsx
+++ b/apps/smashers/src/app/(auth_routes)/login/page.tsx
@@ -1,8 +1,6 @@
-import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { getSession } from '@/utils/session'
-import { Loading } from '@nl/ui/custom/loading'
-import LoginClient from './LoginClient'
+import LoginRoute from './LoginRoute'
 
 export default async function LoginPage() {
   const session = await getSession()
@@ -18,9 +16,5 @@ export default async function LoginPage() {
     // Add any other necessary session data here, but avoid methods
   }
 
-  return (
-    <Suspense fallback={<Loading />}>
-      <LoginClient sessionData={sessionData} />
-    </Suspense>
-  )
+  return <LoginRoute sessionData={sessionData} />
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -146,6 +146,8 @@ const graphQL = 'apps/app/src/hooks/useGraphQL.ts'
 const publicCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const interactivePublicCarousel = 'apps/web/src/components/Carousel/InteractiveCarousel.tsx'
 const smashersLoginClient = 'apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx'
+const smashersLoginPage = 'apps/smashers/src/app/(auth_routes)/login/page.tsx'
+const smashersLoginRoute = 'apps/smashers/src/app/(auth_routes)/login/LoginRoute.tsx'
 const smashersProfilePage = 'apps/smashers/src/app/(auth_routes)/profile/page.tsx'
 const smashersProfileRoute = 'apps/smashers/src/app/(auth_routes)/profile/ProfileRoute.tsx'
 const smashersRootLayout = 'apps/smashers/src/app/layout.tsx'
@@ -282,6 +284,25 @@ describe('Smashers profile loading contract', () => {
     expect(pageSource).toContain('getSession')
     expect(pageSource).toContain("redirect('/login')")
     expect(routeSource).toContain("dynamic(() => import('./ProfileClient')")
+    expect(routeSource).toContain('ssr: false')
+    expect(routeSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(routeSource).toContain('role="status"')
+    expect(routeSource).toContain('aria-live="polite"')
+    expect(routeSource).toContain('aria-busy="true"')
+  })
+})
+
+describe('Smashers login loading contract', () => {
+  it('keeps the interactive login graph behind an accessible route boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), smashersLoginPage), 'utf8')
+    const routeSource = readFileSync(join(process.cwd(), smashersLoginRoute), 'utf8')
+
+    expect(pageSource).not.toContain("from '@nl/ui/custom/loading'")
+    expect(pageSource).not.toContain("from './LoginClient'")
+    expect(pageSource).toContain("from './LoginRoute'")
+    expect(pageSource).toContain('getSession')
+    expect(pageSource).toContain("redirect('/profile')")
+    expect(routeSource).toContain("dynamic(() => import('./LoginClient')")
     expect(routeSource).toContain('ssr: false')
     expect(routeSource).toContain("from '@nl/ui/base/skeleton'")
     expect(routeSource).toContain('role="status"')


### PR DESCRIPTION
## Summary
- keep Smashers login session checks and authenticated redirect on the server
- move the interactive LoginClient graph behind a client-only dynamic route boundary
- use the shared shadcn Skeleton with accessible loading status semantics

## Measured impact
- Smashers `/login` first-load JS: 663,948 -> 621,807 bytes
- reduction: 42,141 bytes (6.3%)

## Validation
- `bun test test/contract/route-surface.test.ts` (132 passed)
- `bun --filter smashers type-check`
- `bun --filter smashers test` (15 passed)
- `bun --filter smashers build`
- Prettier and `git diff --check`
- local runtime smoke: `/login` 200 with theme marker; anonymous `/profile` retained redirect marker

Targets `staging`. Ready to promote after local validation and the reduced ready-PR checks pass.