### PR TITLE
perf(app): replace responsive table deep clones

### DIFF
--- a/apps/app/src/components/ResponsiveTable/DataList.tsx
+++ b/apps/app/src/components/ResponsiveTable/DataList.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { cloneDeep } from 'lodash'
 import { Checkbox } from '@nl/ui/base/checkbox'
 
 import { CellRenderer, LabelRenderer } from './Renderer'
@@ -80,7 +79,7 @@ const DataList: React.FC<DataListProps> = (props) => {
     onChangePage(event, page)
 
   const handleSelection = (row: Row) => {
-    const newSelection = cloneDeep(selection)
+    const newSelection = [...selection]
     const rowId = row.id || (row.user_id as string | number)
     if (newSelection.indexOf(rowId) === -1) {
       newSelection.push(rowId)
@@ -92,7 +91,7 @@ const DataList: React.FC<DataListProps> = (props) => {
   }
 
   const handleSelectAll = () => {
-    let newSelection = cloneDeep(selection)
+    let newSelection = [...selection]
     if (newSelection.length > 0) {
       newSelection = []
     } else {

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
+
+describe('app performance contracts', () => {
+  it('uses native shallow copies for primitive responsive-table selection state', () => {
+    const source = readFileSync(responsiveTableList, 'utf8')
+
+    expect(source).not.toContain("from 'lodash'")
+    expect(source.match(/\.\.\.selection/g)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## What changed

- Replace lodash `cloneDeep` with native shallow copies in the responsive mobile table.
- Add a contract guard so primitive selection state does not regress to a deep-clone dependency.

## Why

Responsive-table selection contains only string and number IDs. A recursive clone adds interaction-time work without changing behavior, and the native copy is simpler and easier to tree-shake.

## Validation

- `bun run --cwd apps/app build`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app test` — 167 passed
- Contract/dependency suite — 261 passed
- Prettier and `git diff --check`
- Runtime smoke: `/leaderboards` returned HTTP 200

The generated `/leaderboards` route remained 13 scripts / 699,437 bytes; this milestone targets selection-time work and dependency complexity rather than claiming a first-load byte reduction.