### PR TITLE
perf(ui): scope font preloads by app theme

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -4,7 +4,9 @@ import Script from 'next/script'
 
 import DeferredSentry from '@nl/sentry-client/react'
 import { DeferredAnalytics } from '@nl/ui/gtm'
-import { customFontClassName } from '@nl/ui/fonts'
+import { defaultFont } from '@nl/ui/fonts/default'
+import { headerFont } from '@nl/ui/fonts/header'
+import { subheaderFont } from '@nl/ui/fonts/subheader'
 import { cn } from '@nl/ui/utils'
 
 import '@/styles/app.css'
@@ -62,7 +64,11 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={cn(defaultFont.variable, headerFont.variable, subheaderFont.variable, 'dark')}
+    >
       <DeferredAnalytics />
       <DeferredSentry
         enabled={process.env.VERCEL_ENV === 'production'}

--- a/apps/smashers/src/app/layout.tsx
+++ b/apps/smashers/src/app/layout.tsx
@@ -3,7 +3,10 @@ import type { Metadata, Viewport } from 'next'
 
 import DeferredSentry from '@nl/sentry-client/react'
 import { DeferredAnalytics } from '@nl/ui/gtm'
-import { customFontClassName } from '@nl/ui/fonts'
+import { defaultFont } from '@nl/ui/fonts/default'
+import { headerFont } from '@nl/ui/fonts/header'
+import { specialFont } from '@nl/ui/fonts/special'
+import { subheaderFont } from '@nl/ui/fonts/subheader'
 import { cn } from '@nl/ui/utils'
 
 import '@/styles/app.css'
@@ -76,7 +79,17 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={cn(
+        defaultFont.variable,
+        headerFont.variable,
+        subheaderFont.variable,
+        specialFont.variable,
+        'dark'
+      )}
+    >
       <DeferredAnalytics />
       <DeferredSentry
         enabled={process.env.VERCEL_ENV === 'production'}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,9 @@ import type { PropsWithChildren } from 'react'
 import type { Metadata, Viewport } from 'next'
 
 import DeferredSentry from '@nl/sentry-client/react'
-import { customFontClassName } from '@nl/ui/fonts'
+import { defaultFont } from '@nl/ui/fonts/default'
+import { headerFont } from '@nl/ui/fonts/header'
+import { specialFont } from '@nl/ui/fonts/special'
 import { cn } from '@nl/ui/utils'
 
 import '@/styles/app.css'
