### PR TITLE
fix(ci): configure realignment preview identity

### DIFF
--- a/.github/workflows/re-align-staging.yml
+++ b/.github/workflows/re-align-staging.yml
@@ -54,6 +54,8 @@ jobs:
             }
             trap cleanup_preview EXIT
             git worktree add --detach "$preview_dir" origin/staging >/dev/null
+            git -C "$preview_dir" config user.name "re-align-preview"
+            git -C "$preview_dir" config user.email "re-align-preview@users.noreply.github.com"
 
             resolve_ours_conflicts() {
               local conflicted_path


### PR DESCRIPTION
## Summary
- give the isolated re-alignment preview an explicit local Git identity
- allow the staging-first conflict simulation to run on GitHub-hosted runners

## Validation
- Prettier and YAML checks pass
- follows the already-merged conflict-safe re-alignment policy in #545