### PR TITLE
perf: defer shared Sentry initialization and route loading

### DIFF
--- a/apps/app/src/app/global-error.tsx
+++ b/apps/app/src/app/global-error.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    captureException(error)
+    void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
+      captureException(error)
+    )
   }, [error])
 
   return (

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from 'react'
 import type { Metadata, Viewport } from 'next'
 import Script from 'next/script'
 
+import DeferredSentry from '@nl/sentry-client/react'
 import { DeferredAnalytics } from '@nl/ui/gtm'
 import { customFontClassName } from '@nl/ui/fonts'
 import { cn } from '@nl/ui/utils'
@@ -63,6 +64,15 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
       <DeferredAnalytics />
+      <DeferredSentry
+        enabled={process.env.VERCEL_ENV === 'production'}
+        options={{
+          dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
+          sendDefaultPii: true,
+          tracesSampleRate: 0.1,
+          debug: false,
+        }}
+      />
 
       <body suppressHydrationWarning>
         {children}

--- a/apps/app/src/app/loading.tsx
+++ b/apps/app/src/app/loading.tsx
@@ -1,1 +1,5 @@
-export { default } from '@nl/ui/custom/loading'
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+export default function Loading() {
+  return <RouteLoading label="Loading Nifty League" />
+}

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -2,13 +2,6 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
-
-scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
-  dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
-  sendDefaultPii: true,
-  tracesSampleRate: 0.1,
-  debug: false,
-})
+import { captureRouterTransitionStart } from '@nl/sentry-client/router-bridge'
 
 export const onRouterTransitionStart = captureRouterTransitionStart

--- a/apps/smashers/src/app/global-error.tsx
+++ b/apps/smashers/src/app/global-error.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    captureException(error)
+    void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
+      captureException(error)
+    )
   }, [error])
 
   return (

--- a/apps/smashers/src/app/layout.tsx
+++ b/apps/smashers/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react'
 import type { Metadata, Viewport } from 'next'
 
+import DeferredSentry from '@nl/sentry-client/react'
 import { DeferredAnalytics } from '@nl/ui/gtm'
 import { customFontClassName } from '@nl/ui/fonts'
 import { cn } from '@nl/ui/utils'
@@ -77,6 +78,15 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
       <DeferredAnalytics />
+      <DeferredSentry
+        enabled={process.env.VERCEL_ENV === 'production'}
+        options={{
+          dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
+          sendDefaultPii: true,
+          tracesSampleRate: 0.1,
+          debug: false,
+        }}
+      />
 
       <body suppressHydrationWarning>{children}</body>
     </html>

--- a/apps/smashers/src/app/loading.tsx
+++ b/apps/smashers/src/app/loading.tsx
@@ -1,1 +1,5 @@
-export { default } from '@nl/ui/custom/loading'
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+export default function Loading() {
+  return <RouteLoading label="Loading Nifty Smashers" />
+}

--- a/apps/smashers/src/instrumentation-client.ts
+++ b/apps/smashers/src/instrumentation-client.ts
@@ -2,13 +2,6 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
-
-scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
-  dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
-  sendDefaultPii: true,
-  tracesSampleRate: 0.1,
-  debug: false,
-})
+import { captureRouterTransitionStart } from '@nl/sentry-client/router-bridge'
 
 export const onRouterTransitionStart = captureRouterTransitionStart

--- a/apps/web/src/app/(main)/loading.tsx
+++ b/apps/web/src/app/(main)/loading.tsx
@@ -1,1 +1,5 @@
-export { default } from '@nl/ui/custom/loading'
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+export default function Loading() {
+  return <RouteLoading label="Loading Nifty League" />
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { captureException } from '@nl/sentry-client/client'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    captureException(error)
+    void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
+      captureException(error)
+    )
   }, [error])
 
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react'
 import type { Metadata, Viewport } from 'next'
 
+import DeferredSentry from '@nl/sentry-client/react'
 import { customFontClassName } from '@nl/ui/fonts'
 import { cn } from '@nl/ui/utils'
 
