### PR TITLE
perf(app): defer private network warning

### DIFF
--- a/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
@@ -24,7 +24,7 @@ export default function NetworkWarning() {
       style={{ zIndex: 1, position: 'absolute' }}
     >
       <Icon name={isConnectedToIMX ? 'info' : 'triangle-alert'} size="lg" strokeWidth={2.5} />
-      <span className="px-2 text-xl font-semibold">
+      <span aria-live="polite" className="px-2 text-xl font-semibold">
         {isConnectedToIMX
           ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`
           : `Please switch to ${TARGET_NETWORK.label}`}

--- a/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useAccount, useSwitchChain } from 'wagmi'
+import { immutableZkEvm, immutableZkEvmTestnet } from 'viem/chains'
+
+import { Button } from '@nl/ui/base/button'
+import { Icon } from '@nl/ui/base/icon'
+import { TARGET_NETWORK } from '@/constants/networks'
+
+export default function NetworkWarning() {
+  const { address, chain } = useAccount()
+  const { switchChain } = useSwitchChain()
+  const isConnectedToIMX = chain?.id === immutableZkEvm.id || chain?.id === immutableZkEvmTestnet.id
+
+  if (!address || TARGET_NETWORK.chainId === chain?.id) return null
+
+  return (
+    <div
+      className={
+        isConnectedToIMX
+          ? 'bg-success-dark/[80%] flex h-[60px] w-full items-center justify-center'
+          : 'bg-error/[80%] flex h-[60px] w-full items-center justify-center'
+      }
+      style={{ zIndex: 1, position: 'absolute' }}
+    >
+      <Icon name={isConnectedToIMX ? 'info' : 'triangle-alert'} size="lg" strokeWidth={2.5} />
+      <span className="px-2 text-xl font-semibold">
+        {isConnectedToIMX
+          ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`
+          : `Please switch to ${TARGET_NETWORK.label}`}
+      </span>
+      <Button
+        className="px-4 py-0.5"
+        variant="default"
+        onClick={() => switchChain?.({ chainId: TARGET_NETWORK.chainId })}
+      >
+        Switch
+      </Button>
+    </div>
+  )
+}

--- a/apps/app/src/app/_layout/_MainLayout/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/index.tsx
@@ -2,54 +2,20 @@
 
 // third party
 import { type PropsWithChildren } from 'react'
-import { useAccount, useSwitchChain } from 'wagmi'
-import { immutableZkEvm, immutableZkEvmTestnet } from 'viem/chains'
+import dynamic from 'next/dynamic'
 
 // project imports
-import { Button } from '@nl/ui/base/button'
-import { TARGET_NETWORK } from '@/constants/networks'
-
-// components
-import { Icon } from '@nl/ui/base/icon'
 import AppShell from '@/app/_layout/AppShell'
 import Header from './_Header'
 import Sidebar from './_Sidebar'
 
