### PR TITLE
perf(app): remove eager lodash equality

### DIFF
--- a/apps/app/src/hooks/useContractReader.ts
+++ b/apps/app/src/hooks/useContractReader.ts
@@ -2,9 +2,9 @@
 
 /* eslint-disable no-console */
 import { useCallback, useState, useMemo } from 'react'
-import isEqual from 'lodash/isEqual'
 import type { Contracts } from '@/types/web3'
 import type { BaseContract, Contract, ContractMethod } from 'ethers'
+import { areValuesEqual } from '@/utils/value-equality'
 import useAsyncInterval from './useAsyncInterval'
 
 /*
@@ -52,7 +52,7 @@ export default function useContractReader(
           }
         }
         if (formatter && typeof formatter === 'function') newValue = formatter(newValue)
-        if (!isEqual(newValue, value)) setValue(newValue)
+        if (!areValuesEqual(newValue, value)) setValue(newValue)
         return
       } catch (e) {
         console.error('Read Contract Error:', contractName, e)

--- a/apps/app/src/hooks/useLocalStorage.ts
+++ b/apps/app/src/hooks/useLocalStorage.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
-import isEqual from 'lodash/isEqual'
 import { safeJSONParse } from '@/utils/json'
+import { areValuesEqual } from '@/utils/value-equality'
 
 // ==============================|| Local Storage Hook ||============================== //
 
@@ -34,7 +34,7 @@ export default function useLocalStorage<T>(
         return
       }
       const currentValueInStorage = safeJSONParse(window.localStorage.getItem(key)) as T
-      if (!isEqual(currentValueInStorage, storedValue)) {
+      if (!areValuesEqual(currentValueInStorage, storedValue)) {
         window.localStorage.setItem(key, JSON.stringify(storedValue))
       }
     }

--- a/apps/app/src/utils/value-equality.test.ts
+++ b/apps/app/src/utils/value-equality.test.ts
@@ -10,7 +10,7 @@ describe('areValuesEqual', () => {
     expect(areValuesEqual({ first: 1, second: 2 }, { second: 2, first: 1 })).toBe(true)
   })
 
-  it('handles dates and cyclic objects without depending on lodash', () => {
+  it('handles dates and cyclic values without depending on lodash', () => {
     expect(areValuesEqual(new Date('2026-01-01'), new Date('2026-01-01'))).toBe(true)
     expect(areValuesEqual(new Date('2026-01-01'), new Date('2026-01-02'))).toBe(false)
 
@@ -19,6 +19,12 @@ describe('areValuesEqual', () => {
     first.self = first
     second.self = second
     expect(areValuesEqual(first, second)).toBe(true)
+
+    const firstArray: unknown[] = []
+    const secondArray: unknown[] = []
+    firstArray.push(firstArray)
+    secondArray.push(secondArray)
+    expect(areValuesEqual(firstArray, secondArray)).toBe(true)
   })
 
   it('does not treat different prototypes as equal', () => {

--- a/apps/app/src/utils/value-equality.test.ts
+++ b/apps/app/src/utils/value-equality.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+
+import { areValuesEqual } from './value-equality'
+
+describe('areValuesEqual', () => {
+  it('compares primitive, nested, and array values', () => {
+    expect(areValuesEqual(1n, 1n)).toBe(true)
+    expect(areValuesEqual({ balances: [1n, 2n] }, { balances: [1n, 2n] })).toBe(true)
+    expect(areValuesEqual({ balances: [1n] }, { balances: [2n] })).toBe(false)
+    expect(areValuesEqual({ first: 1, second: 2 }, { second: 2, first: 1 })).toBe(true)
+  })
+
+  it('handles dates and cyclic objects without depending on lodash', () => {
+    expect(areValuesEqual(new Date('2026-01-01'), new Date('2026-01-01'))).toBe(true)
+    expect(areValuesEqual(new Date('2026-01-01'), new Date('2026-01-02'))).toBe(false)
+
+    const first: { self?: unknown } = {}
+    const second: { self?: unknown } = {}
+    first.self = first
+    second.self = second
+    expect(areValuesEqual(first, second)).toBe(true)
+  })
+
+  it('does not treat different prototypes as equal', () => {
+    class Value {
+      constructor(public value: number) {}
+    }
+
+    expect(areValuesEqual(new Value(1), { value: 1 })).toBe(false)
+  })
+})

--- a/apps/app/src/utils/value-equality.ts
+++ b/apps/app/src/utils/value-equality.ts
@@ -1,0 +1,43 @@
+/**
+ * Compares the JSON-like values used by local storage and contract polling
+ * without pulling a general-purpose equality implementation into the app shell.
+ */
+export function areValuesEqual(
+  left: unknown,
+  right: unknown,
+  seen: WeakMap<object, object> = new WeakMap()
+): boolean {
+  if (Object.is(left, right)) return true
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+    return false
+  }
+
+  if (left instanceof Date || right instanceof Date) {
+    return left instanceof Date && right instanceof Date && left.getTime() === right.getTime()
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+
+    return left.every((value, index) => areValuesEqual(value, right[index], seen))
+  }
+
+  if (Object.getPrototypeOf(left) !== Object.getPrototypeOf(right)) return false
+
+  const previous = seen.get(left)
+  if (previous) return previous === right
+  seen.set(left, right)
+
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) return false
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+
+  return leftKeys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(rightRecord, key) &&
+      areValuesEqual(leftRecord[key], rightRecord[key], seen)
+  )
+}