@@ -59,6 +60,15 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
+      <DeferredSentry
+        enabled={process.env.VERCEL_ENV === 'production'}
+        options={{
+          dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
+          sendDefaultPii: true,
+          tracesSampleRate: 0.1,
+          debug: false,
+        }}
+      />
       <body suppressHydrationWarning>{children}</body>
     </html>
   )

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -2,13 +2,6 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { captureRouterTransitionStart, scheduleSentryInit } from '@nl/sentry-client/client'
-
-scheduleSentryInit(process.env.VERCEL_ENV === 'production', {
-  dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
-  sendDefaultPii: true,
-  tracesSampleRate: 0.1,
-  debug: false,
-})
+import { captureRouterTransitionStart } from '@nl/sentry-client/router-bridge'
 
 export const onRouterTransitionStart = captureRouterTransitionStart

--- a/bun.lock
+++ b/bun.lock
@@ -285,6 +285,9 @@
       "devDependencies": {
         "@types/react": "19.2.18",
       },
+      "peerDependencies": {
+        "react": "19.2.8",
+      },
     },
     "packages/typescript-config": {
       "name": "@nl/typescript-config",

--- a/bun.lock
+++ b/bun.lock
@@ -8,29 +8,29 @@
         "@axelar-network/axelarjs-sdk": "^0.21.0",
         "@cowprotocol/cow-sdk": "^9.2.6",
         "@google/model-viewer": "^4.3.1",
-        "@imtbl/sdk": "^2.24.4",
-        "@types/three": "^0.185.3",
-        "lucide-react": "^1.28.0",
-        "react-hook-form": "^7.84.0",
+        "@imtbl/sdk": "^2.24.6",
+        "@types/three": "^0.185.4",
+        "lucide-react": "^1.31.0",
+        "react-hook-form": "^7.85.0",
         "react-unity-webgl": "~10.2.0",
         "sharp": "^0.35.3",
         "three": "^0.185.1",
-        "wagmi": "^3.7.5",
+        "wagmi": "^3.7.6",
       },
       "devDependencies": {
-        "@happy-dom/global-registrator": "^20.11.1",
+        "@happy-dom/global-registrator": "^20.11.2",
         "@nl/eslint-config": "workspace:*",
         "@nl/prettier-config": "workspace:*",
         "@nl/typescript-config": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^26.1.2",
-        "eslint": "^10.8.0",
+        "@testing-library/user-event": "^14.6.3",
+        "@types/node": "^26.2.0",
+        "eslint": "^10.8.1",
         "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "semver": "^7.8.5",
-        "syncpack": "^15.3.2",
+        "syncpack": "^15.3.3",
         "turbo": "^2.10.9",
         "typescript": "~6.0.3",
       },
@@ -80,7 +80,7 @@
     },
     "apps/app": {
       "name": "app",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "^0.21.0",
         "@cowprotocol/cow-sdk": "^9.2.6",
@@ -156,7 +156,7 @@
     },
     "apps/smashers": {
       "name": "smashers",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@nl/playfab": "workspace:*",
         "@nl/sentry-client": "workspace:*",
@@ -181,7 +181,7 @@
     },
     "apps/template": {
       "name": "template",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@nl/ui": "workspace:*",
         "next": "16.3.0",
@@ -196,7 +196,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@google/model-viewer": "^4.3.1",
         "@nl/sentry-client": "workspace:*",
@@ -281,6 +281,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@sentry/nextjs": "^10.69.0",
+      },
+      "devDependencies": {
+        "@types/react": "19.2.18",
       },
     },
     "packages/typescript-config": {

--- a/packages/sentry-client/package.json
+++ b/packages/sentry-client/package.json
@@ -6,13 +6,19 @@
   "private": true,
   "main": "./src/client.ts",
   "exports": {
-    "./client": "./src/client.ts"
+    "./bootstrap": "./src/bootstrap.ts",
+    "./client": "./src/client.ts",
+    "./react": "./src/react.tsx",
+    "./router-bridge": "./src/router-bridge.ts"
   },
   "scripts": {
     "format": "prettier --write \"**/*.{js,ts,tsx,md,mdx,json}\" --ignore-path ../../.gitignore",
     "lint": "eslint . --max-warnings 0",
     "test": "bun test --isolate --preload ../../test/happy-dom-setup.ts --preload ../../test/preload.ts --preload ../../test/setup.ts --pass-with-no-tests",
     "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.18"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.69.0"

--- a/packages/sentry-client/package.json
+++ b/packages/sentry-client/package.json
@@ -22,5 +22,8 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^10.69.0"
+  },
+  "peerDependencies": {
+    "react": "19.2.8"
   }
 }

