### PR TITLE
perf(web): server-render GLTF viewer shell

### DIFF
--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+
+import { cn } from '@nl/ui/utils'
+import { ErrorBoundary } from '@nl/ui/custom/error-boundry'
+import { ToggleGroup, ToggleGroupItem } from '@nl/ui/base/toggle-group'
+import { SRC, Color } from '@/types/gltf'
+
+import styles from '../gltf.module.css'
+
+const TokenMenu = dynamic(() => import('./TokenMenu'), { ssr: false })
+const ModelView = dynamic(() => import('./ModelView'), { ssr: false })
+const ModelActions = dynamic(() => import('./ModelActions'), { ssr: false })
+
+interface DegenViewsProps {
+  tokenId: string
+  initialImage: ReactNode
+  spriteImage: ReactNode
+  logo: ReactNode
+}
+
+export default function DegenViews({ tokenId, initialImage, spriteImage, logo }: DegenViewsProps) {
+  const [source, setSource] = useState<SRC>(SRC.IMAGE)
+  const [color, setColor] = useState<Color>('purple')
+  const tokenNumber = Number(tokenId)
+
+  return (
+    <>
+      <main
+        className={cn(styles.main__wrapper, {
+          ...(source === SRC.MODEL && {
+            [styles.gradient_salmon as string]: color === 'salmon',
+            [styles.gradient_purple as string]: color === 'purple',
+            [styles.gradient_blue as string]: color === 'blue',
+            [styles.gradient_bluegrey as string]: color === 'bluegrey',
+            [styles.gradient_bluepurple as string]: color === 'bluepurple',
+            [styles.gradient_green as string]: color === 'green',
+            [styles.gradient_bluegreen as string]: color === 'bluegreen',
+            [styles.gradient_brown as string]: color === 'brown',
+            [styles.gradient_ochre as string]: color === 'ochre',
+            [styles.gradient_palepink as string]: color === 'palepink',
+            [styles.gradient_yellow as string]: color === 'yellow',
+            [styles.gradient_greenish as string]: color === 'greenish',
+            [styles.gradient_lightblue as string]: color === 'lightblue',
+            [styles.gradient_ochretwo as string]: color === 'ochretwo',
+          }),
+        })}
+      >
+        {source === SRC.IMAGE ? initialImage : null}
+        {source === SRC.SPRITE ? spriteImage : null}
+        {source === SRC.MODEL && <ModelView source={source} tokenId={tokenId} />}
+        {tokenNumber < 9999 ? (
+          <div className={styles.menu__overlay}>
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              value={source}
+              onValueChange={(value: SRC) => value && setSource(value)}
+              className={styles.menu__overlay__toggle}
+            >
+              <ToggleGroupItem value={SRC.IMAGE} aria-label="Toggle 2D">
+                2D
+              </ToggleGroupItem>
+              <ToggleGroupItem value={SRC.MODEL} aria-label="Toggle 3D">
+                3D
+              </ToggleGroupItem>
+              {tokenNumber < 9901 ? (
+                <ToggleGroupItem value={SRC.SPRITE} aria-label="Toggle Sprite" className="px-5">
+                  SPRITE
+                </ToggleGroupItem>
+              ) : null}
+            </ToggleGroup>
+            {source === SRC.MODEL && <ModelActions color={color} setColor={setColor} />}
+          </div>
+        ) : null}
+        {source === SRC.IMAGE ? (
+          <ErrorBoundary>
+            <TokenMenu tokenId={tokenId} />
+          </ErrorBoundary>
+        ) : (
+          <div className={styles.menu__logo}>{logo}</div>
+        )}
+      </main>
+    </>
+  )
+}

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/ModelView.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/ModelView.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import '@google/model-viewer'
-import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { CircularProgress } from '@nl/ui/custom/circular-progress'
 
@@ -42,9 +41,7 @@ const ModelViewer: React.FC<ModelViewerProps> = (props) => {
   return <model-viewer {...props} />
 }
 