+const NetworkWarning = dynamic(() => import('./_Header/NetworkWarning'), { ssr: false })
+
 // ==============================|| MAIN LAYOUT ||============================== //
 
 const MainLayout = ({ children }: PropsWithChildren) => {
-  const { address, chain } = useAccount()
-  const { switchChain } = useSwitchChain()
-  const isConnectedToIMX = chain?.id === immutableZkEvm.id || chain?.id === immutableZkEvmTestnet.id
-
-  const networkWarning =
-    address && TARGET_NETWORK.chainId !== chain?.id ? (
-      <div
-        className={
-          isConnectedToIMX
-            ? 'bg-success-dark/[80%] flex h-[60px] w-full items-center justify-center'
-            : 'bg-error/[80%] flex h-[60px] w-full items-center justify-center'
-        }
-        style={{ zIndex: 1, position: 'absolute' }}
-      >
-        <Icon name={isConnectedToIMX ? 'info' : 'triangle-alert'} size="lg" strokeWidth={2.5} />
-        <span className="px-2 text-xl font-semibold">
-          {isConnectedToIMX
-            ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`
-            : `Please switch to ${TARGET_NETWORK.label}`}
-        </span>
-        <Button
-          className="px-4 py-0.5"
-          variant="default"
-          onClick={() => switchChain?.({ chainId: TARGET_NETWORK.chainId })}
-        >
-          Switch
-        </Button>
-      </div>
-    ) : null
-
   return (
-    <AppShell header={<Header />} sidebar={<Sidebar />} networkWarning={networkWarning}>
+    <AppShell header={<Header />} sidebar={<Sidebar />} networkWarning={<NetworkWarning />}>
       {children}
     </AppShell>
   )

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -160,6 +160,8 @@ const sidebarProfile = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfi
 const localStorageHook = 'apps/app/src/hooks/useLocalStorage.ts'
 const contractReaderHook = 'apps/app/src/hooks/useContractReader.ts'
 const valueEqualityUtility = 'apps/app/src/utils/value-equality.ts'
+const mainLayout = 'apps/app/src/app/_layout/_MainLayout/index.tsx'
+const networkWarning = 'apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx'
 const staleWalletContextWrapper = 'apps/app/src/contexts/WalletContextWrapper.tsx'
 const deferredAnalyticsSource = 'packages/ui/src/lib/gtm/DeferredAnalytics.tsx'
 const analyticsLayouts = [
@@ -580,6 +582,19 @@ describe('verification route shell contract', () => {
 })
 
 describe('private provider loading contract', () => {
+  it('defers chain-specific warning UI out of the private shell', () => {
+    const layoutSource = readFileSync(join(process.cwd(), mainLayout), 'utf8')
+    const warningSource = readFileSync(join(process.cwd(), networkWarning), 'utf8')
+
+    expect(layoutSource).toContain("dynamic(() => import('./_Header/NetworkWarning')")
+    expect(layoutSource).toContain('ssr: false')
+    expect(layoutSource).not.toContain("from 'viem/chains'")
+    expect(layoutSource).not.toContain('useSwitchChain')
+    expect(warningSource).toContain('useSwitchChain')
+    expect(warningSource).toContain('TARGET_NETWORK')
+    expect(warningSource).toContain('<Button')
+  })
+
   it('keeps the superseded all-in-one wallet provider removed', () => {
     expect(existsSync(join(process.cwd(), staleWalletContextWrapper))).toBe(false)
   })

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -592,6 +592,7 @@ describe('private provider loading contract', () => {
     expect(layoutSource).not.toContain('useSwitchChain')
     expect(warningSource).toContain('useSwitchChain')
     expect(warningSource).toContain('TARGET_NETWORK')
+    expect(warningSource).toContain('aria-live="polite"')
     expect(warningSource).toContain('<Button')
   })
 


### PR DESCRIPTION
## What changed

- Extract the private network mismatch warning into a client-only dynamic boundary.
- Keep the existing themed shadcn `Button`, icon, copy, and switch-chain behavior unchanged.
- Add a route contract so chain-specific wallet logic stays out of the eager private shell.

## Why

The private layout imported wallet hooks, chain definitions, and the network warning UI for every private route. Deferring that warning keeps the initial shell lighter while preserving the warning for connected wallets on the wrong network.

## Evidence

- Dashboard overview route entry: 193,643 bytes across 9 initial chunks, down from the 193,713-byte `origin/staging` baseline.
- `bun run --cwd apps/app build` passed.
- `bun run --cwd apps/app lint` passed.
- `bun run --cwd apps/app test`: 167 passed, 0 failed.
- `bun test --isolate test/contract/route-surface.test.ts`: 134 passed, 0 failed.
- Production smoke of `/dashboard/overview` preserved `Loading private app`, `role="status"`, and `aria-busy="true"`.

## Cost controls

This is intentionally a draft PR targeting `staging`; draft validation/security jobs remain skipped and feature-branch Vercel deployments remain disabled until the PR is marked ready.
