### PR TITLE
chore(ci): keep draft PRs out of hosted validation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -167,6 +167,7 @@ Keep pull requests focused and reviewable. Include screenshots or recordings for
 The single validation caller keys concurrency by event and pull-request head. A newer update to the same pull request cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
 
 Draft feature work is intentionally cost-aware: local validation is the feedback loop while a pull request is draft. Marking the pull request ready for review starts hosted validation. Vercel projects disable Git-triggered deployments on feature branches through the versioned `git.deploymentEnabled` policy in `apps/*/vercel.json` and continue on `staging` and `main`; manual deployments remain available.
+If a ready pull request is returned to draft, its in-flight hosted validation is cancelled and no replacement validation starts until it is ready again.
 
 Required checks are enforced by branch protection rulesets/branch protection. Do not duplicate their checklists in the pull request description; document validation commands and results instead.
 

--- a/.github/workflows/opencode-security.yml
+++ b/.github/workflows/opencode-security.yml
@@ -3,6 +3,12 @@ name: Code Foundry
 on:
   pull_request:
     branches: [main, staging]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - converted_to_draft
   schedule:
     - cron: '31 6 * * 1'
   workflow_dispatch:
@@ -16,8 +17,10 @@ on:
 # only the scopes their own validation path consumes.
 permissions: {}
 
-# Superseded PR updates cancel the previous run; schedule and dispatch runs
-# are keyed by event so periodic audits and manual runs stay independent.
+# Superseded PR updates cancel the previous run; converting a PR back to draft
+# also cancels any hosted validation that was already in progress. Schedule
+# and dispatch runs are keyed by event so periodic audits and manual runs stay
+# independent.
 concurrency:
   group: code-foundry-validation-${{ github.event_name }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true

--- a/test/contract/ci-cost-policy.test.ts
+++ b/test/contract/ci-cost-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const readWorkflow = (name: string) =>
+  readFileSync(join(process.cwd(), '.github/workflows', name), 'utf8')
+
+describe('hosted validation cost policy', () => {
+  it('runs validation for ready PRs and cancels it when a PR returns to draft', () => {
+    const source = readWorkflow('validation.yml')
+
+    expect(source).toContain('      - ready_for_review')
+    expect(source).toContain('      - converted_to_draft')
+    expect(source).toContain(
+      "if: github.event_name != 'pull_request' || github.event.pull_request.draft != true"
+    )
+    expect(source).toContain('cancel-in-progress: true')
+  })
+
+  it('keeps optional security scans off for drafts while supporting ready release PRs', () => {
+    const source = readWorkflow('opencode-security.yml')
+
+    expect(source).toContain('      - ready_for_review')
+    expect(source).toContain('      - converted_to_draft')
+    expect(source).toContain('github.event.pull_request.draft != true')
+    expect(source).toContain('startsWith(github.event.pull_request.head.ref')
+  })
+})


### PR DESCRIPTION
## Summary
- keep hosted validation and optional security scans off while a pull request is draft
- cancel in-flight hosted validation when a ready pull request is returned to draft
- keep Vercel Git deployments disabled for feature branches through the existing shared policy
- add contract coverage for the cost controls

## Validation
- `bun test test/contract/ci-cost-policy.test.ts test/contract/vercel-build-policy.test.ts`
- `actionlint .github/workflows/validation.yml .github/workflows/opencode-security.yml`
- `bunx prettier --check .github/workflows/validation.yml .github/workflows/opencode-security.yml test/contract/ci-cost-policy.test.ts`
- `git diff --check`