-export default function ModelView({ source }: { source: SRC }) {
-  const params = useParams()
-  const tokenId = params.tokenId as string
+export default function ModelView({ source, tokenId }: { source: SRC; tokenId: string }) {
   const [loading, setLoading] = useState(true)
   const MODEL_SRC = `${DEGEN_3D_MODEL_URL}/${tokenId}/${tokenId}.gltf`
 

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
@@ -3,6 +3,17 @@
   --default-font-size: var(--text-sm); /* 0.875rem */
 }
 
+:global(html),
+:global(body),
+:global(main) {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  background-color: var(--color-light);
+}
+
 /* ==============================|| FILES ||============================== */
 
 .pixelated {

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
@@ -1,48 +1,23 @@
-'use client'
-
-import { useState } from 'react'
-import { useParams } from 'next/navigation'
-import dynamic from 'next/dynamic'
 import Image from 'next/image'
 
-import { cn } from '@nl/ui/utils'
-import { ErrorBoundary } from '@nl/ui/custom/error-boundry'
-import { ToggleGroup, ToggleGroupItem } from '@nl/ui/base/toggle-group'
 import { DEGEN_BASE_SPRITE_URL, LEGGIES } from '@/constants/degens'
-import { SRC, Color } from '@/types/gltf'
 
+import DegenViews from './components/DegenViews'
 import styles from './gltf.module.css'
 
-const TokenMenu = dynamic(() => import('./components/TokenMenu'), { ssr: false })
-const ModelView = dynamic(() => import('./components/ModelView'), { ssr: false })
-const ModelActions = dynamic(() => import('./components/ModelActions'), { ssr: false })
+interface DegenViewsPageProps {
+  params: Promise<{ tokenId: string }>
+}
 
-export default function DegenViews() {
-  const params = useParams()
-  const tokenId = params.tokenId as string
-  const [source, setSource] = useState<SRC>(SRC.IMAGE)
-  const [color, setColor] = useState<Color>('purple')
-  const IMAGE_SRC = `/img/degens/nfts/${tokenId}.${LEGGIES.includes(Number(tokenId)) ? 'gif' : 'webp'}`
-  const SPRITE_SRC = `${DEGEN_BASE_SPRITE_URL}/${tokenId}.gif`
-
-  if (!tokenId) return null
+export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
+  const { tokenId } = await params
+  const imageSrc = `/img/degens/nfts/${tokenId}.${LEGGIES.includes(Number(tokenId)) ? 'gif' : 'webp'}`
+  const spriteSrc = `${DEGEN_BASE_SPRITE_URL}/${tokenId}.gif`
 
   return (
-    <>
-      {/* eslint-disable react/no-unknown-property */}
-      <style jsx global>{`
-        html,
-        body,
-        main {
-          margin: 0;
-          padding: 0;
-          height: 100%;
-          width: 100%;
-          overflow: hidden;
-          background-color: var(--color-light);
-        }
-      `}</style>
-      {source === SRC.IMAGE && (
+    <DegenViews
+      tokenId={tokenId}
+      initialImage={
         <Image
           alt="NiftyDegen 2D NFT"
           className={styles.image}
@@ -50,82 +25,30 @@ export default function DegenViews() {
           height={640}
           priority
           quality={100}
-          src={IMAGE_SRC}
-          unoptimized={IMAGE_SRC.includes('.gif')}
+          src={imageSrc}
+          unoptimized={imageSrc.includes('.gif')}
         />
-      )}
-      {source === SRC.SPRITE && (
+      }
+      spriteImage={
         <Image
           alt="Degen Sprite"
           className={styles.sprite}
           fill
           priority
           unoptimized
-          src={SPRITE_SRC}
+          src={spriteSrc}
         />
-      )}
-      <main
-        className={cn(styles.main__wrapper, {
-          ...(source === SRC.MODEL && {
-            [styles.gradient_salmon as string]: color === 'salmon',
-            [styles.gradient_purple as string]: color === 'purple',
-            [styles.gradient_blue as string]: color === 'blue',
-            [styles.gradient_bluegrey as string]: color === 'bluegrey',
-            [styles.gradient_bluepurple as string]: color === 'bluepurple',
-            [styles.gradient_green as string]: color === 'green',
-            [styles.gradient_bluegreen as string]: color === 'bluegreen',
-            [styles.gradient_brown as string]: color === 'brown',
-            [styles.gradient_ochre as string]: color === 'ochre',
-            [styles.gradient_palepink as string]: color === 'palepink',
-            [styles.gradient_yellow as string]: color === 'yellow',
-            [styles.gradient_greenish as string]: color === 'greenish',
-            [styles.gradient_lightblue as string]: color === 'lightblue',
-            [styles.gradient_ochretwo as string]: color === 'ochretwo',
-          }),
-        })}
-      >
-        {source === SRC.MODEL && <ModelView source={source} />}
-        {Number(tokenId) < 9999 ? (
-          <div className={styles.menu__overlay}>
-            <ToggleGroup
-              type="single"
-              variant="outline"
-              value={source}
-              onValueChange={(value: SRC) => value && setSource(value)}
-              className={styles.menu__overlay__toggle}
-            >
-              <ToggleGroupItem value={SRC.IMAGE} aria-label="Toggle 2D">
-                2D
-              </ToggleGroupItem>
-              <ToggleGroupItem value={SRC.MODEL} aria-label="Toggle 3D">
-                3D
-              </ToggleGroupItem>
-              {Number(tokenId) < 9901 ? (
-                <ToggleGroupItem value={SRC.SPRITE} aria-label="Toggle Sprite" className="px-5">
-                  SPRITE
-                </ToggleGroupItem>
-              ) : null}
-            </ToggleGroup>
-            {source === SRC.MODEL && <ModelActions color={color} setColor={setColor} />}
-          </div>
-        ) : null}
-        {source === SRC.IMAGE ? (
-          <ErrorBoundary>
-            <TokenMenu tokenId={tokenId} />
-          </ErrorBoundary>
-        ) : (
-          <div className={styles.menu__logo}>
-            <Image
-              alt="Nifty League Logo"
-              width={200}
-              height={70}
-              style={{ maxWidth: '24vw', height: 'auto' }}
-              quality={100}
-              src="/img/logos/NL/wordmark.webp"
-            />
-          </div>
-        )}
-      </main>
-    </>
+      }
+      logo={
+        <Image
+          alt="Nifty League Logo"
+          width={200}
+          height={70}
+          style={{ maxWidth: '24vw', height: 'auto' }}
+          quality={100}
+          src="/img/logos/NL/wordmark.webp"
+        />
+      }
+    />
   )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -193,6 +193,8 @@ const routeLoadingFiles = [
   'apps/smashers/src/app/loading.tsx',
 ]
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
+const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
+const gltfClient = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
@@ -270,6 +272,22 @@ describe('public degen loading contract', () => {
     expect(routeBoundarySource).toContain('aria-busy="true"')
     expect(routeBoundarySource).toContain("from '@nl/ui/base/skeleton'")
     expect(clientPageSource).toContain("'use client'")
+  })
+})
+
+describe('GLTF viewer loading contract', () => {
+  it('keeps the initial NFT shell server-rendered and browser controls isolated', () => {
+    const pageSource = readFileSync(join(process.cwd(), gltfPage), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), gltfClient), 'utf8')
+
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain('await params')
+    expect(pageSource).toContain("from 'next/image'")
+    expect(pageSource).toContain("from './components/DegenViews'")
+    expect(clientSource).toContain("'use client'")
+    expect(clientSource).not.toContain("from 'next/image'")
+    expect(clientSource).toContain("dynamic(() => import('./ModelView')")
+    expect(clientSource).toContain('ssr: false')
   })
 })
 


### PR DESCRIPTION
## Summary

- move the GLTF route page back to a Server Component and read the dynamic token from `params`
- render the initial NFT, sprite, and logo assets through the server-rendered shell
- keep only source/color controls in the client island
- keep `TokenMenu`, `ModelActions`, and the browser-only model-viewer component deferred
- remove the redundant client `useParams` lookup from the model viewer
- move the route global reset into the existing themed CSS module
- add a route contract protecting the server/client boundary

## Measured result

The GLTF route client entry graph fell from 109,680 to 99,236 uncompressed bytes: 10,444 bytes saved (9.5%). The initial production HTML now includes the token image and accessible 2D/3D/Sprite controls. The `@google/model-viewer` code remains out of the initial entry and loads only when 3D is selected.

## Validation

- `bun run --cwd apps/web test` — 14 passed
- `bun test --isolate test/contract/route-surface.test.ts` — 134 passed
- `bun run --cwd apps/web type-check` — passed
- `bun run --cwd apps/web lint` — passed
- `bun run --cwd apps/web build` — passed
- local `next start` smoke test for `/gltf/123` — server HTML contained the NFT image and all accessible source toggles
- Prettier check and `git diff --check` — passed