--- a/packages/sentry-client/src/bootstrap.ts
+++ b/packages/sentry-client/src/bootstrap.ts
@@ -1,0 +1,55 @@
+type ClientModule = typeof import('./client')
+type SentryInitOptions = Parameters<(typeof import('@sentry/nextjs'))['init']>[0]
+
+import { registerRouterTransitionCapture, type RouterTransitionArgs } from './router-bridge'
+
+let clientModulePromise: Promise<ClientModule> | undefined
+let routerCaptureRegistered = false
+
+const loadClient = (): Promise<ClientModule> => {
+  clientModulePromise ??= import('./client')
+  return clientModulePromise
+}
+
+const reportClientLoadError = (error: unknown): void => {
+  console.error('Failed to load deferred Sentry client', error)
+}
+
+export function scheduleSentryInit(enabled: boolean, options: SentryInitOptions): void {
+  if (!enabled || typeof window === 'undefined') return
+
+  if (!routerCaptureRegistered) {
+    routerCaptureRegistered = true
+    registerRouterTransitionCapture((...args: RouterTransitionArgs) => {
+      void loadClient()
+        .then(({ captureRouterTransitionStart }) => captureRouterTransitionStart(...args))
+        .catch(reportClientLoadError)
+    })
+  }
+
+  const initialize = () => {
+    void loadClient()
+      .then(({ initializeSentry }) => initializeSentry(options))
+      .catch(reportClientLoadError)
+  }
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(initialize, { timeout: 2000 })
+  } else {
+    globalThis.setTimeout(initialize, 0)
+  }
+}
+
+export function captureException(error: unknown): void {
+  void loadClient()
+    .then(({ captureException: capture }) => capture(error))
+    .catch(reportClientLoadError)
+}
+
+export function captureRouterTransitionStart(...args: RouterTransitionArgs): void {
+  if (typeof window === 'undefined' || process.env.VERCEL_ENV !== 'production') return
+
+  void loadClient()
+    .then(({ captureRouterTransitionStart: capture }) => capture(...args))
+    .catch(reportClientLoadError)
+}

--- a/packages/sentry-client/src/client.ts
+++ b/packages/sentry-client/src/client.ts
@@ -15,7 +15,7 @@ const reportSentryLoadError = (error: unknown): void => {
   console.error('Failed to load Sentry client SDK', error)
 }
 
