### PR TITLE
perf(web): keep static legal pages server-rendered

### DIFF
--- a/apps/web/src/app/(main)/disclaimer/page.tsx
+++ b/apps/web/src/app/(main)/disclaimer/page.tsx
@@ -1,127 +1,91 @@
 import type { NextPage } from 'next'
 import Definitions from '@/components/Definitions'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 
 const Disclaimer: NextPage = () => (
   <div className="container pt-30 mb-20">
     <div className="mb-3 mb-md-5">
-      <AnimatedWrapper>
-        <h1 className="text-center transition-fade-slow transition-fade-start delay-lite">
-          DISCLAIMER
-        </h1>
-      </AnimatedWrapper>
+      <h1 className="text-center">DISCLAIMER</h1>
     </div>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Effective date: <strong>January 19th, 2022</strong>
-      </p>
-    </AnimatedWrapper>
+    <p>
+      Effective date: <strong>January 19th, 2022</strong>
+    </p>
     <Definitions />
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Rights and Conditions
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The content contained in this Site does not constitute an offer or sale of securities in or
-        into the United States, or to or for the account or benefit of U.S. persons, or in any other
-        jurisdictions where it is unlawful to do so.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Using a Smart Contract on the Blockchain requires a high degree of technical skills and is
-        therefore associated with a high risk. Obtaining and holding an NFT-Token represents
-        ownership of a piece of digital artwork only. Accordingly, no information on this Site (or
-        any other documents mentioned therein) is or may be considered to be advice or an invitation
-        to enter into an agreement for any investment purpose. Further, as NFT-Token represents
-        artwork, nothing on this Site qualifies or is intended to be an offering of securities in
-        any jurisdiction nor does it constitute an offer or an invitation to purchase shares,
-        securities or other financial product.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The NFTL governance and utility token is solely to be used for governance within the Nifty
-        DAO as well as for platform-wide expenses. Accordingly, no information on this Site (or any
-        other documents mentioned therein) is or may be considered to be advice or an invitation to
-        enter into an agreement for any investment purpose with Nifty League Inc.
-        (&quot;Company&quot;). By no means should NFTL token holders expect any income from our
-        team&apos;s contributions, gain from Company profits, or ownership of the Company in any
-        way. NFTL is not purchasable from our Company and will always and only be distributed
-        freely. Free distributions are not intended to be an offering of securities in any
-        jurisdiction nor does it constitute an offer or invitation for Company shares. Transfer of
-        NFTL tokens may be subject to legal restrictions under applicable laws. Under no
-        circumstances shall NFTL tokens be reoffered, resold or transferred within the United States
-        or to, or for the account or benefit of, U.S. persons, except pursuant to an exemption from,
-        or in a transaction not subject to, the registration requirements of the U.S. Securities Act
-        of 1933, as amended.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The information contained on this Site is not intended for individuals or entities who are
-        ordinarily resident in Austria or the United States of America nor for residents of a
-        geographic area that is subject to UN-, US-, EU- or Swiss sanctions or embargoes, including:
-        Afghanistan, Albania, Belarus, Bosnia &amp; Herzegovina, Burundi, Central African Republic,
-        Côte d&apos;Ivoire, Cuba, Democratic Republic of the Congo, Ethiopia, Guinea, Guinea-Bissau,
-        Iran, Iraq, Lebanon, Liberia, Libya, Myanmar (Burma), North Korea, Russia, Republic of
-        Macedonia, Serbia, Somalia, South Sudan, Sri Lanka, Sudan, Syria, Thailand, Trinidad &amp;
-        Tobago, Tunisia, Uganda, Ukraine, Vatican, Venezuela, Yemen, and Zimbabwe. By entering or
-        using the Site, you accept representation and warrant that you are not resident in those
-        countries. The company reserves the right to restrict the sale of the NFT-token in any
-        jurisdiction or to any individuals or entities at its discretion.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Warranties and Limitations
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Without limiting the foregoing, neither the Company nor any of the Company&apos;s provider
-        makes any representation or warranty of any kind, express or implied: (i) as to the
-        operation or availability of the Service, or the information, content, and materials or
-        products included thereon; (ii) that the Service will be uninterrupted or error-free; (iii)
-        as to the accuracy, reliability, or currency of any information or content provided through
-        the Service; or (iv) that the Service, its servers, the content, or e-mails sent from or on
-        behalf of the Company are free of viruses, scripts, trojan horses, worms, malware, timebombs
-        or other harmful components.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Some jurisdictions do not allow the exclusion of certain types of warranties or limitations
-        on applicable statutory rights of a consumer, so some or all of the above exclusions and
-        limitations may not apply to You. But in such a case the exclusions and limitations set
-        forth in this section shall be applied to the greatest extent enforceable under applicable
-        law.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        “AS IS” and “AS AVAILABLE”
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Service is provided to You &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; and with all
-        faults and defects without warranty of any kind. To the maximum extent permitted under
-        applicable law, the Company, on its own behalf and on behalf of its affiliates and their
-        respective licensors and service providers, expressly disclaims all warranties, whether
-        express, implied, statutory or otherwise, with respect to the Service, including all implied
-        warranties of merchantability, fitness for a particular purpose, title and non-infringement,
-        and warranties that may arise out of course of dealing, course of performance, usage or
-        trade practice. Without limitation to the foregoing, the Company provides no warranty or
-        undertaking, and makes no representation of any kind that the Service will meet Your
-        requirements, achieve any intended results, be compatible or work with any other software,
-        applications, systems or services, operate without interruption, meet any performance or
-        reliability standards or be error free or that any errors or defects can or will be
-        corrected.
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 my-md-5">Rights and Conditions</h5>
+    <p>
+      The content contained in this Site does not constitute an offer or sale of securities in or
+      into the United States, or to or for the account or benefit of U.S. persons, or in any other
+      jurisdictions where it is unlawful to do so.
+    </p>
+    <p>
+      Using a Smart Contract on the Blockchain requires a high degree of technical skills and is
+      therefore associated with a high risk. Obtaining and holding an NFT-Token represents ownership
+      of a piece of digital artwork only. Accordingly, no information on this Site (or any other
+      documents mentioned therein) is or may be considered to be advice or an invitation to enter
+      into an agreement for any investment purpose. Further, as NFT-Token represents artwork,
+      nothing on this Site qualifies or is intended to be an offering of securities in any
+      jurisdiction nor does it constitute an offer or an invitation to purchase shares, securities
+      or other financial product.
+    </p>
+    <p>
+      The NFTL governance and utility token is solely to be used for governance within the Nifty DAO
+      as well as for platform-wide expenses. Accordingly, no information on this Site (or any other
+      documents mentioned therein) is or may be considered to be advice or an invitation to enter
+      into an agreement for any investment purpose with Nifty League Inc. (&quot;Company&quot;). By
+      no means should NFTL token holders expect any income from our team&apos;s contributions, gain
+      from Company profits, or ownership of the Company in any way. NFTL is not purchasable from our
+      Company and will always and only be distributed freely. Free distributions are not intended to
+      be an offering of securities in any jurisdiction nor does it constitute an offer or invitation
+      for Company shares. Transfer of NFTL tokens may be subject to legal restrictions under
+      applicable laws. Under no circumstances shall NFTL tokens be reoffered, resold or transferred
+      within the United States or to, or for the account or benefit of, U.S. persons, except
+      pursuant to an exemption from, or in a transaction not subject to, the registration
+      requirements of the U.S. Securities Act of 1933, as amended.
+    </p>
+    <p>
+      The information contained on this Site is not intended for individuals or entities who are
+      ordinarily resident in Austria or the United States of America nor for residents of a
+      geographic area that is subject to UN-, US-, EU- or Swiss sanctions or embargoes, including:
+      Afghanistan, Albania, Belarus, Bosnia &amp; Herzegovina, Burundi, Central African Republic,
+      Côte d&apos;Ivoire, Cuba, Democratic Republic of the Congo, Ethiopia, Guinea, Guinea-Bissau,
+      Iran, Iraq, Lebanon, Liberia, Libya, Myanmar (Burma), North Korea, Russia, Republic of
+      Macedonia, Serbia, Somalia, South Sudan, Sri Lanka, Sudan, Syria, Thailand, Trinidad &amp;
+      Tobago, Tunisia, Uganda, Ukraine, Vatican, Venezuela, Yemen, and Zimbabwe. By entering or
+      using the Site, you accept representation and warrant that you are not resident in those
+      countries. The company reserves the right to restrict the sale of the NFT-token in any
+      jurisdiction or to any individuals or entities at its discretion.
+    </p>
+    <h5 className="my-3 my-md-5">Warranties and Limitations</h5>
+    <p>
+      Without limiting the foregoing, neither the Company nor any of the Company&apos;s provider
+      makes any representation or warranty of any kind, express or implied: (i) as to the operation
+      or availability of the Service, or the information, content, and materials or products
+      included thereon; (ii) that the Service will be uninterrupted or error-free; (iii) as to the
+      accuracy, reliability, or currency of any information or content provided through the Service;
+      or (iv) that the Service, its servers, the content, or e-mails sent from or on behalf of the
+      Company are free of viruses, scripts, trojan horses, worms, malware, timebombs or other
+      harmful components.
+    </p>
+    <p>
+      Some jurisdictions do not allow the exclusion of certain types of warranties or limitations on
+      applicable statutory rights of a consumer, so some or all of the above exclusions and
+      limitations may not apply to You. But in such a case the exclusions and limitations set forth
+      in this section shall be applied to the greatest extent enforceable under applicable law.
+    </p>
+    <h5 className="my-3 my-md-5">“AS IS” and “AS AVAILABLE”</h5>
+    <p>
+      The Service is provided to You &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; and with all
+      faults and defects without warranty of any kind. To the maximum extent permitted under
+      applicable law, the Company, on its own behalf and on behalf of its affiliates and their
+      respective licensors and service providers, expressly disclaims all warranties, whether
+      express, implied, statutory or otherwise, with respect to the Service, including all implied
+      warranties of merchantability, fitness for a particular purpose, title and non-infringement,
+      and warranties that may arise out of course of dealing, course of performance, usage or trade
+      practice. Without limitation to the foregoing, the Company provides no warranty or
+      undertaking, and makes no representation of any kind that the Service will meet Your
+      requirements, achieve any intended results, be compatible or work with any other software,
+      applications, systems or services, operate without interruption, meet any performance or
+      reliability standards or be error free or that any errors or defects can or will be corrected.
+    </p>
   </div>
 )
 

