### PR TITLE
perf(ui): coalesce shared parallax updates

### DIFF
--- a/packages/ui/src/hooks/useParallax.ts
+++ b/packages/ui/src/hooks/useParallax.ts
@@ -5,6 +5,12 @@ import { useEffect } from 'react'
 export type ParallaxDirection = 'up' | 'down' | 'left' | 'right'
 export type ParallaxIntensity = 'lite' | 'normal' | 'strong' | 'extreme'
 
+type ParallaxUpdate = () => void
+
+const parallaxUpdates = new Set<ParallaxUpdate>()
+let scheduledFrame: number | null = null
+let cancelScheduledFrame: ((frame: number) => void) | null = null
+
 // Function to apply the transform to the element or its child
 const applyTransform = <T extends HTMLElement>(
   element: T,
@@ -46,6 +52,50 @@ const calculateTransform = <T extends HTMLElement>(
   return `translateX(${translationX * directionValue * multiplier}px)`
 }
 
+const flushParallaxUpdates = (): void => {
+  scheduledFrame = null
+  cancelScheduledFrame = null
+  parallaxUpdates.forEach((update) => update())
+}
+
+const scheduleParallaxUpdates = (): void => {
+  if (scheduledFrame !== null) return
+
+  if (typeof window.requestAnimationFrame === 'function') {
+    scheduledFrame = window.requestAnimationFrame(flushParallaxUpdates)
+    cancelScheduledFrame = window.cancelAnimationFrame
+    return
+  }
+
+  scheduledFrame = window.setTimeout(flushParallaxUpdates, 0)
+  cancelScheduledFrame = window.clearTimeout
+}
+
+const handleParallaxScroll = (): void => {
+  scheduleParallaxUpdates()
+}
+
+const subscribeToParallaxUpdates = (update: ParallaxUpdate): (() => void) => {
+  if (parallaxUpdates.size === 0) {
+    window.addEventListener('scroll', handleParallaxScroll, { passive: true })
+  }
+
+  parallaxUpdates.add(update)
+
+  return () => {
+    parallaxUpdates.delete(update)
+
+    if (parallaxUpdates.size > 0) return
+
+    window.removeEventListener('scroll', handleParallaxScroll)
+    if (scheduledFrame !== null) {
+      cancelScheduledFrame?.(scheduledFrame)
+      scheduledFrame = null
+      cancelScheduledFrame = null
+    }
+  }
+}
+
 interface UseParallaxOptions {
   enabled: boolean
   direction: ParallaxDirection
@@ -68,10 +118,7 @@ export function useParallax<T extends HTMLElement = HTMLDivElement>(
     }
 
     handleParallax()
-    window.addEventListener('scroll', handleParallax, { passive: true })
-    return () => {
-      window.removeEventListener('scroll', handleParallax)
-    }
+    return subscribeToParallaxUpdates(handleParallax)
   }, [elementRef, options.enabled, options.direction, options.intensity])
 }
 

--- a/packages/ui/src/hooks/visibility.test.tsx
+++ b/packages/ui/src/hooks/visibility.test.tsx
@@ -196,6 +196,73 @@ describe('useParallax', () => {
     expect(element.style.transform).toBe(`translateX(${(-50 * 100 * 0.5) / window.innerHeight}px)`)
   })
 
+  it('shares one scroll listener and coalesces updates into one animation frame', () => {
+    const addEventListener = spyOn(window, 'addEventListener')
+    const removeEventListener = spyOn(window, 'removeEventListener')
+    const originalRequestAnimationFrame = window.requestAnimationFrame
+    const originalCancelAnimationFrame = window.cancelAnimationFrame
+    let animationFrameCallback: FrameRequestCallback | undefined
+
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        animationFrameCallback = callback
+        return 1
+      },
+    })
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      value: () => undefined,
+    })
+
+    try {
+      const firstElement = elementWithTop(100)
+      const secondElement = elementWithTop(200)
+      const first = renderHook(() =>
+        useParallax(
+          { current: firstElement },
+          { enabled: true, direction: 'down', intensity: 'normal' }
+        )
+      )
+      const second = renderHook(() =>
+        useParallax(
+          { current: secondElement },
+          { enabled: true, direction: 'up', intensity: 'normal' }
+        )
+      )
+
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+      window.dispatchEvent(new Event('scroll'))
+      window.dispatchEvent(new Event('scroll'))
+      expect(animationFrameCallback).toBeDefined()
+
+      firstElement.getBoundingClientRect = () => ({ top: 150 }) as DOMRect
+      secondElement.getBoundingClientRect = () => ({ top: 250 }) as DOMRect
+      act(() => animationFrameCallback?.(1))
+
+      expect((firstElement.firstElementChild as HTMLElement).style.transform).toBe(
+        `translateY(${(-150 * 100) / window.innerHeight}px)`
+      )
+      expect((secondElement.firstElementChild as HTMLElement).style.transform).toBe(
+        `translateY(${(250 * 100) / window.innerHeight}px)`
+      )
+
+      first.unmount()
+      expect(removeEventListener).not.toHaveBeenCalledWith('scroll', expect.any(Function))
+      second.unmount()
+      expect(removeEventListener).toHaveBeenCalledWith('scroll', expect.any(Function))
+    } finally {
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      })
+      Object.defineProperty(window, 'cancelAnimationFrame', {
+        configurable: true,
+        value: originalCancelAnimationFrame,
+      })
+    }
+  })
+
   it('does nothing while disabled or before the ref is mounted', () => {
     const addEventListener = spyOn(window, 'addEventListener')
     renderHook(() =>


### PR DESCRIPTION
## Summary

- share one passive `scroll` listener across all active `useParallax` consumers
- coalesce repeated scroll events into one `requestAnimationFrame` update
- preserve the existing initial transform, direction, intensity, and timer fallback behavior
- add regression coverage for listener sharing, frame coalescing, transform updates, and cleanup

## Validation

- `bun run --cwd packages/ui test` — 139 passed
- `bun run --cwd packages/ui type-check` — passed
- `bun run --cwd packages/ui lint` — passed
- `bun run --cwd apps/web type-check` — passed
- `bun run --cwd apps/web lint` — passed
- `bun run --cwd apps/web build` — passed
- `bun run --cwd apps/app build` — passed
- `git diff --check` — passed

## Performance note

This is a runtime-scroll optimization. The web home client graph remains effectively flat at 107,649 bytes, while app public route graphs are unchanged because they do not use parallax. The primary saving is eliminating one native scroll listener per parallax wrapper and preventing duplicate layout/transform work during a single frame.