### PR TITLE
perf(app): remove remaining lodash imports

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -35,7 +35,6 @@
     "ethers": "^6.17.0",
     "graphql": "^17.0.2",
     "graphql-request": "^7.4.0",
-    "lodash": "^4.18.1",
     "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
@@ -53,7 +52,6 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.25",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@types/react-slick": "^0.23.13"

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
-import merge from 'lodash/merge'
 
 import { Title } from '@nl/ui/custom/typography'
 
@@ -26,6 +25,7 @@ const GamerProfileContent = (): React.ReactNode => {
   const { profile, error, loadingProfile } = useGamerProfile()
   const { address } = useAccount()
   const { avatarsAndFee } = useProfileAvatarFee()
+  const profileAvatars = avatarsAndFee?.avatars
   const { data } = useFetch<Degen[]>(`${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`)
 
   const { comicsBalances, degenCount, degensBalances, itemsBalances } = useNFTsBalances()
@@ -58,6 +58,15 @@ const GamerProfileContent = (): React.ReactNode => {
     [itemsBalances]
   )
 
+  const profileDegens = useMemo(() => {
+    if (!profileAvatars) return filteredDegens
+
+    return filteredDegens.map((degen, index) => ({
+      ...degen,
+      ...(profileAvatars[index] ?? {}),
+    }))
+  }, [filteredDegens, profileAvatars])
+
   const renderEmptyProfile = () => {
     return (
       <div className="flex h-full items-center justify-center">
@@ -73,11 +82,7 @@ const GamerProfileContent = (): React.ReactNode => {
           <ImageProfile
             avatar={profile?.avatar}
             avatarFee={avatarsAndFee?.price}
-            degens={
-              filteredDegens &&
-              avatarsAndFee?.avatars &&
-              merge(filteredDegens, avatarsAndFee?.avatars)
-            }
+            degens={profileDegens}
           />
         </div>
         <div className="w-full min-w-0 lg:flex-1">

--- a/apps/app/src/components/dialog/DegenDialog/EquipDegenContentDialog/index.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/EquipDegenContentDialog/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import isEqual from 'lodash/isEqual'
 
 import { gtm, GTM_EVENTS } from '@nl/ui/gtm'
 import { Button } from '@nl/ui/base/button'
@@ -16,6 +15,7 @@ import type { Degen } from '@/types/degens'
 import DegenImage from '@/components/cards/DegenCard/DegenImage'
 import EmptyState from '@/components/EmptyState'
 import { Icon } from '@nl/ui/base/icon'
+import { areValuesEqual } from '@/utils/value-equality'
 
 import {
   getInventoryAnalyticsEventName,
@@ -101,7 +101,7 @@ const EquipDegenContentDialog = ({ degen, name }: EquipDegenContentDialogProps) 
   )
 
   const stateChanged = useMemo(
-    () => !isEqual(equipped, pendingEquipped),
+    () => !areValuesEqual(equipped, pendingEquipped),
     [equipped, pendingEquipped]
   )
 

--- a/apps/app/src/components/dialog/DegenDialog/TokenInfoBox.tsx
+++ b/apps/app/src/components/dialog/DegenDialog/TokenInfoBox.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useEffect, useMemo } from 'react'
-import debounce from 'lodash/debounce'
 import { cn } from '@nl/ui/utils'
 import { formatNumberToDisplay } from '@nl/ui/utils'
+import { useDebouncedCallback } from '@nl/ui/hooks/useDebouncedCallback'
 import useTokenUSDPrice from '@/hooks/useTokenUSDPrice'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 
@@ -40,20 +40,10 @@ const TokenInfoBox = ({
     return () => clearInterval(timer)
   }, [refetch])
 
-  const debouncedGetMarketplace = useMemo(
-    () =>
-      debounce(async (amount: string) => {
-        if (!amount || Number(amount) === 0) return
-        getMarketPrice(kind === 'From' ? OrderKind.SELL : OrderKind.BUY, amount)
-      }, 300),
-    [getMarketPrice, kind]
-  )
-
-  useEffect(() => {
-    return () => {
-      debouncedGetMarketplace.cancel()
-    }
-  }, [debouncedGetMarketplace])
+  const debouncedGetMarketplace = useDebouncedCallback((amount: string) => {
+    if (!amount || Number(amount) === 0) return
+    getMarketPrice(kind === 'From' ? OrderKind.SELL : OrderKind.BUY, amount)
+  }, 300)
 
   const handleChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,6 @@
         "ethers": "^6.17.0",
         "graphql": "^17.0.2",
         "graphql-request": "^7.4.0",
-        "lodash": "^4.18.1",
         "next": "16.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -118,7 +117,6 @@
         "yup": "^1.7.1",
       },
       "devDependencies": {
-        "@types/lodash": "^4.17.25",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@types/react-slick": "^0.23.13",
@@ -2333,8 +2331,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
-
-    "@types/lodash": ["@types/lodash@4.17.25", "", {}, "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 

--- a/packages/ui/src/hooks/useDebouncedCallback.test.tsx
+++ b/packages/ui/src/hooks/useDebouncedCallback.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, jest, mock } from 'bun:test'
+
+import { useDebouncedCallback } from './useDebouncedCallback'
+
+describe('useDebouncedCallback', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  it('coalesces calls and invokes the latest callback', () => {
+    const callback = mock()
+    const { result } = renderHook(() => useDebouncedCallback(callback, 300))
+
+    act(() => {
+      result.current('first')
+      result.current('second')
+      jest.advanceTimersByTime(299)
+    })
+    expect(callback).not.toHaveBeenCalled()
+
+    act(() => jest.advanceTimersByTime(1))
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('second')
+  })
+
+  it('uses the callback from the latest render without restarting the timer', () => {
+    const callback = mock()
+    const { result, rerender } = renderHook(
+      ({ prefix }: { prefix: string }) =>
+        useDebouncedCallback((value: string) => callback(`${prefix}:${value}`), 300),
+      { initialProps: { prefix: 'old' } }
+    )
+
+    act(() => result.current('value'))
+    rerender({ prefix: 'new' })
+    act(() => jest.advanceTimersByTime(300))
+
+    expect(callback).toHaveBeenCalledWith('new:value')
+  })
+
+  it('cancels pending work when the consumer unmounts', () => {
+    const callback = mock()
+    const { result, unmount } = renderHook(() => useDebouncedCallback(callback, 300))
+
+    act(() => result.current('value'))
+    unmount()
+    act(() => jest.advanceTimersByTime(300))
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/hooks/useDebouncedCallback.ts
+++ b/packages/ui/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+type Callback = (...args: never[]) => void
+
+/**
+ * Shares one small, cancellable debounce implementation across client apps.
+ * The callback ref keeps the pending timer on the same schedule while still
+ * invoking the latest callback after a render.
+ */
+export function useDebouncedCallback<T extends Callback>(callback: T, delay: number) {
+  const callbackRef = useRef(callback)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current === null) return
+    clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
+  }, [])
+
+  const debounced = useCallback(
+    (...args: Parameters<T>) => {
+      cancel()
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null
+        callbackRef.current(...args)
+      }, delay)
+    },
+    [cancel, delay]
+  )
+
+  useEffect(() => cancel, [cancel])
+
+  return debounced
+}
+
+export default useDebouncedCallback

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'node:fs'
 
 const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
+const appManifest = 'apps/app/package.json'
 
 describe('app performance contracts', () => {
   it('uses native shallow copies for primitive responsive-table selection state', () => {
@@ -9,5 +10,21 @@ describe('app performance contracts', () => {
 
     expect(source).not.toContain("from 'lodash'")
     expect(source.match(/\.\.\.selection/g)).toHaveLength(2)
+  })
+
+  it('keeps the app free of lodash route imports', () => {
+    const sources = [
+      'apps/app/src/components/dialog/DegenDialog/TokenInfoBox.tsx',
+      'apps/app/src/components/dialog/DegenDialog/EquipDegenContentDialog/index.tsx',
+      'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx',
+    ]
+
+    for (const file of sources) {
+      expect(readFileSync(file, 'utf8')).not.toMatch(/from ['\"]lodash(?:\/|['\"])/)
+    }
+
+    const manifest = JSON.parse(readFileSync(appManifest, 'utf8'))
+    expect(manifest.dependencies?.lodash).toBeUndefined()
+    expect(manifest.devDependencies?.['@types/lodash']).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- remove the last direct lodash imports from the app
- share a cancellable debounce hook through @nl/ui
- use native array/object composition and the existing value equality helper
- remove lodash and @types/lodash from the app manifest and lockfile

## Validation
- shared hook tests: 3 pass
- app contracts: 149 pass / 551 expectations
- app unit suite: 173 pass / 1,189 expectations
- @nl/ui tests: 144 pass / 340 expectations
- app type-check, lint, and production build pass (21/21 pages)

Draft milestone; hosted validation will be enabled when ready.