--- a/apps/app/src/utils/value-equality.ts
+++ b/apps/app/src/utils/value-equality.ts
@@ -19,6 +19,10 @@ export function areValuesEqual(
   if (Array.isArray(left) || Array.isArray(right)) {
     if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
 
+    const previous = seen.get(left)
+    if (previous) return previous === right
+    seen.set(left, right)
+
     return left.every((value, index) => areValuesEqual(value, right[index], seen))
   }
 

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -155,6 +155,9 @@ const smashersAuthLayout = 'apps/smashers/src/app/(auth_routes)/layout.tsx'
 const staleSmashersUnityDialog = 'apps/smashers/src/components/UnityDialog/index.tsx'
 const privateShellLayout = 'apps/app/src/app/(private-routes)/layout.tsx'
 const sidebarProfile = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/_UserProfile/index.tsx'
+const localStorageHook = 'apps/app/src/hooks/useLocalStorage.ts'
+const contractReaderHook = 'apps/app/src/hooks/useContractReader.ts'
+const valueEqualityUtility = 'apps/app/src/utils/value-equality.ts'
 const staleWalletContextWrapper = 'apps/app/src/contexts/WalletContextWrapper.tsx'
 const deferredAnalyticsSource = 'packages/ui/src/lib/gtm/DeferredAnalytics.tsx'
 const analyticsLayouts = [
@@ -668,6 +671,19 @@ describe('private provider loading contract', () => {
     expect(profileSource).not.toContain('SidebarWalletActions')
     expect(profileSource).not.toContain("from '@/hooks/useNetworkContext'")
     expect(profileSource).not.toContain("from '@/hooks/writeContracts/useClaimNFTL'")
+  })
+})
+
+describe('shared value equality contract', () => {
+  it('keeps lodash equality out of eager app utilities', () => {
+    const utilitySource = readFileSync(join(process.cwd(), valueEqualityUtility), 'utf8')
+
+    expect(utilitySource).not.toContain('lodash')
+    for (const file of [localStorageHook, contractReaderHook]) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source).toContain("from '@/utils/value-equality'")
+      expect(source).not.toContain("from 'lodash/isEqual'")
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- replace the eager `lodash/isEqual` imports in `useLocalStorage` and `useContractReader` with one shared native value-equality utility
- preserve nested values, arrays, dates, BigInt values, and cyclic object behavior needed by these hooks
- add a route contract so lodash equality does not return to the eager app utilities

## Performance evidence

- private dashboard route entry: 193,713 bytes on `origin/staging` -> 179,429 bytes locally (-14,284 bytes, about 7.4%)
- dashboard initial scripts: 768,979 bytes baseline -> 754,567 bytes locally (-14,412 bytes)
- public route shell remained unchanged at 124,614 bytes
- lodash remains available to deferred feature modules that still use it; this removes it from the eager private/auth shell path

## Validation

- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app build`
- `bun run --cwd apps/app test` — 170 passed, 0 failed
- `bun test --isolate test/contract/route-surface.test.ts test/contract/dependencies.test.ts` — 261 passed, 0 failed
- production smoke: `/dashboard/overview` and `/verification` returned HTTP 200
- Prettier check and `git diff --check`

This is intentionally a draft to keep hosted CI and Vercel spend at zero until the milestone is ready for review.