-function initializeSentry(options: SentryInitOptions): Promise<SentryModule> {
+export function initializeSentry(options: SentryInitOptions): Promise<SentryModule> {
   const initOptions = (sentryInitOptions ??= options)
   sentryInitPromise ??= loadSentry().then((sentry) => {
     sentry.init(initOptions)
@@ -26,20 +26,6 @@ function initializeSentry(options: SentryInitOptions): Promise<SentryModule> {
 
 function getSentryForCapture(): Promise<SentryModule> {
   return sentryInitOptions ? initializeSentry(sentryInitOptions) : loadSentry()
-}
-
-export function scheduleSentryInit(enabled: boolean, options: SentryInitOptions): void {
-  if (!enabled || typeof window === 'undefined') return
-
-  const initialize = () => {
-    void initializeSentry(options).catch(reportSentryLoadError)
-  }
-
-  if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(initialize, { timeout: 2000 })
-  } else {
-    globalThis.setTimeout(initialize, 0)
-  }
 }
 
 export function captureException(error: unknown): void {

--- a/packages/sentry-client/src/react.tsx
+++ b/packages/sentry-client/src/react.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type SentryInitOptions = Parameters<(typeof import('@sentry/nextjs'))['init']>[0]
+
+interface DeferredSentryProps {
+  enabled: boolean
+  options: SentryInitOptions
+}
+
+export default function DeferredSentry({ enabled, options }: DeferredSentryProps) {
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+    void import('./bootstrap').then(({ scheduleSentryInit }) => {
+      if (!cancelled) scheduleSentryInit(true, options)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, options])
+
+  return null
+}

--- a/packages/sentry-client/src/router-bridge.ts
+++ b/packages/sentry-client/src/router-bridge.ts
@@ -1,0 +1,35 @@
+type SentryModule = typeof import('@sentry/nextjs')
+
+export type RouterTransitionArgs = Parameters<SentryModule['captureRouterTransitionStart']>
+type RouterTransitionCapture = (...args: RouterTransitionArgs) => void
+
+interface RouterTransitionBridge {
+  capture?: RouterTransitionCapture
+  queue?: RouterTransitionArgs[]
+}
+
+const bridge = globalThis as typeof globalThis & {
+  __nlSentryRouterTransitionBridge?: RouterTransitionBridge
+}
+
+const getBridge = (): RouterTransitionBridge => (bridge.__nlSentryRouterTransitionBridge ??= {})
+
+export function captureRouterTransitionStart(...args: RouterTransitionArgs): void {
+  if (process.env.VERCEL_ENV !== 'production') return
+
+  const state = getBridge()
+  if (state.capture) {
+    state.capture(...args)
+    return
+  }
+
+  ;(state.queue ??= []).push(args)
+}
+
+export function registerRouterTransitionCapture(capture: RouterTransitionCapture): void {
+  const state = getBridge()
+  state.capture = capture
+
+  for (const args of state.queue ?? []) capture(...args)
+  state.queue = []
+}

--- a/packages/sentry-client/tsconfig.json
+++ b/packages/sentry-client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@nl/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node"]
+    "types": ["node", "react"]
   },
   "include": ["."]
 }

--- a/packages/ui/src/components/custom/loading/index.tsx
+++ b/packages/ui/src/components/custom/loading/index.tsx
@@ -1,7 +1,0 @@
-import { PreloaderBase } from '../preloader/base'
-
-export function Loading({ ready = false }: { ready?: boolean }) {
-  return <PreloaderBase ready={ready} />
-}
-
-export default Loading

--- a/packages/ui/src/components/custom/route-loading/index.test.tsx
+++ b/packages/ui/src/components/custom/route-loading/index.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import RouteLoading from './index'
+
+describe('RouteLoading', () => {
+  it('renders a themed, accessible loading boundary', () => {
+    const { container } = render(<RouteLoading label="Loading Nifty League" />)
+    const status = screen.getByRole('status')
+
+    expect(status.getAttribute('aria-live')).toBe('polite')
+    expect(status.getAttribute('aria-busy')).toBe('true')
+    expect(screen.getByText('Loading Nifty League')).toBeTruthy()
+    expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy()
+  })
+})

--- a/packages/ui/src/components/custom/route-loading/index.tsx
+++ b/packages/ui/src/components/custom/route-loading/index.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+interface RouteLoadingProps {
+  label?: string
+}
+
+export function RouteLoading({ label = 'Loading page' }: RouteLoadingProps) {
+  return (
+    <div
+      className="flex min-h-screen w-full items-center justify-center bg-background px-4 text-foreground"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="flex w-full max-w-3xl flex-col gap-4">
+        <Skeleton aria-hidden="true" className="h-8 w-48" />
+        <Skeleton aria-hidden="true" className="h-64 w-full" />
+      </div>
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}
+
+export default RouteLoading

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -171,6 +171,12 @@ const deferredConsoleGameRoutes = [
   'apps/smashers/src/app/page.tsx',
 ]
 const sharedDeferredSection = 'packages/ui/src/components/custom/deferred-section/index.tsx'
+const sharedRouteLoading = 'packages/ui/src/components/custom/route-loading/index.tsx'
+const routeLoadingFiles = [
+  'apps/app/src/app/loading.tsx',
+  'apps/web/src/app/(main)/loading.tsx',
+  'apps/smashers/src/app/loading.tsx',
+]
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
@@ -260,6 +266,28 @@ describe('shared notification loading contract', () => {
     expect(deferredSource).toContain("import('@/components/extended/Snackbar')")
     expect(deferredSource).toContain("import('@nl/ui/base/sonner')")
     expect(deferredSource).toContain('Promise.all')
+  })
+})
+
+describe('shared route loading contract', () => {
+  it('uses the themed shadcn skeleton boundary for every Next app', () => {
+    const sharedSource = readFileSync(join(process.cwd(), sharedRouteLoading), 'utf8')
+
+    expect(sharedSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(sharedSource).toContain('role="status"')
+    expect(sharedSource).toContain('aria-live="polite"')
+    expect(sharedSource).toContain('aria-busy="true"')
+    expect(sharedSource).toContain('bg-background')
+
+    for (const file of routeLoadingFiles) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source).toContain("from '@nl/ui/custom/route-loading'")
+      expect(source).not.toContain("from '@nl/ui/custom/loading'")
+    }
+
+    expect(
+      existsSync(join(process.cwd(), 'packages/ui/src/components/custom/loading/index.tsx'))
+    ).toBe(false)
   })
 })
 
@@ -932,14 +960,30 @@ describe('deferred Sentry client contract', () => {
       const source = readFileSync(join(process.cwd(), file), 'utf8')
 
       expect(source).not.toContain("from '@sentry/nextjs'")
-      expect(source).toContain('@nl/sentry-client/client')
+      if (file.endsWith('instrumentation-client.ts')) {
+        expect(source).toContain('@nl/sentry-client/router-bridge')
+        expect(source).not.toContain('@nl/sentry-client/bootstrap')
+      } else {
+        expect(source).toContain("import('@nl/sentry-client/bootstrap')")
+      }
     })
   }
 
   it('keeps the shared Sentry loader dynamic', () => {
     const source = readFileSync(join(process.cwd(), 'packages/sentry-client/src/client.ts'), 'utf8')
+    const bootstrap = readFileSync(
+      join(process.cwd(), 'packages/sentry-client/src/bootstrap.ts'),
+      'utf8'
+    )
+    const routerBridge = readFileSync(
+      join(process.cwd(), 'packages/sentry-client/src/router-bridge.ts'),
+      'utf8'
+    )
 
     expect(source).toContain("import('@sentry/nextjs')")
+    expect(bootstrap).toContain("import('./client')")
+    expect(bootstrap).not.toContain("from '@sentry/nextjs'")
+    expect(routerBridge).not.toContain("from '@sentry/nextjs'")
   })
 })
 


### PR DESCRIPTION
## Summary
- defer the Sentry SDK behind one shared idle-loaded client boundary across app, web, and Smashers
- preserve route-transition capture through a lightweight bridge without statically importing Sentry
- share one accessible, themed shadcn route-loading boundary and remove the stale wrapper

## Validation
- `bun test test/contract/route-surface.test.ts test/contract/ci-cost-policy.test.ts test/contract/vercel-build-policy.test.ts` (141 pass)
- `bun test packages/ui/src/components/custom/route-loading/index.test.tsx` (1 pass)
- `bun run --cwd packages/sentry-client type-check`
- `bun run --cwd packages/ui type-check`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app build`
- `bun run --cwd apps/web build`
- `bun run --cwd apps/smashers build`
- `bunx prettier --check ...`
- `git diff --check`