@@ -59,7 +61,11 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn(customFontClassName, 'dark')}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={cn(defaultFont.variable, headerFont.variable, specialFont.variable, 'dark')}
+    >
       <DeferredSentry
         enabled={process.env.VERCEL_ENV === 'production'}
         options={{

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
     "./custom/*": "./src/components/custom/*/index.tsx",
     "./hooks/*": "./src/hooks/*.ts",
     "./fonts": "./src/lib/fonts/index.ts",
+    "./fonts/*": "./src/lib/fonts/*.ts",
     "./gtm": "./src/lib/gtm/index.tsx",
     "./utils": "./src/lib/utils.ts",
     "./postcss.config": "./postcss.config.mjs",

--- a/packages/ui/src/lib/fonts/default.ts
+++ b/packages/ui/src/lib/fonts/default.ts
@@ -1,0 +1,18 @@
+import localFont from 'next/font/local'
+
+export const defaultFont = localFont({
+  src: [
+    {
+      path: './assets/ibm-plex-sans-400.woff2',
+      weight: '400 700',
+      style: 'normal',
+    },
+    {
+      path: './assets/ibm-plex-sans-italic-400.woff2',
+      weight: '400 700',
+      style: 'italic',
+    },
+  ],
+  variable: '--font-ibm-plex-sans',
+  display: 'swap',
+})

--- a/packages/ui/src/lib/fonts/header.ts
+++ b/packages/ui/src/lib/fonts/header.ts
@@ -1,0 +1,9 @@
+import localFont from 'next/font/local'
+
+export const headerFont = localFont({
+  src: './NexaRustSans_Black/NexaRustSans-Black.woff2',
+  weight: '700',
+  style: 'normal',
+  variable: '--font-nexa-rust-sans-black',
+  display: 'swap',
+})

--- a/packages/ui/src/lib/fonts/index.ts
+++ b/packages/ui/src/lib/fonts/index.ts
@@ -1,40 +1,16 @@
-import localFont from 'next/font/local'
+export { defaultFont as imbPlexSans } from './default'
+export { headerFont as nexaRustSansBlack } from './header'
+export { specialFont as pressStart } from './special'
+export { subheaderFont as lilitaOne } from './subheader'
 
-export const imbPlexSans = localFont({
-  src: [
-    {
-      path: './assets/ibm-plex-sans-400.woff2',
-      weight: '400 700',
-      style: 'normal',
-    },
-    {
-      path: './assets/ibm-plex-sans-italic-400.woff2',
-      weight: '400 700',
-      style: 'italic',
-    },
-  ],
-  variable: '--font-ibm-plex-sans',
-  display: 'swap',
-})
+import { defaultFont } from './default'
+import { headerFont } from './header'
+import { specialFont } from './special'
+import { subheaderFont } from './subheader'
 
-export const lilitaOne = localFont({
-  src: './assets/lilita-one-400.woff2',
-  variable: '--font-lilita-one',
-  display: 'swap',
-})
-
-export const pressStart = localFont({
-  src: './assets/press-start-2p-400.woff2',
-  variable: '--font-press-start',
-  display: 'swap',
-})
-
-export const nexaRustSansBlack = localFont({
-  src: './NexaRustSans_Black/NexaRustSans-Black.woff2',
-  weight: '700',
-  style: 'normal',
-  variable: '--font-nexa-rust-sans-black',
-  display: 'swap',
-})
-
-export const customFontClassName = `${imbPlexSans.variable} ${lilitaOne.variable} ${nexaRustSansBlack.variable} ${pressStart.variable}`
+export const customFontClassName = [
+  defaultFont.variable,
+  subheaderFont.variable,
+  headerFont.variable,
+  specialFont.variable,
+].join(' ')

--- a/packages/ui/src/lib/fonts/special.ts
+++ b/packages/ui/src/lib/fonts/special.ts
@@ -1,0 +1,7 @@
+import localFont from 'next/font/local'
+
+export const specialFont = localFont({
+  src: './assets/press-start-2p-400.woff2',
+  variable: '--font-press-start',
+  display: 'swap',
+})

--- a/packages/ui/src/lib/fonts/subheader.ts
+++ b/packages/ui/src/lib/fonts/subheader.ts
@@ -1,0 +1,7 @@
+import localFont from 'next/font/local'
+
+export const subheaderFont = localFont({
+  src: './assets/lilita-one-400.woff2',
+  variable: '--font-lilita-one',
+  display: 'swap',
+})

--- a/test/contract/font-loading.test.ts
+++ b/test/contract/font-loading.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const fontLayoutContracts = [
+  {
+    app: 'web',
+    layout: 'apps/web/src/app/layout.tsx',
+    required: ['default', 'header', 'special'],
+    omitted: ['subheader'],
+  },
+  {
+    app: 'app',
+    layout: 'apps/app/src/app/layout.tsx',
+    required: ['default', 'header', 'subheader'],
+    omitted: ['special'],
+  },
+  {
+    app: 'smashers',
+    layout: 'apps/smashers/src/app/layout.tsx',
+    required: ['default', 'header', 'subheader', 'special'],
+    omitted: [],
+  },
+] as const
+
+describe('shared font loading contract', () => {
+  for (const contract of fontLayoutContracts) {
+    it(`${contract.app} loads only the font families required by its theme`, () => {
+      const source = readFileSync(join(process.cwd(), contract.layout), 'utf8')
+
+      expect(source).not.toContain("from '@nl/ui/fonts'")
+      for (const font of contract.required) {
+        expect(source).toContain(`from '@nl/ui/fonts/${font}'`)
+      }
+      for (const font of contract.omitted) {
+        expect(source).not.toContain(`from '@nl/ui/fonts/${font}'`)
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- split the shared `next/font/local` definitions into independently importable semantic font modules
- load only the font files required by each app's existing theme variables
- preserve the legacy all-font export for shared consumers while preventing the three Next app roots from importing unused families
- add a contract test to prevent broad font imports from returning to app layouts

## Performance evidence

The generated route HTML previously preloaded all five shared font files (152,204 bytes) for every app.

- `apps/web`: 4 files, omitting unused Lilita One; saves 10,672 bytes from the preload set
- `apps/app`: 4 files, omitting unused Press Start 2P; saves 12,512 bytes from the preload set
- `apps/smashers`: retains all required themed font files with no visual fallback substitution

The fonts remain local, use the existing `swap` behavior, and keep the existing typography variables/theme values intact.

## Validation

- `bun run --cwd packages/ui type-check`
- type-check for `apps/web`, `apps/app`, and `apps/smashers`
- production builds for all three Next apps
- full package/app suites: UI 138 passed; web 14 passed; app 167 passed; Smashers 15 passed
- contract suite: 263 passed, 0 failed
- built-server smoke: web `/` and `/games`, app `/` and `/verification`, Smashers `/` and `/loot` all returned HTTP 200
- Prettier check, `git diff --check`, and `bunx code-foundry doctor`

This is intentionally a draft so hosted CI and Vercel remain skipped until the milestone is ready.
