### PR TITLE
perf(app): replace trivial lodash collection helpers

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
@@ -5,8 +5,6 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
 import { useAccount } from 'wagmi'
-import isEmpty from 'lodash/isEmpty'
-import xor from 'lodash/xor'
 
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { Button } from '@nl/ui/base/button'
@@ -40,6 +38,7 @@ import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import DegensTopNav from '@/components/extended/DegensTopNav'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
 import { isAuditFixtureEnabled } from '@/audit/fixture'
+import { hasEntries, toggleValue } from '@/utils/collections'
 
 const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
   ssr: false,
@@ -108,7 +107,7 @@ const DashboardDegensPageContent = (): React.ReactNode => {
     setDefaultValues(getDefaultFilterValueFromData(populatedDegens))
     const params = Object.fromEntries(searchParams.entries())
     let newDegens = populatedDegens
-    if (!isEmpty(params)) {
+    if (hasEntries(params)) {
       if (params.searchTerm) setSearchTerm(params.searchTerm)
       const newFilterOptions = updateFilterValue(defaultValues, params)
       if (newFilterOptions) {
@@ -197,10 +196,7 @@ const DashboardDegensPageContent = (): React.ReactNode => {
 
   const handleClickFavorite = useCallback(
     async (degen: Degen) => {
-      const newFavs = xor(
-        favDegens?.filter((f) => f),
-        [degen.id]
-      )
+      const newFavs = toggleValue(favDegens?.filter((f) => f) ?? [], degen.id)
       await fetch(`${PROFILE_FAV_DEGENS_API}`, {
         method: 'POST',
         body: JSON.stringify({ favorites: newFavs.toString() }),

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/_components/comics-grid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/_components/comics-grid.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from 'react'
 import Image from 'next/image'
-import xor from 'lodash/xor'
-import sum from 'lodash/sum'
 import { Skeleton } from '@nl/ui/base/skeleton'
 import { Icon } from '@nl/ui/base/icon'
 import { Input } from '@nl/ui/custom/input'
 
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
 import type { Comic } from '@/types/marketplace'
+import { toggleValue } from '@/utils/collections'
 
 import styles from './comics-grid.module.css'
 
@@ -38,7 +37,10 @@ export default function ComicsGrid({
     () => (burnCount.some((v) => v === 0) ? 0 : Math.min(...burnCount)),
     [burnCount]
   )
-  const itemCount = useMemo(() => sum(burnCount) - keyCount * 6, [burnCount, keyCount])
+  const itemCount = useMemo(
+    () => burnCount.reduce((total, count) => total + count, 0) - keyCount * 6,
+    [burnCount, keyCount]
+  )
 
   const handleManualSetBurnCount = (comic: Comic, value: string) => {
     const newBurnCount = [...burnCount]
@@ -59,8 +61,7 @@ export default function ComicsGrid({
   }
 
   const handleSelectComic = (comic: Comic) => {
-    // xor creates an array of unique values that is the symmetric difference of the given arrays
-    const newSelectedComics = xor(selectedComics, [comic])
+    const newSelectedComics = toggleValue(selectedComics, comic)
     setSelectedComics(newSelectedComics)
     handleUpdateBurnCount(comic, newSelectedComics)
   }

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import xor from 'lodash/xor'
 import { Button } from '@nl/ui/base/button'
 import { Dialog, DialogContent } from '@nl/ui/base/dialog'
 
@@ -21,6 +20,7 @@ import { useProfileFavDegens } from '@/hooks/useGamerProfile'
 import useAuth from '@/hooks/useAuth'
 import type { Degen } from '@/types/degens'
 import useLocalStorageContext from '@/hooks/useLocalStorageContext'
+import { toggleValue } from '@/utils/collections'
 
 const DegenCard = dynamic(
   () =>
@@ -102,10 +102,7 @@ const MyDegens = (): React.ReactNode => {
 
   const handleClickFavorite = useCallback(
     async (degen: Degen) => {
-      const newFavs = xor(
-        favDegens?.filter((f) => f),
-        [degen.id]
-      )
+      const newFavs = toggleValue(favDegens?.filter((f) => f) ?? [], degen.id)
       await fetch(`${PROFILE_FAV_DEGENS_API}`, {
         method: 'POST',
         body: JSON.stringify({ favorites: newFavs.toString() }),

--- a/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
+++ b/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import isEmpty from 'lodash/isEmpty'
 import { useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
 
@@ -23,6 +22,7 @@ import SectionTitle from '@/components/sections/SectionTitle'
 import { DEGEN_BASE_API_URL } from '@/constants/api'
 import useFetch from '@/hooks/useFetch'
 import usePagination from '@/hooks/usePagination'
+import { hasEntries } from '@/utils/collections'
 import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
 import DegensTopNav from '@/components/extended/DegensTopNav'
@@ -73,7 +73,7 @@ const AllDegensPage = (): React.ReactNode => {
     setDegens(originalDegens)
     const params = Object.fromEntries(searchParams.entries())
     let newDegens = originalDegens
-    if (!isEmpty(params)) {
+    if (hasEntries(params)) {
       if (params.searchTerm) setSearchTerm(params.searchTerm)
       const newFilterOptions = updateFilterValue(defaultValues, params)
       if (newFilterOptions) {
@@ -141,7 +141,7 @@ const AllDegensPage = (): React.ReactNode => {
 
   const renderDrawer = useCallback(
     () =>
-      !isEmpty(defaultValues) && (
+      hasEntries(defaultValues) && (
         <DeferredDegensFilter
           onFilter={handleFilter}
           defaultFilterValues={defaultValues as DegenFilter}

--- a/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-import isEmpty from 'lodash/isEmpty'
 import { Button } from '@nl/ui/base/button'
 import { Skeleton } from '@nl/ui/base/skeleton'
 import { Title } from '@nl/ui/custom/typography'
@@ -9,6 +8,7 @@ import { TRAIT_KEY_VALUE_MAP, TRAIT_NAME_MAP } from '@/constants/cosmeticsFilter
 import type { Degen, GetDegenResponse } from '@/types/degens'
 import { DEGEN_PURCHASE_URL } from '@/constants/public-urls'
 import type { SxProps } from '@/types'
+import { hasEntries } from '@/utils/collections'
 
 export interface ViewTraitsContentDialogProps {
   degen?: Degen
@@ -84,7 +84,7 @@ const ViewTraitsContentDialog = ({
             <Title level={3}>Degen Traits</Title>
           </div>
           <div className="mt-6 grid grid-cols-12 justify-center gap-x-4 gap-y-6">
-            {isEmpty(traits)
+            {!hasEntries(traits)
               ? [...Array(9)].map((_, index) => (
                   <div className="col-span-3" key={`trait-skeleton-${index}`}>
                     <div className="flex flex-col items-center">

--- a/apps/app/src/components/extended/DegensFilter/index.tsx
+++ b/apps/app/src/components/extended/DegensFilter/index.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react'
 import Image from 'next/image'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import isEmpty from 'lodash/isEmpty'
 import { cn } from '@nl/ui/utils'
 import { Button } from '@nl/ui/base/button'
 import { Checkbox } from '@nl/ui/base/checkbox'
@@ -21,6 +20,7 @@ import type { DegenFilter } from '@/types/degenFilter'
 import { updateFilterValue } from './utils'
 import FilterAccordion from './FilterAccordion'
 import FilterAllTraitCheckboxes from '../FilterAllTraitCheckboxes'
+import { hasEntries } from '@/utils/collections'
 
 import styles from './index.module.css'
 
@@ -43,7 +43,7 @@ const DegensFilter = ({
     () => Object.fromEntries(searchParams.entries()) as { [key in FilterSource]?: string },
     [searchParams]
   )
-  const isParamsEmpty = isEmpty(params)
+  const isParamsEmpty = !hasEntries(params)
 
   // Filter states
   const [showMore, setShowMore] = useState(false)

--- a/apps/app/src/utils/collections.test.ts
+++ b/apps/app/src/utils/collections.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test'
+
+import { hasEntries, toggleValue } from './collections'
+
+describe('collection helpers', () => {
+  it('detects non-empty records without treating nullish values as entries', () => {
+    expect(hasEntries(undefined)).toBe(false)
+    expect(hasEntries(null)).toBe(false)
+    expect(hasEntries({})).toBe(false)
+    expect(hasEntries({ filter: '' })).toBe(true)
+  })
+
+  it('toggles primitive and reference values while preserving order', () => {
+    expect(toggleValue(['one', 'two'], 'one')).toEqual(['two'])
+    expect(toggleValue(['one'], 'two')).toEqual(['one', 'two'])
+
+    const item = { id: 1 }
+    expect(toggleValue([item], item)).toEqual([])
+    expect(toggleValue([], item)).toEqual([item])
+  })
+})

--- a/apps/app/src/utils/collections.ts
+++ b/apps/app/src/utils/collections.ts
@@ -1,0 +1,9 @@
+export function hasEntries(value: object | null | undefined): boolean {
+  return value !== null && value !== undefined && Object.keys(value).length > 0
+}
+
+export function toggleValue<T>(values: readonly T[], value: T): T[] {
+  const index = values.indexOf(value)
+  if (index === -1) return [...values, value]
+  return values.filter((_, currentIndex) => currentIndex !== index)
+}

--- a/bun.lock
+++ b/bun.lock
@@ -254,13 +254,11 @@
         "@nl/ui": "workspace:*",
         "ethers": "^6.17.0",
         "https": "^1.0.0",
-        "lodash": "^4.18.1",
         "notistack": "^3.0.2",
         "swr": "^2.4.2",
         "url": "^0.11.4",
       },
       "devDependencies": {
-        "@types/lodash": "^4.17.25",
         "@types/node": "^26.1.2",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",

--- a/packages/playfab/package.json
+++ b/packages/playfab/package.json
@@ -28,13 +28,11 @@
     "@nl/ui": "workspace:*",
     "ethers": "^6.17.0",
     "https": "^1.0.0",
-    "lodash": "^4.18.1",
     "notistack": "^3.0.2",
     "swr": "^2.4.2",
     "url": "^0.11.4"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.25",
     "@types/node": "^26.1.2",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4"

--- a/packages/playfab/src/components/AccountDetails/index.tsx
+++ b/packages/playfab/src/components/AccountDetails/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import isEmpty from 'lodash/isEmpty'
 import { useSnackbar } from 'notistack'
 
 import { fetchJson } from '../../utils/fetchJson'
@@ -44,7 +43,7 @@ export default function AccountDetails({
   const providers = useProviders()
 
   useEffect(() => {
-    if (account && !isEmpty(account)) {
+    if (account && Object.keys(account).length > 0) {
       setEmail(account.PrivateInfo?.Email)
       setAvatarUrl(profile?.AvatarUrl)
       setDisplayName(publisherData?.DisplayName?.Value)

--- a/test/contract/native-collections.test.ts
+++ b/test/contract/native-collections.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const appCollectionConsumers = [
+  'apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx',
+  'apps/app/src/components/extended/DegensFilter/index.tsx',
+  'apps/app/src/components/dialog/DegenDialog/ViewTraitsContentDialog.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/items/burner/_components/comics-grid.tsx',
+]
+
+describe('native collection contracts', () => {
+  it('keeps trivial collection operations out of app route consumers', () => {
+    for (const file of appCollectionConsumers) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).not.toMatch(/from ['\"]lodash\/(isEmpty|sum|xor)['\"]/)
+    }
+  })
+
+  it('keeps PlayFab free of a dependency used only by removed helpers', () => {
+    const manifest = JSON.parse(readFileSync('packages/playfab/package.json', 'utf8'))
+
+    expect(manifest.dependencies?.lodash).toBeUndefined()
+    expect(manifest.devDependencies?.['@types/lodash']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What changed

- Add shared `hasEntries` and `toggleValue` helpers for app collection operations.
- Replace low-risk `lodash/isEmpty`, `lodash/xor`, and `lodash/sum` usage across public degen filters and dashboard flows.
- Remove PlayFab’s direct lodash and `@types/lodash` dependencies and refresh `bun.lock`.
- Add unit and contract coverage for the native helpers and dependency boundary.

## Why

These consumers only needed empty-record checks, array toggling, or numeric reduction. The general-purpose lodash helpers added dependency edges and route code for behavior that native operations express directly. The shared helper keeps array toggling consistent across dashboard screens.

## Evidence

- `/degens` route: 13 scripts, 698,642 bytes -> 13 scripts, 698,609 bytes (33 bytes smaller).
- `/leaderboards` route unchanged at 13 scripts / 699,437 bytes.
- PlayFab’s direct lodash dependency is removed from both `package.json` and `bun.lock`.

## Validation

- `bun run --cwd apps/app build`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app test` — 169 passed
- `bun run --cwd packages/playfab lint`
- `bun run --cwd packages/playfab type-check`
- `bun run --cwd packages/playfab test` — 83 passed
- Contract/dependency suite — 128 passed
- Runtime smoke: `/degens?searchTerm=ape` returned HTTP 200
- Prettier and `git diff --check`

Existing equality and responsive-table lodash work remains isolated in draft PRs #532 and #535 to avoid overlapping changes.