### PR TITLE
perf(web): lazy-load shared YouTube embeds

### DIFF
--- a/apps/web/src/app/(main)/compete-and-earn/page.tsx
+++ b/apps/web/src/app/(main)/compete-and-earn/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import type { NextPage } from 'next'
 import { cn } from '@nl/ui/utils'
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
 import styles from './index.module.css'
 
@@ -68,11 +69,8 @@ const CompeteAndEarn: NextPage = () => {
         <div className="w-full md:w-1/2">
           <AnimatedWrapper>
             <div className="relative text-right transition-fade-slow transition-fade-start delay-normal mb-4 md:mb-0 ps-0 lg:ps-5">
-              <iframe
+              <LazyYouTubeEmbed
                 src="https://www.youtube.com/embed/wv_fI1PPBi0"
-                frameBorder="0"
-                allow="autoplay; encrypted-media"
-                allowFullScreen
                 title="Nifty League Compete & Earn"
                 className={styles.video}
               />

--- a/apps/web/src/app/(main)/degens/page.tsx
+++ b/apps/web/src/app/(main)/degens/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { DegenSpecialsTable } from '@nl/ui/custom/degen-specials-table'
+import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
 import { cn } from '@nl/ui/utils'
 
 import { NIFTY_DEGENS_ALL } from '@/constants/degens'
@@ -51,13 +52,10 @@ const Degens: NextPage = () => (
           <div className="w-full md:w-1/2">
             <AnimatedWrapper>
               <div className="relative text-right transition-fade-slow transition-fade-start delay-normal mb-4 md:mb-0 ps-0 lg:pl-5">
-                <iframe
-                  width="100%"
-                  height="315"
+                <LazyYouTubeEmbed
                   src="https://www.youtube.com/embed/WWLqE1tnf6U"
-                  frameBorder="0"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  allowFullScreen
+                  title="Nifty League DEGENs"
+                  className="h-[315px] w-full"
                 />
               </div>
             </AnimatedWrapper>

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next'
 import Image from 'next/image'
 
 import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 import { cn } from '@nl/ui/utils'
 
@@ -125,14 +126,7 @@ const Games: NextPage = () => (
             <AnimatedWrapper>
               <div className="relative text-right transition-fade-slow transition-fade-start delay-normal mb-4">
                 {video.includes('youtube') ? (
-                  <iframe
-                    src={video}
-                    frameBorder="0"
-                    allow="autoplay; encrypted-media"
-                    allowFullScreen
-                    title={name}
-                    className={styles.video}
-                  />
+                  <LazyYouTubeEmbed src={video} title={name} className={styles.video} />
                 ) : (
                   <ViewportVideo
                     id="console-video"

--- a/packages/ui/src/components/custom/lazy-youtube-embed/index.tsx
+++ b/packages/ui/src/components/custom/lazy-youtube-embed/index.tsx
@@ -1,0 +1,34 @@
+import type { ComponentPropsWithoutRef } from 'react'
+
+const YOUTUBE_ALLOW =
+  'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+
+type LazyYouTubeEmbedProps = Omit<
+  ComponentPropsWithoutRef<'iframe'>,
+  'allow' | 'allowFullScreen' | 'loading' | 'src' | 'title'
+> & {
+  src: string
+  title: string
+}
+
+/**
+ * Shared accessible YouTube embed with native browser lazy loading.
+ *
+ * Keeping the iframe behind one primitive prevents marketing pages from
+ * eagerly opening third-party connections before a visitor reaches the video.
+ */
+export function LazyYouTubeEmbed({ src, title, ...props }: LazyYouTubeEmbedProps) {
+  return (
+    <iframe
+      {...props}
+      src={src}
+      title={title}
+      loading="lazy"
+      allow={YOUTUBE_ALLOW}
+      allowFullScreen
+      frameBorder={0}
+    />
+  )
+}
+
+export default LazyYouTubeEmbed

--- a/packages/ui/src/components/custom/lazy-youtube-embed/lazy-youtube-embed.test.tsx
+++ b/packages/ui/src/components/custom/lazy-youtube-embed/lazy-youtube-embed.test.tsx
@@ -6,11 +6,7 @@ import { LazyYouTubeEmbed } from './index'
 describe('LazyYouTubeEmbed', () => {
   it('renders an accessible, natively lazy YouTube iframe', () => {
     const { container } = render(
-      <LazyYouTubeEmbed
-        src="about:blank"
-        title="Example game trailer"
-        className="aspect-video"
-      />
+      <LazyYouTubeEmbed src="about:blank" title="Example game trailer" className="aspect-video" />
     )
     const iframe = container.querySelector('iframe')
 

--- a/packages/ui/src/components/custom/lazy-youtube-embed/lazy-youtube-embed.test.tsx
+++ b/packages/ui/src/components/custom/lazy-youtube-embed/lazy-youtube-embed.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { LazyYouTubeEmbed } from './index'
+
+describe('LazyYouTubeEmbed', () => {
+  it('renders an accessible, natively lazy YouTube iframe', () => {
+    const { container } = render(
+      <LazyYouTubeEmbed
+        src="about:blank"
+        title="Example game trailer"
+        className="aspect-video"
+      />
+    )
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe('about:blank')
+    expect(iframe?.getAttribute('title')).toBe('Example game trailer')
+    expect(iframe?.getAttribute('loading')).toBe('lazy')
+    expect(iframe?.getAttribute('allow')).toContain('autoplay')
+    expect(iframe?.getAttribute('frameborder')).toBe('0')
+    expect(iframe?.className).toBe('aspect-video')
+  })
+})

--- a/test/contract/web-embed-policy.test.ts
+++ b/test/contract/web-embed-policy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const marketingEmbedConsumers = [
+  'apps/web/src/app/(main)/games/page.tsx',
+  'apps/web/src/app/(main)/compete-and-earn/page.tsx',
+  'apps/web/src/app/(main)/degens/page.tsx',
+]
+
+describe('marketing video embed policy', () => {
+  it('uses the shared lazy YouTube primitive for every marketing embed', () => {
+    for (const file of marketingEmbedConsumers) {
+      const source = readFileSync(file, 'utf8')
+
+      expect(source).toContain('@nl/ui/custom/lazy-youtube-embed')
+      expect(source).not.toMatch(/<iframe\b/)
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- Add a shared `@nl/ui/custom/lazy-youtube-embed` primitive with native `loading="lazy"` and a required accessible title.
- Replace the three duplicated marketing YouTube iframes on Games, Compete & Earn, and DEGENs pages.
- Preserve existing layout classes and embed behavior while standardizing permissions and iframe attributes.
- Add component and source-policy contracts.

## Impact

Marketing pages no longer eagerly open YouTube iframe connections before the video is near the viewport. The DEGENs embed also gains the missing accessible title.

## Validation

- `bun run --cwd packages/ui test -- src/components/custom/lazy-youtube-embed/lazy-youtube-embed.test.tsx`
- `bun run --cwd packages/ui type-check`
- `bun run --cwd packages/ui lint`
- `bun run --cwd apps/web type-check`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web build`
- `bun test --isolate test/contract/web-embed-policy.test.ts`
- Runtime smoke checks for `/games`, `/compete-and-earn`, and `/degens` returned HTTP 200 with lazy, titled iframes.

Hosted CI and Vercel remain deferred while this PR is draft.