--- a/apps/web/src/app/(main)/privacy-policy/page.tsx
+++ b/apps/web/src/app/(main)/privacy-policy/page.tsx
@@ -1,352 +1,198 @@
 import type { NextPage } from 'next'
 import Link from 'next/link'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 
 const PrivacyPolicy: NextPage = () => (
   <div className="container pt-30 mb-20">
     <div className="mb-3 mb-md-5">
-      <AnimatedWrapper>
-        <h1 className="text-center transition-fade-slow transition-fade-start delay-lite">
-          PRIVACY POLICY
-        </h1>
-      </AnimatedWrapper>
+      <h1 className="text-center">PRIVACY POLICY</h1>
     </div>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Effective date: <strong>September 6th, 2021</strong>
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Nifty League (&quot;us&quot;, &quot;we&quot;, or &quot;our&quot;) operates the website.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        This page informs you of our policies regarding the collection, use, and disclosure of
-        personal data when you use our Service and the choices you have associated with that data.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We may use your data to provide and improve the Service. By using the Service, you agree to
-        the collection and use of information in accordance with this policy. Unless otherwise
-        defined in this Privacy Policy, terms used in this Privacy Policy have the same meanings as
-        in our <Link href="/terms-of-service">Terms and Conditions</Link>.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Information Collection and Use
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We reserve the right to collect several different types of information for various purposes
-        to provide and improve our Service to you.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If you do not use (log in to) the service for two years all of your personal data will be
-        deleted.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Types of Data Collected:
-      </p>
-    </AnimatedWrapper>
+    <p>
+      Effective date: <strong>September 6th, 2021</strong>
+    </p>
+    <p>Nifty League (&quot;us&quot;, &quot;we&quot;, or &quot;our&quot;) operates the website.</p>
+    <p>
+      This page informs you of our policies regarding the collection, use, and disclosure of
+      personal data when you use our Service and the choices you have associated with that data.
+    </p>
+    <p>
+      We may use your data to provide and improve the Service. By using the Service, you agree to
+      the collection and use of information in accordance with this policy. Unless otherwise defined
+      in this Privacy Policy, terms used in this Privacy Policy have the same meanings as in our{' '}
+      <Link href="/terms-of-service">Terms and Conditions</Link>.
+    </p>
+    <h5 className="my-3 my-md-5">Information Collection and Use</h5>
+    <p>
+      We reserve the right to collect several different types of information for various purposes to
+      provide and improve our Service to you.
+    </p>
+    <p>
+      If you do not use (log in to) the service for two years all of your personal data will be
+      deleted.
+    </p>
+    <p>Types of Data Collected:</p>
     <ol>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">Personal Data</p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              While using our Service, we may ask you to provide us with certain personally
-              identifiable information that can be used to contact or identify you (&quot;Personal
-              Data&quot;). Personally identifiable information may include, but is not limited to:
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Email address, Cookies and Usage Data.
-            </p>
-          </AnimatedWrapper>
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">Usage Data</p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              We may also collect information that your browser sends whenever you visit our Service
-              or when you access the Service by or through a mobile device (&quot;Usage Data&quot;).
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              This Usage Data may include information such as your computer&apos;s Internet Protocol
-              address (i.e. IP address), browser type, browser version, the pages of our Service
-              that you visit, the time and date of your visit, the time spent on those pages, unique
-              device identifiers and other diagnostic data.
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              When you access the Service by or through a mobile device, this Usage Data may include
-              information such as the type of mobile device you use, your mobile device unique ID,
-              the IP address of your mobile device, your mobile device&apos;s operating system, the
-              type of mobile Internet browser you use, unique device identifiers and other
-              diagnostic data.
-            </p>
-          </AnimatedWrapper>
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Tracking Cookies Data
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              We use cookies and similar tracking technologies to track the activity on our Service
-              and hold certain information.
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Cookies are files with small amounts of data which may include an anonymous unique
-              identifier. Cookies are sent to your browser from a website and stored on your device.
-              Tracking technologies also used are beacons, tags, and scripts to collect and track
-              information and to improve and analyze our Service.
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              You can instruct your browser to refuse all cookies or to indicate when a cookie is
-              being sent. However, if you do not accept cookies, you may not be able to use some
-              portions of our Service.
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Examples of Cookies we use:
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Session Cookies – We use Session Cookies to operate our Service.
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Preference Cookies – We use Preference Cookies to remember your preferences and
-              various settings
-            </p>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="transition-fade-slow transition-fade-start delay-lite">
-              Security Cookies – We use Security Cookies for security purposes.
-            </p>
-          </AnimatedWrapper>
-        </li>
-      </AnimatedWrapper>
+      <li>
+        <p>Personal Data</p>
+        <p>
+          While using our Service, we may ask you to provide us with certain personally identifiable
+          information that can be used to contact or identify you (&quot;Personal Data&quot;).
+          Personally identifiable information may include, but is not limited to:
+        </p>
+        <p>Email address, Cookies and Usage Data.</p>
+      </li>
+      <li>
+        <p>Usage Data</p>
+        <p>
+          We may also collect information that your browser sends whenever you visit our Service or
+          when you access the Service by or through a mobile device (&quot;Usage Data&quot;).
+        </p>
+        <p>
+          This Usage Data may include information such as your computer&apos;s Internet Protocol
+          address (i.e. IP address), browser type, browser version, the pages of our Service that
+          you visit, the time and date of your visit, the time spent on those pages, unique device
+          identifiers and other diagnostic data.
+        </p>
+        <p>
+          When you access the Service by or through a mobile device, this Usage Data may include
+          information such as the type of mobile device you use, your mobile device unique ID, the
+          IP address of your mobile device, your mobile device&apos;s operating system, the type of
+          mobile Internet browser you use, unique device identifiers and other diagnostic data.
+        </p>
+      </li>
+      <li>
+        <p>Tracking Cookies Data</p>
+        <p>
+          We use cookies and similar tracking technologies to track the activity on our Service and
+          hold certain information.
+        </p>
+        <p>
+          Cookies are files with small amounts of data which may include an anonymous unique
+          identifier. Cookies are sent to your browser from a website and stored on your device.
+          Tracking technologies also used are beacons, tags, and scripts to collect and track
+          information and to improve and analyze our Service.
+        </p>
+        <p>
+          You can instruct your browser to refuse all cookies or to indicate when a cookie is being
+          sent. However, if you do not accept cookies, you may not be able to use some portions of
+          our Service.
+        </p>
+        <p>Examples of Cookies we use:</p>
+        <p>Session Cookies – We use Session Cookies to operate our Service.</p>
+        <p>
+          Preference Cookies – We use Preference Cookies to remember your preferences and various
+          settings
+        </p>
+        <p>Security Cookies – We use Security Cookies for security purposes.</p>
+      </li>
     </ol>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Use of Data
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Nifty League uses the collected data for various purposes:
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        To provide and maintain the Service, to notify you about changes to our Service, to allow
-        you to participate in interactive features of our Service when you choose to do so, to
-        provide customer care and support, to provide analysis or valuable information so that we
-        can improve the Service, to monitor the usage of the Service, to detect, prevent and address
-        technical issues.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Transfer of Data
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Your information, including Personal Data, may be transferred to — and maintained on —
-        computers located outside of your state, province, country or other governmental
-        jurisdiction where the data protection laws may differ from those in your jurisdiction.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If you are located outside the United States and choose to provide information to us, please
-        note that we transfer the data, including Personal Data, to the United States and process it
-        there.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Your consent to this Privacy Policy followed by your submission of such information
-        represents your agreement to that transfer.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Nifty League will take all steps reasonably necessary to ensure that your data is treated
-        securely and in accordance with this Privacy Policy and no transfer of your Personal Data
-        will take place to an organization or a country unless there are adequate controls in place
-        including the security of your data and other personal information.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Disclosure of Data
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Nifty League may disclose your Personal Data in the good faith belief that such action is
-        necessary:
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        To comply with a legal obligation, to protect and defend the rights or property of the Nifty
-        League, to prevent or investigate possible wrongdoing in connection with the Service, to
-        protect the personal safety of users of the Service or the public, to protect against legal
-        liability.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Security of Data
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The security of your data is important to us, but remember that no method of transmission
-        over the Internet, or method of electronic storage is 100% secure. While we strive to use
-        commercially acceptable means to protect your Personal Data, we cannot guarantee its
-        absolute security.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Service Providers
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We may employ third-party companies and individuals to facilitate our Service (&quot;Service
-        Providers&quot;), to provide the Service on our behalf, to perform Service-related services
-        or to assist us in analyzing how our Service is used.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        These third-parties have access to your Personal Data only to perform these tasks on our
-        behalf and are obligated not to disclose or use it for any other purpose.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We may use third-party Service Providers to monitor and analyze the use of our Service for
-        analytics.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Links to Other Sites
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Our Service may contain links to other sites that are not operated by us. If you click on a
-        third-party link, you will be directed to that third-party&apos;s site. We strongly advise
-        you to review the Privacy Policy of every site you visit.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We have no control over and assume no responsibility for the content, privacy policies or
-        practices of any third-party sites or services.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Children&apos;s Privacy
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Our Service does not address anyone under the age of 18 (&quot;Children&quot;).
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We do not knowingly collect personally identifiable information from anyone under the age of
-        18. If you are a parent or guardian and you are aware that your child has provided us with
-        Personal Data, please contact us. If we become aware that we have collected Personal Data
-        from children without verification of parental consent, we take steps to remove that
-        information from our servers.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Changes to this Privacy Policy
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We may update our Privacy Policy from time to time. We will notify you of any changes by
-        posting the new Privacy Policy on this page.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We will let you know via{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
-          Discord
-        </a>{' '}
-        and/or a prominent notice on our Service, prior to the change becoming effective and update
-        the &quot;effective date&quot; at the top of this Privacy Policy.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        You are advised to review this Privacy Policy periodically for any changes. Changes to this
-        Privacy Policy are effective when they are posted on this page.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Contact Us
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If you have any questions about this Privacy Policy, please contact us via email at{' '}
-        <a href="mailto: team@niftyleague.com">team@niftyleague.com</a> or reach out to one of the
-        members of our team on{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
-          Discord
-        </a>
-        .
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 my-md-5">Use of Data</h5>
+    <p>Nifty League uses the collected data for various purposes:</p>
+    <p>
+      To provide and maintain the Service, to notify you about changes to our Service, to allow you
+      to participate in interactive features of our Service when you choose to do so, to provide
+      customer care and support, to provide analysis or valuable information so that we can improve
+      the Service, to monitor the usage of the Service, to detect, prevent and address technical
+      issues.
+    </p>
+    <h5 className="my-3 my-md-5">Transfer of Data</h5>
+    <p>
+      Your information, including Personal Data, may be transferred to — and maintained on —
+      computers located outside of your state, province, country or other governmental jurisdiction
+      where the data protection laws may differ from those in your jurisdiction.
+    </p>
+    <p>
+      If you are located outside the United States and choose to provide information to us, please
+      note that we transfer the data, including Personal Data, to the United States and process it
+      there.
+    </p>
+    <p>
+      Your consent to this Privacy Policy followed by your submission of such information represents
+      your agreement to that transfer.
+    </p>
+    <p>
+      Nifty League will take all steps reasonably necessary to ensure that your data is treated
+      securely and in accordance with this Privacy Policy and no transfer of your Personal Data will
+      take place to an organization or a country unless there are adequate controls in place
+      including the security of your data and other personal information.
+    </p>
+    <h5 className="my-3 my-md-5">Disclosure of Data</h5>
+    <p>
+      Nifty League may disclose your Personal Data in the good faith belief that such action is
+      necessary:
+    </p>
+    <p>
+      To comply with a legal obligation, to protect and defend the rights or property of the Nifty
+      League, to prevent or investigate possible wrongdoing in connection with the Service, to
+      protect the personal safety of users of the Service or the public, to protect against legal
+      liability.
+    </p>
+    <h5 className="my-3 my-md-5">Security of Data</h5>
+    <p>
+      The security of your data is important to us, but remember that no method of transmission over
+      the Internet, or method of electronic storage is 100% secure. While we strive to use
+      commercially acceptable means to protect your Personal Data, we cannot guarantee its absolute
+      security.
+    </p>
+    <h5 className="my-3 my-md-5">Service Providers</h5>
+    <p>
+      We may employ third-party companies and individuals to facilitate our Service (&quot;Service
+      Providers&quot;), to provide the Service on our behalf, to perform Service-related services or
+      to assist us in analyzing how our Service is used.
+    </p>
+    <p>
+      These third-parties have access to your Personal Data only to perform these tasks on our
+      behalf and are obligated not to disclose or use it for any other purpose.
+    </p>
+    <p>
+      We may use third-party Service Providers to monitor and analyze the use of our Service for
+      analytics.
+    </p>
+    <h5 className="my-3 my-md-5">Links to Other Sites</h5>
+    <p>
+      Our Service may contain links to other sites that are not operated by us. If you click on a
+      third-party link, you will be directed to that third-party&apos;s site. We strongly advise you
+      to review the Privacy Policy of every site you visit.
+    </p>
+    <p>
+      We have no control over and assume no responsibility for the content, privacy policies or
+      practices of any third-party sites or services.
+    </p>
+    <h5 className="my-3 my-md-5">Children&apos;s Privacy</h5>
+    <p>Our Service does not address anyone under the age of 18 (&quot;Children&quot;).</p>
+    <p>
+      We do not knowingly collect personally identifiable information from anyone under the age of
+      18. If you are a parent or guardian and you are aware that your child has provided us with
+      Personal Data, please contact us. If we become aware that we have collected Personal Data from
+      children without verification of parental consent, we take steps to remove that information
+      from our servers.
+    </p>
+    <h5 className="my-3 my-md-5">Changes to this Privacy Policy</h5>
+    <p>
+      We may update our Privacy Policy from time to time. We will notify you of any changes by
+      posting the new Privacy Policy on this page.
+    </p>
+    <p>
+      We will let you know via{' '}
+      <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
+        Discord
+      </a>{' '}
+      and/or a prominent notice on our Service, prior to the change becoming effective and update
+      the &quot;effective date&quot; at the top of this Privacy Policy.
+    </p>
+    <p>
+      You are advised to review this Privacy Policy periodically for any changes. Changes to this
+      Privacy Policy are effective when they are posted on this page.
+    </p>
+    <h5 className="my-3 my-md-5">Contact Us</h5>
+    <p>
+      If you have any questions about this Privacy Policy, please contact us via email at{' '}
+      <a href="mailto: team@niftyleague.com">team@niftyleague.com</a> or reach out to one of the
+      members of our team on{' '}
+      <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
+        Discord
+      </a>
+      .
+    </p>
   </div>
 )
 

--- a/apps/web/src/app/(main)/terms-of-service/page.tsx
+++ b/apps/web/src/app/(main)/terms-of-service/page.tsx
@@ -1,809 +1,527 @@
 import type { NextPage } from 'next'
 import Link from 'next/link'
 import Definitions from '@/components/Definitions'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 
 const ToS: NextPage = () => (
   <div className="container pt-30 mb-20">
     <div className="mb-3 mb-md-5">
-      <AnimatedWrapper>
-        <h1 className="text-center transition-fade-slow transition-fade-start delay-lite">
-          TERMS AND CONDITIONS
-        </h1>
-      </AnimatedWrapper>
+      <h1 className="text-center">TERMS AND CONDITIONS</h1>
     </div>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Last updated: <strong>March 15th, 2022</strong>
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Please read these terms and conditions carefully before using Our Service.
-      </p>
-    </AnimatedWrapper>
+    <p>
+      Last updated: <strong>March 15th, 2022</strong>
+    </p>
+    <p>Please read these terms and conditions carefully before using Our Service.</p>
     <Definitions />
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Acknowledgement
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        These are the Terms and Conditions governing the use of this Service and the agreement that
-        operates between You, whether personally or on behalf of an entity, and the Company. These
-        Terms and Conditions set out the rights and obligations of all users regarding the use of
-        our Application.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Nifty League is a distributed application that is currently running on the Ethereum
-        Network, using specially-developed Smart Contracts to enable users to own, transfer,
-        compete, and purchase genetically-unique digital characters. It also intends to enable users
-        to own and transfer other digital assets like plots of land or items. These assets can then
-        be visualized on our Site and be used to interact with our Application or Online Games.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        In addition, each DEGEN NFT-Token accumulates a utility and governance token (“NFTL”). The
-        NFTL token cannot be purchased, but it can be freely accumulated by holding the DEGEN
-        NFT-Token along with contributing to the community. The Company does not provide or intend
-        to provide a secondary market place for our NFT-Tokens or NFTL. NFTL does not constitute any
-        ownership of the Company nor do we guarantee any value to the NFTL token in and of itself
-        outside of the Nifty DAO, nor do we guarantee NFTL will be used for any platform-wide
-        expenses outside of renaming characters. After the sale of an NFT-Token to You, the
-        ownership of the NFT-Token, and to the connected Art, is transferred from the Smart Contract
-        to the purchaser and concludes the business transaction between both parties.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Transactions on the App are managed and confirmed via the Ethereum blockchain and other
-        networks such as Arbitrum. We neither own nor control MetaMask, Google Chrome, the Ethereum
-        network, Arbitrum, or any other third-party site, product, or service that You might access,
-        visit, or use for the purpose of enabling You to use the various features of the App. We
-        will not be liable for the acts or omissions of any such third parties, nor will we be
-        liable for any damage that You may suffer as a result of Your transactions or any other
-        interaction with any such third parties.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Your access to and use of the Service is conditioned on Your acceptance of and compliance
-        with these Terms and Conditions. These Terms and Conditions apply to all visitors, users and
-        others who access or use the Service. By accessing or using the Service You agree to be
-        bound by these Terms and Conditions. Your access to and use of the Service is also
-        conditioned on Your acceptance of and compliance with our{' '}
-        <Link href="/disclaimer">Disclaimer</Link> and{' '}
-        <Link href="/privacy-policy">Privacy Policy</Link>. If You disagree with any part of these
-        Terms and Conditions, Disclaimer, or Privacy Policy then You may not access our Application.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Site is intended for users who are at least 18 years old. People under the age of 18 are
-        not permitted to use or register for the Site, the App, and the Smart Contracts.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Intellectual Property Rights
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Unless otherwise indicated, the Site and the Smart Contracts are our proprietary property
-        and all source code, database, functionality, software, website design, audio, video, text,
-        photographs, and graphics on the Site and the Apps (collectively, the &quot;Content&quot;)
-        and trademarks, service marks and logos contained therein (the &quot;Marks&quot;) are owned,
-        controlled by us or licensed to us. Except as expressly provided in these Terms of Use, no
-        part of the Site, the App as well as the Smart Contract and no Content or Marks may be
-        copied, reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded,
-        translated, transmitted, distributed, sold, licensed, or otherwise exploited for any
-        commercial purpose whatsoever, without our prior express written permission.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Provided that You are eligible to use the Site, the App and the Smart Contracts, You are
-        granted a limited license to access and use the Site or to download or print a copy of any
-        portion of the Content to which You have properly gained access solely to Your personal,
-        non-commercial use. We reserve all rights not expressly granted to You in and to the Site,
-        the App, the Content, and the Marks.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        When a User purchases a Good or platform asset, the User owns the underlying NFT-Token
-        completely for as long as the User owns the NFT-Token. Ownership of the NFT-Token is
-        mediated entirely by the smart contract and Ethereum Network (or any other applicable
-        network): at no point may Nifty League seize, freeze, or otherwise modify the ownership of
-        the Good.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Subject to Your continued compliance with these Terms, The Company grants You a worldwide,
-        non-exclusive, royalty-free license to use, copy, and display the purchased Art, along with
-        any extensions that You choose to create or use, solely for the following purposes: (i) for
-        Your own personal, non-commercial use; (ii) as part of a marketplace that permits the
-        purchase and sale of Your Nifty League NFT-Tokens, provided that the marketplace
-        cryptographically verifies each NFT-Token owner&apos;s rights to display the Art for their
-        NFT-Token to ensure that only the actual owner can display the Art; or (iii) as part of a
-        third party website or application that permits the inclusion, involvement, or participation
-        of Your NFT-Token, provided that the website/application cryptographically verifies each
-        NFT-Token owner&apos;s rights to display the Art for their NFT-Token to ensure that only the
-        actual owner can display the Art.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        By using the Site and in conjunction with creating, submitting, posting, promoting, or
-        displaying content, You grant us a worldwide, non-exclusive, sublicensable, royalty-free
-        license to use, copy, modify, and display any content, including but not limited to text,
-        materials, images, files, communications, comments, feedback, suggestions, ideas, concepts,
-        questions, data, or otherwise, that you submit or post on or through the Site or the App
-        (collectively, “User Contributions”) for our current and future business purposes, including
-        to provide, promote, and improve the Site and the App. This includes any digital file, art,
-        or other material linked to or associated with any NFTs or other crypto assets that are
-        displayed on the Site or the App.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Provided that You own an ERC721 NFT-Token asset, You are granted a limited license to create
-        fan-art and merchandise which can be used commercially given that You follow the terms set
-        herein:
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 my-md-5">Acknowledgement</h5>
+    <p>
+      These are the Terms and Conditions governing the use of this Service and the agreement that
+      operates between You, whether personally or on behalf of an entity, and the Company. These
+      Terms and Conditions set out the rights and obligations of all users regarding the use of our
+      Application.
+    </p>
+    <p>
+      The Nifty League is a distributed application that is currently running on the Ethereum
+      Network, using specially-developed Smart Contracts to enable users to own, transfer, compete,
+      and purchase genetically-unique digital characters. It also intends to enable users to own and
+      transfer other digital assets like plots of land or items. These assets can then be visualized
+      on our Site and be used to interact with our Application or Online Games.
+    </p>
+    <p>
+      In addition, each DEGEN NFT-Token accumulates a utility and governance token (“NFTL”). The
+      NFTL token cannot be purchased, but it can be freely accumulated by holding the DEGEN
+      NFT-Token along with contributing to the community. The Company does not provide or intend to
+      provide a secondary market place for our NFT-Tokens or NFTL. NFTL does not constitute any
+      ownership of the Company nor do we guarantee any value to the NFTL token in and of itself
+      outside of the Nifty DAO, nor do we guarantee NFTL will be used for any platform-wide expenses
+      outside of renaming characters. After the sale of an NFT-Token to You, the ownership of the
+      NFT-Token, and to the connected Art, is transferred from the Smart Contract to the purchaser
+      and concludes the business transaction between both parties.
+    </p>
+    <p>
+      Transactions on the App are managed and confirmed via the Ethereum blockchain and other
+      networks such as Arbitrum. We neither own nor control MetaMask, Google Chrome, the Ethereum
+      network, Arbitrum, or any other third-party site, product, or service that You might access,
+      visit, or use for the purpose of enabling You to use the various features of the App. We will
+      not be liable for the acts or omissions of any such third parties, nor will we be liable for
+      any damage that You may suffer as a result of Your transactions or any other interaction with
+      any such third parties.
+    </p>
+    <p>
+      Your access to and use of the Service is conditioned on Your acceptance of and compliance with
+      these Terms and Conditions. These Terms and Conditions apply to all visitors, users and others
+      who access or use the Service. By accessing or using the Service You agree to be bound by
+      these Terms and Conditions. Your access to and use of the Service is also conditioned on Your
+      acceptance of and compliance with our <Link href="/disclaimer">Disclaimer</Link> and{' '}
+      <Link href="/privacy-policy">Privacy Policy</Link>. If You disagree with any part of these
+      Terms and Conditions, Disclaimer, or Privacy Policy then You may not access our Application.
+    </p>
+    <p>
+      The Site is intended for users who are at least 18 years old. People under the age of 18 are
+      not permitted to use or register for the Site, the App, and the Smart Contracts.
+    </p>
+    <h5 className="my-3 my-md-5">Intellectual Property Rights</h5>
+    <p>
+      Unless otherwise indicated, the Site and the Smart Contracts are our proprietary property and
+      all source code, database, functionality, software, website design, audio, video, text,
+      photographs, and graphics on the Site and the Apps (collectively, the &quot;Content&quot;) and
+      trademarks, service marks and logos contained therein (the &quot;Marks&quot;) are owned,
+      controlled by us or licensed to us. Except as expressly provided in these Terms of Use, no
+      part of the Site, the App as well as the Smart Contract and no Content or Marks may be copied,
+      reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded,
+      translated, transmitted, distributed, sold, licensed, or otherwise exploited for any
+      commercial purpose whatsoever, without our prior express written permission.
+    </p>
+    <p>
+      Provided that You are eligible to use the Site, the App and the Smart Contracts, You are
+      granted a limited license to access and use the Site or to download or print a copy of any
+      portion of the Content to which You have properly gained access solely to Your personal,
+      non-commercial use. We reserve all rights not expressly granted to You in and to the Site, the
+      App, the Content, and the Marks.
+    </p>
+    <p>
+      When a User purchases a Good or platform asset, the User owns the underlying NFT-Token
+      completely for as long as the User owns the NFT-Token. Ownership of the NFT-Token is mediated
+      entirely by the smart contract and Ethereum Network (or any other applicable network): at no
+      point may Nifty League seize, freeze, or otherwise modify the ownership of the Good.
+    </p>
+    <p>
+      Subject to Your continued compliance with these Terms, The Company grants You a worldwide,
+      non-exclusive, royalty-free license to use, copy, and display the purchased Art, along with
+      any extensions that You choose to create or use, solely for the following purposes: (i) for
+      Your own personal, non-commercial use; (ii) as part of a marketplace that permits the purchase
+      and sale of Your Nifty League NFT-Tokens, provided that the marketplace cryptographically
+      verifies each NFT-Token owner&apos;s rights to display the Art for their NFT-Token to ensure
+      that only the actual owner can display the Art; or (iii) as part of a third party website or
+      application that permits the inclusion, involvement, or participation of Your NFT-Token,
+      provided that the website/application cryptographically verifies each NFT-Token owner&apos;s
+      rights to display the Art for their NFT-Token to ensure that only the actual owner can display
+      the Art.
+    </p>
+    <p>
+      By using the Site and in conjunction with creating, submitting, posting, promoting, or
+      displaying content, You grant us a worldwide, non-exclusive, sublicensable, royalty-free
+      license to use, copy, modify, and display any content, including but not limited to text,
+      materials, images, files, communications, comments, feedback, suggestions, ideas, concepts,
+      questions, data, or otherwise, that you submit or post on or through the Site or the App
+      (collectively, “User Contributions”) for our current and future business purposes, including
+      to provide, promote, and improve the Site and the App. This includes any digital file, art, or
+      other material linked to or associated with any NFTs or other crypto assets that are displayed
+      on the Site or the App.
+    </p>
+    <p>
+      Provided that You own an ERC721 NFT-Token asset, You are granted a limited license to create
+      fan-art and merchandise which can be used commercially given that You follow the terms set
+      herein:
+    </p>
     <ol>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Anyone creating fan-art of a NFT-Token needs to either own the NFT-Token they are creating
-          fan-art from or receive permission from that NFT-Token&apos;s owner.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Fan artwork must not use official Nifty League assets, but creating unique art using Nifty
-          League NFT-Token assets as inspiration is acceptable.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          The artwork must clearly state &quot;Nifty League Fanart&quot;, link to
-          https://www.niftyleague.com, and link directly to the NFT-Token that is being used for
-          inspiration.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          A Nifty League NFT-Token can be used to generate a maximum of $10,000 in revenue before a
-          separate official license agreement is required to be discussed, agreed to and signed by
-          both parties. The revenue can come from either fan-art (tokenized or physical) or
-          merchandise (t-shirts, mugs, hoodies, etc).
-        </li>
-      </AnimatedWrapper>
+      <li>
+        Anyone creating fan-art of a NFT-Token needs to either own the NFT-Token they are creating
+        fan-art from or receive permission from that NFT-Token&apos;s owner.
+      </li>
+      <li>
+        Fan artwork must not use official Nifty League assets, but creating unique art using Nifty
+        League NFT-Token assets as inspiration is acceptable.
+      </li>
+      <li>
+        The artwork must clearly state &quot;Nifty League Fanart&quot;, link to
+        https://www.niftyleague.com, and link directly to the NFT-Token that is being used for
+        inspiration.
+      </li>
+      <li>
+        A Nifty League NFT-Token can be used to generate a maximum of $10,000 in revenue before a
+        separate official license agreement is required to be discussed, agreed to and signed by
+        both parties. The revenue can come from either fan-art (tokenized or physical) or
+        merchandise (t-shirts, mugs, hoodies, etc).
+      </li>
     </ol>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Creating original fan-art without monetizing it or for the sake of charity is acceptable
-        without any license or ownership.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Furthermore, we will not place any restrictions on using our assets or NFT-Token art for the
-        creation of games generated for the Nifty League by community developers. Upon receipt of
-        payment for Your development efforts You agree to transfer ownership and commercial rights
-        of the game to our Company.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        User Representations
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        By using the Site, the App and the Smart Contracts, You represent and warrant that: (i) You
-        have the legal capacity and You agree to comply with these Terms of Use; (ii) You are not a
-        minor in the jurisdiction in which You reside; (iii) You will not access the Site, the App
-        and the Smart Contracts through automated and non-human means, whether through a bot, script
-        or otherwise. This does not include building public tools and bots that facilitate
-        transparency and analysis.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        (iv) You will not use the Site, the App, and the Smart Contracts for any illegal and
-        unauthorized purpose; and (v) Your use of the Site, the App, and the Smart Contracts will
-        not violate any applicable law or regulation. If You provide any information that is untrue,
-        inaccurate, not current, or incomplete, we have the right to suspend or terminate Your
-        account and refuse any and all current or future use of the Site, the App, and the Smart
-        Contracts (or any portion thereof).
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        (vi) You have not been included in any trade embargoes or economic sanctions list (such as
-        United Nations Security Council Sanctions List), the list of specially designated nationals
-        maintained by OFAC (the Office of Foreign Assets Control of the U.S. Department of the
-        Treasury), or the denied persons or entity list of the U.S. Department of Commerce. Nifty
-        League reserves the right to choose markets and jurisdictions to conduct business, and may
-        restrict or refuse, in its sole discretion, the provision of our Services in certain
-        countries or regions.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Placing Orders for Goods
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        By placing an Order for Goods through the Service, You warrant that You are legally capable
-        of entering into binding contracts.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Your Information</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If You wish to place an Order for Goods available on the Service, You will not be asked to
-        provide any information. The transaction occurs between You and the Smart Contract.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        You represent and warrant that: (i) You have the legal right to use the payment method in
-        connection with any Order; and that (ii) You are not residing in a country excluded by the{' '}
-        <Link href="/disclaimer">Disclaimer</Link>.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Order Cancellation</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We, bound by the Smart Contract, reserve the right to refuse or cancel Your Order at any
-        time for certain reasons including but not limited to:
-      </p>
-    </AnimatedWrapper>
+    <p>
+      Creating original fan-art without monetizing it or for the sake of charity is acceptable
+      without any license or ownership.
+    </p>
+    <p>
+      Furthermore, we will not place any restrictions on using our assets or NFT-Token art for the
+      creation of games generated for the Nifty League by community developers. Upon receipt of
+      payment for Your development efforts You agree to transfer ownership and commercial rights of
+      the game to our Company.
+    </p>
+    <h5 className="my-3 my-md-5">User Representations</h5>
+    <p>
+      By using the Site, the App and the Smart Contracts, You represent and warrant that: (i) You
+      have the legal capacity and You agree to comply with these Terms of Use; (ii) You are not a
+      minor in the jurisdiction in which You reside; (iii) You will not access the Site, the App and
+      the Smart Contracts through automated and non-human means, whether through a bot, script or
+      otherwise. This does not include building public tools and bots that facilitate transparency
+      and analysis.
+    </p>
+    <p>
+      (iv) You will not use the Site, the App, and the Smart Contracts for any illegal and
+      unauthorized purpose; and (v) Your use of the Site, the App, and the Smart Contracts will not
+      violate any applicable law or regulation. If You provide any information that is untrue,
+      inaccurate, not current, or incomplete, we have the right to suspend or terminate Your account
+      and refuse any and all current or future use of the Site, the App, and the Smart Contracts (or
+      any portion thereof).
+    </p>
+    <p>
+      (vi) You have not been included in any trade embargoes or economic sanctions list (such as
+      United Nations Security Council Sanctions List), the list of specially designated nationals
+      maintained by OFAC (the Office of Foreign Assets Control of the U.S. Department of the
+      Treasury), or the denied persons or entity list of the U.S. Department of Commerce. Nifty
+      League reserves the right to choose markets and jurisdictions to conduct business, and may
+      restrict or refuse, in its sole discretion, the provision of our Services in certain countries
+      or regions.
+    </p>
+    <h5 className="my-3 my-md-5">Placing Orders for Goods</h5>
+    <p>
+      By placing an Order for Goods through the Service, You warrant that You are legally capable of
+      entering into binding contracts.
+    </p>
+    <h6>Your Information</h6>
+    <p>
+      If You wish to place an Order for Goods available on the Service, You will not be asked to
+      provide any information. The transaction occurs between You and the Smart Contract.
+    </p>
+    <p>
+      You represent and warrant that: (i) You have the legal right to use the payment method in
+      connection with any Order; and that (ii) You are not residing in a country excluded by the{' '}
+      <Link href="/disclaimer">Disclaimer</Link>.
+    </p>
+    <h6>Order Cancellation</h6>
+    <p>
+      We, bound by the Smart Contract, reserve the right to refuse or cancel Your Order at any time
+      for certain reasons including but not limited to:
+    </p>
     <ul>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Goods availability
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Errors in Your Order
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Technical problems
-        </li>
-      </AnimatedWrapper>
+      <li>Goods availability</li>
+      <li>Errors in Your Order</li>
+      <li>Technical problems</li>
     </ul>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">
-        Your Order Cancellation Rights
-      </h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        As transactions with a Smart Contract are digital and final goods (for example NFT-tokens)
-        cannot be returned and therefore there is no Returns Policy.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        By interacting with the Smart Contract You agree that any sale is final and You do not have
-        any right or possibility to cancel an Order.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Prices Policy</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Company reserves the right to revise its prices or generate new Smart Contracts at any
-        time. The prices quoted are specified by the respective Smart Contract.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Payments</h6>
-    </AnimatedWrapper>
+    <h6>Your Order Cancellation Rights</h6>
+    <p>
+      As transactions with a Smart Contract are digital and final goods (for example NFT-tokens)
+      cannot be returned and therefore there is no Returns Policy.
+    </p>
+    <p>
+      By interacting with the Smart Contract You agree that any sale is final and You do not have
+      any right or possibility to cancel an Order.
+    </p>
+    <h6>Prices Policy</h6>
+    <p>
+      The Company reserves the right to revise its prices or generate new Smart Contracts at any
+      time. The prices quoted are specified by the respective Smart Contract.
+    </p>
+    <h6>Payments</h6>
     <ol type="A">
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          All Goods purchased are subject to a one-time payment. A payment can be made through the
-          Ethereum Blockchain only. We have no control over these payments or transactions, nor do
-          we have the ability to reverse any transactions. With that in mind, the company will have
-          no liability to You or to any third party for any claims or damages that may arise as a
-          result of any transactions that You engage in via the App, or using the Smart Contracts,
-          or any other transactions that You conduct via the Ethereum network.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Ethereum requires the payment of a transaction fee (a &quot;Gas Fee&quot;) for every
-          transaction that occurs on the Ethereum network. The Gas Fee funds the network of
-          computers that run the decentralized Ethereum network. This means that You will need to
-          pay a Gas Fee for each transaction that occurs via the App. The Gas Fee does not go to us
-          and We have no control over its pricing.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          All paid prices exclude any possible duties or charges. You will be solely responsible to
-          pay any and all sales, use, value-added and other taxes, duties, and assessments (except
-          taxes on our net income) now or hereafter claimed or imposed by any governmental authority
-          (collectively, &quot;Taxes&quot;) associated with Your use of the App (including, without
-          limitation, any Taxes that may become payable as the result of Your ownership of a Nifty
-          League NFT-Token or NFTL. Except for income and net-wealth taxes levied on The Company,
-          You: (i) will pay or reimburse us for all national, federal, state, local or other taxes
-          and assessments of any jurisdiction, including value added taxes and taxes as required by
-          international tax treaties, customs or other import or export taxes, and amounts levied in
-          lieu thereof based on charges set, services performed or payments made hereunder, as are
-          now or hereafter may be imposed under the authority of any national, state, local or any
-          other taxing jurisdiction; and (ii) shall not be entitled to deduct the amount of any such
-          taxes, duties or assessments from payments made to us pursuant to these Terms.
-        </li>
-      </AnimatedWrapper>
+      <li>
+        All Goods purchased are subject to a one-time payment. A payment can be made through the
+        Ethereum Blockchain only. We have no control over these payments or transactions, nor do we
+        have the ability to reverse any transactions. With that in mind, the company will have no
+        liability to You or to any third party for any claims or damages that may arise as a result
+        of any transactions that You engage in via the App, or using the Smart Contracts, or any
+        other transactions that You conduct via the Ethereum network.
+      </li>
+      <li>
+        Ethereum requires the payment of a transaction fee (a &quot;Gas Fee&quot;) for every
+        transaction that occurs on the Ethereum network. The Gas Fee funds the network of computers
+        that run the decentralized Ethereum network. This means that You will need to pay a Gas Fee
+        for each transaction that occurs via the App. The Gas Fee does not go to us and We have no
+        control over its pricing.
+      </li>
+      <li>
+        All paid prices exclude any possible duties or charges. You will be solely responsible to
+        pay any and all sales, use, value-added and other taxes, duties, and assessments (except
+        taxes on our net income) now or hereafter claimed or imposed by any governmental authority
+        (collectively, &quot;Taxes&quot;) associated with Your use of the App (including, without
+        limitation, any Taxes that may become payable as the result of Your ownership of a Nifty
+        League NFT-Token or NFTL. Except for income and net-wealth taxes levied on The Company, You:
+        (i) will pay or reimburse us for all national, federal, state, local or other taxes and
+        assessments of any jurisdiction, including value added taxes and taxes as required by
+        international tax treaties, customs or other import or export taxes, and amounts levied in
+        lieu thereof based on charges set, services performed or payments made hereunder, as are now
+        or hereafter may be imposed under the authority of any national, state, local or any other
+        taxing jurisdiction; and (ii) shall not be entitled to deduct the amount of any such taxes,
+        duties or assessments from payments made to us pursuant to these Terms.
+      </li>
     </ol>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Links to Other Websites
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Our Service may contain links to third-party web sites or services that are not owned or
-        controlled by the Company including all articles, photograph, text, graphics, pictures,
-        designs, music, sound, video, information, applications, software, and other content or
-        items belonging to or originating from third-parties.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Company has no control over, and assumes no responsibility for, the content, privacy
-        policies, or practices of any third party web sites or services. You further acknowledge and
-        agree that the Company shall not be responsible or liable, directly or indirectly, for any
-        damage or loss caused or alleged to be caused by or in connection with the use of or
-        reliance on any such content, goods or services available on or through any such web sites
-        or services.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We strongly advise You to read the terms and conditions and privacy policies of any
-        third-party websites or services that You visit.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Termination
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        These Terms remain in full force and effect while You use the Site, the App and the Smart
-        Contracts. We may terminate or suspend Your access immediately, without prior notice or
-        liability, for any reason whatsoever, including without limitation if You breach these Terms
-        and Conditions.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Upon termination, Your right to use the Service will cease immediately. However,
-        interactions between You and the public Smart Contract will be outside our control. In
-        addition to terminating and suspending Your account, we reserve the right to take
-        appropriate legal action, including without limitation pursuing civil, criminal, and
-        injunctive redress.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Limitation of Liability
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Notwithstanding any damages that You might incur, the entire liability of the Company and
-        any of its suppliers under any provision of this Terms and Your exclusive remedy for all of
-        the foregoing shall be limited to the amount actually paid by You through the Service.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        To the maximum extent permitted by applicable law, in no event shall the Company or its
-        suppliers be liable for any special, incidental, indirect, or consequential damages
-        whatsoever (including, but not limited to, damages for loss of profits, loss of data or
-        other information, for business interruption, for personal injury, loss of privacy arising
-        out of or in any way related to the use of or inability to use the Service, third-party
-        software and/or third-party hardware used with the Service, or otherwise in connection with
-        any provision of these Terms), even if the Company or any supplier has been advised of the
-        possibility of such damages and even if the remedy fails of its essential purpose.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Some states do not allow the exclusion of implied warranties or limitation of liability for
-        incidental or consequential damages, which means that some of the above limitations may not
-        apply. In these states, each party&apos;s liability will be limited to the greatest extent
-        permitted by law.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Assumption of Risk
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        You accept and acknowledge each of the following:
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 my-md-5">Links to Other Websites</h5>
+    <p>
+      Our Service may contain links to third-party web sites or services that are not owned or
+      controlled by the Company including all articles, photograph, text, graphics, pictures,
+      designs, music, sound, video, information, applications, software, and other content or items
+      belonging to or originating from third-parties.
+    </p>
+    <p>
+      The Company has no control over, and assumes no responsibility for, the content, privacy
+      policies, or practices of any third party web sites or services. You further acknowledge and
+      agree that the Company shall not be responsible or liable, directly or indirectly, for any
+      damage or loss caused or alleged to be caused by or in connection with the use of or reliance
+      on any such content, goods or services available on or through any such web sites or services.
+    </p>
+    <p>
+      We strongly advise You to read the terms and conditions and privacy policies of any
+      third-party websites or services that You visit.
+    </p>
+    <h5 className="my-3 my-md-5">Termination</h5>
+    <p>
+      These Terms remain in full force and effect while You use the Site, the App and the Smart
+      Contracts. We may terminate or suspend Your access immediately, without prior notice or
+      liability, for any reason whatsoever, including without limitation if You breach these Terms
+      and Conditions.
+    </p>
+    <p>
+      Upon termination, Your right to use the Service will cease immediately. However, interactions
+      between You and the public Smart Contract will be outside our control. In addition to
+      terminating and suspending Your account, we reserve the right to take appropriate legal
+      action, including without limitation pursuing civil, criminal, and injunctive redress.
+    </p>
+    <h5 className="my-3 my-md-5">Limitation of Liability</h5>
+    <p>
+      Notwithstanding any damages that You might incur, the entire liability of the Company and any
+      of its suppliers under any provision of this Terms and Your exclusive remedy for all of the
+      foregoing shall be limited to the amount actually paid by You through the Service.
+    </p>
+    <p>
+      To the maximum extent permitted by applicable law, in no event shall the Company or its
+      suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever
+      (including, but not limited to, damages for loss of profits, loss of data or other
+      information, for business interruption, for personal injury, loss of privacy arising out of or
+      in any way related to the use of or inability to use the Service, third-party software and/or
+      third-party hardware used with the Service, or otherwise in connection with any provision of
+      these Terms), even if the Company or any supplier has been advised of the possibility of such
+      damages and even if the remedy fails of its essential purpose.
+    </p>
+    <p>
+      Some states do not allow the exclusion of implied warranties or limitation of liability for
+      incidental or consequential damages, which means that some of the above limitations may not
+      apply. In these states, each party&apos;s liability will be limited to the greatest extent
+      permitted by law.
+    </p>
+    <h5 className="my-3 my-md-5">Assumption of Risk</h5>
+    <p>You accept and acknowledge each of the following:</p>
     <ol type="A">
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          The prices of blockchain assets are extremely volatile. Fluctuations in the price of other
-          digital assets could materially and adversely affect the value of Your NFT-Tokens, which
-          may also be subject to significant price volatility. We cannot guarantee that any
-          purchasers of NFT-Token will not lose money.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          You are solely responsible for determining what, if any, taxes apply to Your
-          NFT-Token-related transactions. The Nifty League is not responsible for determining the
-          taxes that apply to Your transactions on the App, the Site, or the Smart Contracts.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          There are risks associated with using an Internet-based currency, including, but not
-          limited to, the risk of hardware, software and Internet connection malfunctions, the risk
-          of malicious software introduction, and the risk that third parties may obtain
-          unauthorized access to information stored within Your wallet. You accept and acknowledge
-          that Nifty League will not be responsible for any communication failures, disruptions,
-          errors, distortions or delays You may encounter while using the Ethereum network, however
-          caused.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          A lack of use or public interest in the creation and development of distributed ecosystems
-          could negatively impact the development of the Nifty League&apos;s platform, and therefore
-          the potential utility and/or value of Nifty League NFT-Tokens.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          The regulatory regime governing blockchain technologies, cryptocurrencies, and tokens is
-          currently uncertain, and new regulations and/or policies may materially adversely affect
-          the development of the Nifty League, and therefore the potential utility and/or value of
-          Nifty League NFT-Tokens.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Upgrades to our platform or the Ethereum Network may have unintended, adverse effects on
-          all Nifty League assets.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Bad actors may hack or exploit systems and steal NFTs.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Legislation or regulation could be adopted that negatively impact the use, transfer,
-          exchange or price of NFTs.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          NFTs compete with other digital assets, and this competition may negatively impact the
-          price of an NFT.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          The market for NFTs is new and volatile, and the price of an NFT relative to fiat
-          currencies may greatly decrease over a short period of time, impacting the liquidity and
-          the price of the NFT.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Bad actors may attempt to impersonate owners of NFTs, counterfeit NFTs, sell replicas of
-          original NFTs or misuse art tied to NFTs.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          Businesses or organizations that issue NFTs may go out of business, declare bankruptcy or
-          cease operations, thereby decreasing the use or value of its NFTs.
-        </li>
-      </AnimatedWrapper>
+      <li>
+        The prices of blockchain assets are extremely volatile. Fluctuations in the price of other
+        digital assets could materially and adversely affect the value of Your NFT-Tokens, which may
+        also be subject to significant price volatility. We cannot guarantee that any purchasers of
+        NFT-Token will not lose money.
+      </li>
+      <li>
+        You are solely responsible for determining what, if any, taxes apply to Your
+        NFT-Token-related transactions. The Nifty League is not responsible for determining the
+        taxes that apply to Your transactions on the App, the Site, or the Smart Contracts.
+      </li>
+      <li>
+        There are risks associated with using an Internet-based currency, including, but not limited
+        to, the risk of hardware, software and Internet connection malfunctions, the risk of
+        malicious software introduction, and the risk that third parties may obtain unauthorized
+        access to information stored within Your wallet. You accept and acknowledge that Nifty
+        League will not be responsible for any communication failures, disruptions, errors,
+        distortions or delays You may encounter while using the Ethereum network, however caused.
+      </li>
+      <li>
+        A lack of use or public interest in the creation and development of distributed ecosystems
+        could negatively impact the development of the Nifty League&apos;s platform, and therefore
+        the potential utility and/or value of Nifty League NFT-Tokens.
+      </li>
+      <li>
+        The regulatory regime governing blockchain technologies, cryptocurrencies, and tokens is
+        currently uncertain, and new regulations and/or policies may materially adversely affect the
+        development of the Nifty League, and therefore the potential utility and/or value of Nifty
+        League NFT-Tokens.
+      </li>
+      <li>
+        Upgrades to our platform or the Ethereum Network may have unintended, adverse effects on all
+        Nifty League assets.
+      </li>
+      <li>Bad actors may hack or exploit systems and steal NFTs.</li>
+      <li>
+        Legislation or regulation could be adopted that negatively impact the use, transfer,
+        exchange or price of NFTs.
+      </li>
+      <li>
+        NFTs compete with other digital assets, and this competition may negatively impact the price
+        of an NFT.
+      </li>
+      <li>
+        The market for NFTs is new and volatile, and the price of an NFT relative to fiat currencies
+        may greatly decrease over a short period of time, impacting the liquidity and the price of
+        the NFT.
+      </li>
+      <li>
+        Bad actors may attempt to impersonate owners of NFTs, counterfeit NFTs, sell replicas of
+        original NFTs or misuse art tied to NFTs.
+      </li>
+      <li>
+        Businesses or organizations that issue NFTs may go out of business, declare bankruptcy or
+        cease operations, thereby decreasing the use or value of its NFTs.
+      </li>
     </ol>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">Abuse</h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Nifty League reserves the right to prevent the withdrawal of NFTL if abuse is detected.
-        Cheating and &apos;boosting&apos; are strictly prohibited. Agreeing with other players to
-        rank experience and earn NFTL faster than can be done through normal gameplay, often
-        referred to as &apos;boosting&apos;, is strictly prohibited. Use of third-party programs,
-        for example, cheat or bot engines, and applications in conjunction with our app is strictly
-        prohibited.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Disclaimer
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Our Disclaimer includes important statements intended to specify or delimit the scope of
-        rights and obligations that may be exercised or enforced, and is hereby incorporated by this
-        reference into these Terms. You agree to the warnings and expectations outlined in our{' '}
-        <Link href="/disclaimer">Disclaimer</Link>.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Governing Law
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The laws of the United States, excluding its conflicts of law rules, shall govern these
-        Terms and Your use of the Service. Your use of the Application may also be subject to other
-        local, state, national, or international laws.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Disputes Resolution
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">
-        Informal Negotiations
-      </h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        To expedite resolution and control the cost of any dispute, controversy, or claim related to
-        these Terms of Use (each a &quot;Dispute&quot; and collectively, the &quot;Disputes&quot;)
-        brought by either You or Us (individually, a &quot;Party&quot; and collectively, the
-        &quot;Parties&quot;), the Parties agree to first attempt to negotiate any Dispute (except
-        those Disputes expressly provided below) informally for at least thirty (30) days before
-        initiating arbitration. Such informal negotiations commence upon written notice from one
-        Party to the other Party.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Binding Arbitration</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If a Party is unable to resolve a Dispute through informal negotiations, the Disputes
-        (except those Disputes expressly excluded below) will be finally and exclusively resolved by
-        binding arbitration. YOU UNDERSTAND THAT WITHOUT THIS PROVISION, YOU WOULD HAVE THE RIGHT TO
-        SUE IN COURT AND HAVE A JURY TRIAL. The arbitration shall be commenced and conducted under
-        the Commercial Arbitration Rules of the American Arbitration Association (&quot;AAA&quot;)
-        and, where appropriate, the AAA&apos;s Supplementary Procedures for Consumer-Related
-        Disputes (&quot;AAA Consumer Rules&quot;), both of which are available at the AAA website
-        www.adr.org. Your arbitration fees and Your share of arbitration compensation shall be
-        governed by the AAA Consumer Rules and, where appropriate, limited by the AAA Consumer
-        Rules. If such costs are determined by the arbitrator to be excessive, we will supplement
-        the arbitration fees and expenses. Except where otherwise required by the applicable AA
-        rules or applicable law, the arbitration will take place in the United States. Except as
-        otherwise provided herein, the Parties may litigate in court to compel arbitration, stay
-        proceedings pending arbitration, or to confirm, modify, vacate, or enter judgement on the
-        award entered by the arbitrator.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If for any reason, a Dispute proceeds in court rather than arbitration, the Dispute shall be
-        commenced or prosecuted in the state and federal courts located in the United States, and
-        the Parties hereby consent to and waive all defenses of lack of personal jurisdiction, and
-        forum non-conveniens with respect to venue and jurisdiction in such state and federal
-        courts.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        In no event shall any Dispute brought by either Party related in any way to the Site, the
-        App and the Smart Contracts be commenced more than one (1) year after the cause of the
-        action arose. If this provision is found to be illegal or unenforceable, then neither Party
-        will elect to arbitrate any Dispute falling within that portion of this provision found to
-        be illegal or unenforceable and such Dispute shall be decided by a court of competent
-        jurisdiction within the courts listed or jurisdiction above, and the Parties agree to submit
-        to the personal jurisdiction of that court.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">
-        Exceptions to the Informal Negotiations and Arbitration
-      </h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The Parties agree that the following Disputes are not subject to the above provision
-        concerning informal negotiations and binding arbitration: (a) any Dispute seeking to enforce
-        or protect, or concerning the validity of, and of the intellectual property rights of a
-        Party, (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion
-        of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision
-        is found to be illegal and unenforceable, then neither Party will elect to arbitrate any
-        Dispute falling within that portion of this provision found to be illegal or unenforceable
-        and such Dispute shall be decided by a court of competent jurisdiction within the courts
-        listed or jurisdiction above, and the Parties agree to submit to the personal jurisdiction
-        of that court.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        For European Union (EU) Users
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If You are a European Union consumer, You will benefit from any mandatory provisions of the
-        law of the country in which You are resident in.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        United States Legal Compliance
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        You represent and warrant that (i) You are not located in a country that is subject to the
-        United States government embargo, or that has been designated by the United States
-        government as a &quot;terrorist supporting&quot; country, and (ii) You are not listed on any
-        United States government list of prohibited or restricted parties. Please read our{' '}
-        <Link href="/disclaimer">Disclaimer</Link> for more details.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Severability and Waiver
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Severability</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If any provision of these Terms is held to be unenforceable or invalid, such provision will
-        be amended and interpreted to accomplish the objectives of such provision to the greatest
-        extent possible under applicable law and the remaining provisions will continue in full
-        force and effect.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="transition-fade-slow transition-fade-start delay-lite">Waiver</h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Except as provided herein, the failure to exercise a right or to require performance of an
-        obligation under these Terms shall not affect a party&apos;s ability to exercise such right
-        or require such performance at any time thereafter nor shall the waiver of a breach
-        constitute a waiver of any subsequent breach.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Translation Interpretation
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        These Terms and Conditions may have been translated if We have made them available to You on
-        our Service. You agree that the original English text shall prevail in the case of a
-        dispute.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Indemnification
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        You agree to defend, indemnify, and hold us harmless, including our subsidiaries,
-        affiliates, and all of our respective officers, agents, partners, and employees, from and
-        against any loss, damage, liability, claim, or demand, including reasonable attorneys&apos;
-        fees and expenses, made by third party due to or arising out of: (1) use of the Site, (2)
-        breach of these Terms of Use, (3) any breach of Your representations and warranties set
-        forth in these Terms of Use, (4) Your violation of the rights of a third party, including
-        but not limited to intellectual property rights, or (5) any overt harmful act toward any
-        other use of the Site, the App and the Smart Contracts with whom You connected via the Site,
-        the App and the Smart Contracts. Notwithstanding the foregoing, we reserve the right, at
-        Your expense, to assume the exclusive defense and control of any matter for which You are
-        required to indemnify us, and You agree to cooperate, at Your expense, with our defense of
-        such claims. We will use reasonable efforts to notify You of any such claim, action or
-        proceeding which is subject to this indemnification upon becoming aware of it.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Privacy Policy
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Our <Link href="/privacy-policy">Privacy Policy</Link> describes the ways we collect, use,
-        store and disclose Your personal information, and is hereby incorporated by this reference
-        into these Terms. You agree to the collection, use, storage, and disclosure of Your data in
-        accordance with our Privacy Policy.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Changes to These Terms and Conditions
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        Supplemental terms and conditions or documents that may be posted on the Site, the App, and
-        the Smart Contracts from time to time are hereby expressly incorporated herein by reference.
-        We reserve the right, in our sole discretion, to make changes or modifications to these
-        Terms of Use at any time and for any reason. We will alert You of any changes by updating
-        the &quot;Last Updated&quot; date of these Terms of Use, and You waive any right to receive
-        specific notice of each such change. It is Your responsibility to periodically review these
-        Terms of Use to stay informed of updates. You will be subject to and will be deemed to have
-        been made aware of and to have accepted, the changes in any revised Terms of Use by Your
-        continued use of the Site, the App, and the Smart Contracts after the date such revised
-        Terms of Use are posted.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        We reserve the right, at Our sole discretion, to modify or replace these Terms at any time.
-        If a revision is material We will make reasonable efforts to provide at least 30 days&apos;
-        notice prior to any new terms taking effect. What constitutes a material change will be
-        determined at Our sole discretion.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        By continuing to access or use Our Service after those revisions become effective, You agree
-        to be bound by the revised terms. If You do not agree to the new terms, in whole or in part,
-        please stop using the Application.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h5 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Contact Us
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        If You have any questions about these Terms and Conditions, You can contact us at{' '}
-        <a href="mailto: team@niftyleague.com">team@niftyleague.com</a> or by reaching out to one of
-        our team members on{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
-          Discord
-        </a>
-        .
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 my-md-5">Abuse</h5>
+    <p>
+      Nifty League reserves the right to prevent the withdrawal of NFTL if abuse is detected.
+      Cheating and &apos;boosting&apos; are strictly prohibited. Agreeing with other players to rank
+      experience and earn NFTL faster than can be done through normal gameplay, often referred to as
+      &apos;boosting&apos;, is strictly prohibited. Use of third-party programs, for example, cheat
+      or bot engines, and applications in conjunction with our app is strictly prohibited.
+    </p>
+    <h5 className="my-3 my-md-5">Disclaimer</h5>
+    <p>
+      Our Disclaimer includes important statements intended to specify or delimit the scope of
+      rights and obligations that may be exercised or enforced, and is hereby incorporated by this
+      reference into these Terms. You agree to the warnings and expectations outlined in our{' '}
+      <Link href="/disclaimer">Disclaimer</Link>.
+    </p>
+    <h5 className="my-3 my-md-5">Governing Law</h5>
+    <p>
+      The laws of the United States, excluding its conflicts of law rules, shall govern these Terms
+      and Your use of the Service. Your use of the Application may also be subject to other local,
+      state, national, or international laws.
+    </p>
+    <h5 className="my-3 my-md-5">Disputes Resolution</h5>
+    <h6>Informal Negotiations</h6>
+    <p>
+      To expedite resolution and control the cost of any dispute, controversy, or claim related to
+      these Terms of Use (each a &quot;Dispute&quot; and collectively, the &quot;Disputes&quot;)
+      brought by either You or Us (individually, a &quot;Party&quot; and collectively, the
+      &quot;Parties&quot;), the Parties agree to first attempt to negotiate any Dispute (except
+      those Disputes expressly provided below) informally for at least thirty (30) days before
+      initiating arbitration. Such informal negotiations commence upon written notice from one Party
+      to the other Party.
+    </p>
+    <h6>Binding Arbitration</h6>
+    <p>
+      If a Party is unable to resolve a Dispute through informal negotiations, the Disputes (except
+      those Disputes expressly excluded below) will be finally and exclusively resolved by binding
+      arbitration. YOU UNDERSTAND THAT WITHOUT THIS PROVISION, YOU WOULD HAVE THE RIGHT TO SUE IN
+      COURT AND HAVE A JURY TRIAL. The arbitration shall be commenced and conducted under the
+      Commercial Arbitration Rules of the American Arbitration Association (&quot;AAA&quot;) and,
+      where appropriate, the AAA&apos;s Supplementary Procedures for Consumer-Related Disputes
+      (&quot;AAA Consumer Rules&quot;), both of which are available at the AAA website www.adr.org.
+      Your arbitration fees and Your share of arbitration compensation shall be governed by the AAA
+      Consumer Rules and, where appropriate, limited by the AAA Consumer Rules. If such costs are
+      determined by the arbitrator to be excessive, we will supplement the arbitration fees and
+      expenses. Except where otherwise required by the applicable AA rules or applicable law, the
+      arbitration will take place in the United States. Except as otherwise provided herein, the
+      Parties may litigate in court to compel arbitration, stay proceedings pending arbitration, or
+      to confirm, modify, vacate, or enter judgement on the award entered by the arbitrator.
+    </p>
+    <p>
+      If for any reason, a Dispute proceeds in court rather than arbitration, the Dispute shall be
+      commenced or prosecuted in the state and federal courts located in the United States, and the
+      Parties hereby consent to and waive all defenses of lack of personal jurisdiction, and forum
+      non-conveniens with respect to venue and jurisdiction in such state and federal courts.
+    </p>
+    <p>
+      In no event shall any Dispute brought by either Party related in any way to the Site, the App
+      and the Smart Contracts be commenced more than one (1) year after the cause of the action
+      arose. If this provision is found to be illegal or unenforceable, then neither Party will
+      elect to arbitrate any Dispute falling within that portion of this provision found to be
+      illegal or unenforceable and such Dispute shall be decided by a court of competent
+      jurisdiction within the courts listed or jurisdiction above, and the Parties agree to submit
+      to the personal jurisdiction of that court.
+    </p>
+    <h6>Exceptions to the Informal Negotiations and Arbitration</h6>
+    <p>
+      The Parties agree that the following Disputes are not subject to the above provision
+      concerning informal negotiations and binding arbitration: (a) any Dispute seeking to enforce
+      or protect, or concerning the validity of, and of the intellectual property rights of a Party,
+      (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of
+      privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is
+      found to be illegal and unenforceable, then neither Party will elect to arbitrate any Dispute
+      falling within that portion of this provision found to be illegal or unenforceable and such
+      Dispute shall be decided by a court of competent jurisdiction within the courts listed or
+      jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that
+      court.
+    </p>
+    <h5 className="my-3 my-md-5">For European Union (EU) Users</h5>
+    <p>
+      If You are a European Union consumer, You will benefit from any mandatory provisions of the
+      law of the country in which You are resident in.
+    </p>
+    <h5 className="my-3 my-md-5">United States Legal Compliance</h5>
+    <p>
+      You represent and warrant that (i) You are not located in a country that is subject to the
+      United States government embargo, or that has been designated by the United States government
+      as a &quot;terrorist supporting&quot; country, and (ii) You are not listed on any United
+      States government list of prohibited or restricted parties. Please read our{' '}
+      <Link href="/disclaimer">Disclaimer</Link> for more details.
+    </p>
+    <h5 className="my-3 my-md-5">Severability and Waiver</h5>
+    <h6>Severability</h6>
+    <p>
+      If any provision of these Terms is held to be unenforceable or invalid, such provision will be
+      amended and interpreted to accomplish the objectives of such provision to the greatest extent
+      possible under applicable law and the remaining provisions will continue in full force and
+      effect.
+    </p>
+    <h6>Waiver</h6>
+    <p>
+      Except as provided herein, the failure to exercise a right or to require performance of an
+      obligation under these Terms shall not affect a party&apos;s ability to exercise such right or
+      require such performance at any time thereafter nor shall the waiver of a breach constitute a
+      waiver of any subsequent breach.
+    </p>
+    <h5 className="my-3 my-md-5">Translation Interpretation</h5>
+    <p>
+      These Terms and Conditions may have been translated if We have made them available to You on
+      our Service. You agree that the original English text shall prevail in the case of a dispute.
+    </p>
+    <h5 className="my-3 my-md-5">Indemnification</h5>
+    <p>
+      You agree to defend, indemnify, and hold us harmless, including our subsidiaries, affiliates,
+      and all of our respective officers, agents, partners, and employees, from and against any
+      loss, damage, liability, claim, or demand, including reasonable attorneys&apos; fees and
+      expenses, made by third party due to or arising out of: (1) use of the Site, (2) breach of
+      these Terms of Use, (3) any breach of Your representations and warranties set forth in these
+      Terms of Use, (4) Your violation of the rights of a third party, including but not limited to
+      intellectual property rights, or (5) any overt harmful act toward any other use of the Site,
+      the App and the Smart Contracts with whom You connected via the Site, the App and the Smart
+      Contracts. Notwithstanding the foregoing, we reserve the right, at Your expense, to assume the
+      exclusive defense and control of any matter for which You are required to indemnify us, and
+      You agree to cooperate, at Your expense, with our defense of such claims. We will use
+      reasonable efforts to notify You of any such claim, action or proceeding which is subject to
+      this indemnification upon becoming aware of it.
+    </p>
+    <h5 className="my-3 my-md-5">Privacy Policy</h5>
+    <p>
+      Our <Link href="/privacy-policy">Privacy Policy</Link> describes the ways we collect, use,
+      store and disclose Your personal information, and is hereby incorporated by this reference
+      into these Terms. You agree to the collection, use, storage, and disclosure of Your data in
+      accordance with our Privacy Policy.
+    </p>
+    <h5 className="my-3 my-md-5">Changes to These Terms and Conditions</h5>
+    <p>
+      Supplemental terms and conditions or documents that may be posted on the Site, the App, and
+      the Smart Contracts from time to time are hereby expressly incorporated herein by reference.
+      We reserve the right, in our sole discretion, to make changes or modifications to these Terms
+      of Use at any time and for any reason. We will alert You of any changes by updating the
+      &quot;Last Updated&quot; date of these Terms of Use, and You waive any right to receive
+      specific notice of each such change. It is Your responsibility to periodically review these
+      Terms of Use to stay informed of updates. You will be subject to and will be deemed to have
+      been made aware of and to have accepted, the changes in any revised Terms of Use by Your
+      continued use of the Site, the App, and the Smart Contracts after the date such revised Terms
+      of Use are posted.
+    </p>
+    <p>
+      We reserve the right, at Our sole discretion, to modify or replace these Terms at any time. If
+      a revision is material We will make reasonable efforts to provide at least 30 days&apos;
+      notice prior to any new terms taking effect. What constitutes a material change will be
+      determined at Our sole discretion.
+    </p>
+    <p>
+      By continuing to access or use Our Service after those revisions become effective, You agree
+      to be bound by the revised terms. If You do not agree to the new terms, in whole or in part,
+      please stop using the Application.
+    </p>
+    <h5 className="my-3 my-md-5">Contact Us</h5>
+    <p>
+      If You have any questions about these Terms and Conditions, You can contact us at{' '}
+      <a href="mailto: team@niftyleague.com">team@niftyleague.com</a> or by reaching out to one of
+      our team members on{' '}
+      <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/niftyleague">
+        Discord
+      </a>
+      .
+    </p>
   </div>
 )
 

--- a/apps/web/src/components/Definitions.tsx
+++ b/apps/web/src/components/Definitions.tsx
@@ -1,110 +1,66 @@
-import { memo } from 'react'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
-
 const Definitions = (): React.ReactNode => (
   <>
-    <AnimatedWrapper>
-      <h5 className="my-3 md:my-5 transition-fade-slow transition-fade-start delay-lite">
-        Interpretation and Definitions
-      </h5>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Interpretation
-      </h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        The words of which the initial letter is capitalized have meanings defined under the
-        following conditions. The following definitions shall have the same meaning regardless of
-        whether they appear in singular or in plural.
-      </p>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <h6 className="my-3 my-md-5 transition-fade-slow transition-fade-start delay-lite">
-        Definitions
-      </h6>
-    </AnimatedWrapper>
-    <AnimatedWrapper>
-      <p className="transition-fade-slow transition-fade-start delay-lite">
-        For the purposes of these Terms and Conditions:
-      </p>
-    </AnimatedWrapper>
+    <h5 className="my-3 md:my-5">Interpretation and Definitions</h5>
+    <h6 className="my-3 my-md-5">Interpretation</h6>
+    <p>
+      The words of which the initial letter is capitalized have meanings defined under the following
+      conditions. The following definitions shall have the same meaning regardless of whether they
+      appear in singular or in plural.
+    </p>
+    <h6 className="my-3 my-md-5">Definitions</h6>
+    <p>For the purposes of these Terms and Conditions:</p>
     <ul>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Company</strong> (referred to as either &quot;the Nifty League&quot;,
-          &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in this Agreement) refers to Nifty
-          League Inc.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>You</strong> (also referred to as &quot;User&quot;) refers to the individual
-          accessing or using the Service, or the company, or other legal entity on behalf of which
-          such individual is accessing or using the Service, as applicable.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Terms and Conditions</strong> (also referred to as &quot;Terms&quot;) mean these
-          Terms and Conditions that form the entire agreement between You and the Company regarding
-          the use of the Service.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Site</strong> refers to the Nifty League, accessible from
-          https://www.nifty-league.com and all subdomains as well as any other media form, media
-          channel, mobile website or mobile application related, linked, or otherwise connected
-          thereto.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Online Games</strong> refer to any games accessible from
-          https://www.nifty-league.com/games while interacting with our Smart Contracts.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Smart Contracts</strong> mean digital contracts used with our Service on the
-          Ethereum Blockchain, Arbitrum (or any other applicable network) which are immutable to any
-          alteration.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Application</strong> (also referred to as &quot;App&quot;) collectively refers to
-          the Smart Contracts, Site, and any Online Games offered by the Nifty League.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Service</strong> refers to the App.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>NFT-Token</strong> means a digital good on the Ethereum Blockchain (or any other
-          applicable network) which represents ownership of a certain piece of artwork such as our
-          DEGEN NFTs or other assets offered by the Nifty League.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Goods</strong> refer to the items and NFT-Tokens offered for sale on the
-          Application.
-        </li>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <li className="transition-fade-slow transition-fade-start delay-lite">
-          <strong>Orders</strong> means a request by You to purchase Goods from Us.
-        </li>
-      </AnimatedWrapper>
+      <li>
+        <strong>Company</strong> (referred to as either &quot;the Nifty League&quot;,
+        &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in this Agreement) refers to Nifty League
+        Inc.
+      </li>
+      <li>
+        <strong>You</strong> (also referred to as &quot;User&quot;) refers to the individual
+        accessing or using the Service, or the company, or other legal entity on behalf of which
+        such individual is accessing or using the Service, as applicable.
+      </li>
+      <li>
+        <strong>Terms and Conditions</strong> (also referred to as &quot;Terms&quot;) mean these
+        Terms and Conditions that form the entire agreement between You and the Company regarding
+        the use of the Service.
+      </li>
+      <li>
+        <strong>Site</strong> refers to the Nifty League, accessible from
+        https://www.nifty-league.com and all subdomains as well as any other media form, media
+        channel, mobile website or mobile application related, linked, or otherwise connected
+        thereto.
+      </li>
+      <li>
+        <strong>Online Games</strong> refer to any games accessible from
+        https://www.nifty-league.com/games while interacting with our Smart Contracts.
+      </li>
+      <li>
+        <strong>Smart Contracts</strong> mean digital contracts used with our Service on the
+        Ethereum Blockchain, Arbitrum (or any other applicable network) which are immutable to any
+        alteration.
+      </li>
+      <li>
+        <strong>Application</strong> (also referred to as &quot;App&quot;) collectively refers to
+        the Smart Contracts, Site, and any Online Games offered by the Nifty League.
+      </li>
+      <li>
+        <strong>Service</strong> refers to the App.
+      </li>
+      <li>
+        <strong>NFT-Token</strong> means a digital good on the Ethereum Blockchain (or any other
+        applicable network) which represents ownership of a certain piece of artwork such as our
+        DEGEN NFTs or other assets offered by the Nifty League.
+      </li>
+      <li>
+        <strong>Goods</strong> refer to the items and NFT-Tokens offered for sale on the
+        Application.
+      </li>
+      <li>
+        <strong>Orders</strong> means a request by You to purchase Goods from Us.
+      </li>
     </ul>
   </>
 )
 
-const MemoizedDefinitions = memo(Definitions)
-export default MemoizedDefinitions
+export default Definitions

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -221,6 +221,12 @@ const animationFreeMarketingComponents = [
   'packages/ui/src/components/custom/accordion/index.tsx',
   'packages/ui/src/components/custom/degen-specials-table/index.tsx',
 ]
+const staticLegalPages = [
+  'apps/web/src/app/(main)/terms-of-service/page.tsx',
+  'apps/web/src/app/(main)/privacy-policy/page.tsx',
+  'apps/web/src/app/(main)/disclaimer/page.tsx',
+]
+const webDefinitions = 'apps/web/src/components/Definitions.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
@@ -1113,6 +1119,27 @@ describe('web marketing animation boundary contract', () => {
       expect(source).not.toContain('delay-long')
     })
   }
+})
+
+describe('static legal route performance contract', () => {
+  for (const file of staticLegalPages) {
+    it(`keeps ${file} server-only and immediately visible`, () => {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).not.toContain("'use client'")
+      expect(source).not.toContain('AnimatedWrapper')
+      expect(source).not.toContain('@nl/ui/custom/animated-wrapper')
+      expect(source).not.toContain('transition-fade-start')
+    })
+  }
+
+  it('keeps the shared legal definitions fragment free of client-only animation code', () => {
+    const source = readFileSync(join(process.cwd(), webDefinitions), 'utf8')
+
+    expect(source).not.toContain("from 'react'")
+    expect(source).not.toContain('AnimatedWrapper')
+    expect(source).not.toContain('transition-fade-start')
+  })
 })
 
 const sentryClientBoundaries = [


### PR DESCRIPTION
## Summary

- remove the client-only `AnimatedWrapper` boundary from the terms, privacy, and disclaimer pages
- keep the shared legal definitions fragment server-rendered
- remove hidden-on-load animation classes so legal content is immediately visible
- add a contract guard preventing the client animation dependency from returning to these routes

## Impact

Static legal routes no longer hydrate hundreds of animation wrapper instances, and list items are no longer wrapped in invalid `div` elements. The rebuilt route client entry drops from 96,298 bytes to 94,111 bytes per route; the disclaimer route emits no page client-reference manifest.

## Validation

- `bun test test/contract/route-surface.test.ts` — 137 passed
- `bun run --cwd apps/web type-check` — passed
- `bun run --cwd apps/web lint` — passed
- targeted Prettier check — passed
- `bun run --cwd apps/web build` — passed

This PR is intentionally draft so hosted validation remains deferred until the milestone is ready.
