### PR TITLE
perf(web): slim home page animation client graph

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -11,8 +11,8 @@ describe('home page', () => {
     mock.module('@/components/MainLayout', () => ({
       default: ({ children }: PropsWithChildren) => <>{children}</>,
     }))
-    mock.module('@nl/ui/custom/animated-wrapper', () => ({
-      AnimatedWrapper: ({ children }: PropsWithChildren) => <>{children}</>,
+    mock.module('@nl/ui/custom/parallax-wrapper', () => ({
+      ParallaxWrapper: ({ children }: PropsWithChildren) => <>{children}</>,
     }))
     mock.module('@/components/BouncingNFTL', () => ({ default: () => null }))
     mock.module('@/components/MintOMatic', () => ({ default: () => null }))

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
+import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 import BouncingNFTL from '@/components/BouncingNFTL'
 import Carousel from '@/components/Carousel'
@@ -35,102 +35,88 @@ const DesktopIntro = () => {
             className="w-full h-auto"
           />
         </div>
-        <AnimatedWrapper>
-          <div className="absolute home-hero-characters-image flex-grow animate-zoom-out-large">
-            <Image
-              src="/img/hero/characters.webp"
-              alt="Nifty Hero Characters"
-              width={1920}
-              height={1042}
-              sizes="100vw"
-              className="w-full h-auto"
-            />
-          </div>
-        </AnimatedWrapper>
+        <div className="absolute home-hero-characters-image flex-grow animate-zoom-out-large">
+          <Image
+            src="/img/hero/characters.webp"
+            alt="Nifty Hero Characters"
+            width={1920}
+            height={1042}
+            sizes="100vw"
+            className="w-full h-auto"
+          />
+        </div>
         <div className="home-hero-companion">
           <div className="relative flex-grow">
-            <AnimatedWrapper>
-              <div className="animate-hover transition-fade-start transition-fade delay-extreme">
-                <Image
-                  src="/img/hero/companion-base.webp"
-                  alt="Home Hero Companion Base"
-                  width={175}
-                  height={175}
-                  className="pixelated w-full h-auto"
-                  sizes="100vw"
-                />
-                <div className="absolute home-hero-companion-swing animate-propeller" />
-              </div>
-            </AnimatedWrapper>
+            <div className="animate-hover transition-fade">
+              <Image
+                src="/img/hero/companion-base.webp"
+                alt="Home Hero Companion Base"
+                width={175}
+                height={175}
+                className="pixelated w-full h-auto"
+                sizes="100vw"
+              />
+              <div className="absolute home-hero-companion-swing animate-propeller" />
+            </div>
           </div>
         </div>
         <div className="home-hero-halo">
           <div className="flex-grow">
-            <AnimatedWrapper>
-              <div className="animate-hover transition-fade-start transition-fade delay-extreme-offset">
-                <Image
-                  src="/img/hero/halo.webp"
-                  alt="Home Hero Halo"
-                  width={133}
-                  height={50}
-                  sizes="100vw"
-                  className="w-full h-auto"
-                />
-              </div>
-            </AnimatedWrapper>
+            <div className="animate-hover transition-fade">
+              <Image
+                src="/img/hero/halo.webp"
+                alt="Home Hero Halo"
+                width={133}
+                height={50}
+                sizes="100vw"
+                className="w-full h-auto"
+              />
+            </div>
           </div>
         </div>
         <div className="dark-gradient-overlay" />
       </div>
 
       <div className="home-satoshi-container">
-        <AnimatedWrapper>
-          <div className="relative flex-grow home-satoshi transition-quick-pop-left transition-quick-pop-left-start delay-normal">
-            <Image
-              alt="Satoshi"
-              src="/img/hero/satoshi.webp"
-              width={180}
-              height={190}
-              sizes="100vw"
-              className="object-cover w-full h-auto"
-            />
-          </div>
-        </AnimatedWrapper>
+        <div className="relative flex-grow home-satoshi transition-quick-pop-left">
+          <Image
+            alt="Satoshi"
+            src="/img/hero/satoshi.webp"
+            width={180}
+            height={190}
+            sizes="100vw"
+            className="object-cover w-full h-auto"
+          />
+        </div>
       </div>
 
       <div className="flex flex-col mt-auto home-content">
-        <AnimatedWrapper>
-          <h1 className="home-content-title transition-vertical-fade transition-vertical-fade-start">
-            WELCOME TO <br />
-            NIFTY LEAGUE
-          </h1>
-        </AnimatedWrapper>
+        <h1 className="home-content-title transition-vertical-fade">
+          WELCOME TO <br />
+          NIFTY LEAGUE
+        </h1>
         <div className="my-2 lg:my-4">
-          <AnimatedWrapper>
-            <p className="home-content-description transition-vertical-fade transition-vertical-fade-start delay-lite">
-              <span className="whitespace-nowrap">DECENTRALIZED GAME STUDIO & PUBLISHER.</span>
-              <br />
-              <span className="whitespace-nowrap">BY GAMERS, FOR GAMERS.</span>
-            </p>
-          </AnimatedWrapper>
+          <p className="home-content-description transition-vertical-fade">
+            <span className="whitespace-nowrap">DECENTRALIZED GAME STUDIO & PUBLISHER.</span>
+            <br />
+            <span className="whitespace-nowrap">BY GAMERS, FOR GAMERS.</span>
+          </p>
         </div>
-        <AnimatedWrapper>
-          <a
-            href="#gaming-section"
-            aria-label="Learn more about Nifty League"
-            className="inline-block relative flex-grow satoshi-learn-more transition-fade-slow transition-fade-start delay-long"
-          >
-            <Image
-              src="/img/hero/speech-bubble.webp"
-              alt="Learn More"
-              width={348}
-              height={108}
-              sizes="100vw"
-              className="w-full h-auto"
-            />
-            <p className="m-0 p-0 speech-bubble-text">Learn More!</p>
-          </a>
-        </AnimatedWrapper>
+        <a
+          href="#gaming-section"
+          aria-label="Learn more about Nifty League"
+          className="inline-block relative flex-grow satoshi-learn-more transition-fade-slow"
+        >
+          <Image
+            src="/img/hero/speech-bubble.webp"
+            alt="Learn More"
+            width={348}
+            height={108}
+            sizes="100vw"
+            className="w-full h-auto"
+          />
+          <p className="m-0 p-0 speech-bubble-text">Learn More!</p>
+        </a>
       </div>
     </section>
   )
@@ -186,11 +172,9 @@ const Home = () => {
 
       {/* SMASHERS */}
       <section id="gaming-section" className="w-screen relative text-center">
-        <AnimatedWrapper>
-          <h2 className="absolute w-full z-10 -mt-4 sm:mt-8 md:mt-16 lg:mt-22 transition-vertical-fade transition-vertical-fade-start">
-            CLASSIC GAMING REINVENTED
-          </h2>
-        </AnimatedWrapper>
+        <h2 className="absolute w-full z-10 -mt-4 sm:mt-8 md:mt-16 lg:mt-22 transition-vertical-fade">
+          CLASSIC GAMING REINVENTED
+        </h2>
 
         <DeferredConsoleGame src="/video/smashers.mp4" />
 
@@ -203,11 +187,9 @@ const Home = () => {
 
       {/* DEGENS */}
       <section className="section w-screen relative flex flex-col text-center sliding-nfts">
-        <AnimatedWrapper>
-          <h2 className="my-3 lg:my-5 px-5 sm:px-8 transition-vertical-fade transition-vertical-fade-start">
-            <ResponsiveLabel mobile="OWN YOUR AVATAR" desktop="COMMUNITY-GENERATED AVATARS" />
-          </h2>
-        </AnimatedWrapper>
+        <h2 className="my-3 lg:my-5 px-5 sm:px-8 transition-vertical-fade">
+          <ResponsiveLabel mobile="OWN YOUR AVATAR" desktop="COMMUNITY-GENERATED AVATARS" />
+        </h2>
 
         <div className="relative pt-16 pb-8 px-0 mx-0 mb-12">
           <div className="absolute inset-0 mt-20 flex items-center justify-center z-10 pointer-events-none">
@@ -229,18 +211,16 @@ const Home = () => {
         <div className="w-full md:w-1/2 flex flex-col relative">
           <div className="purple-bg-orb orb-top-left" />
           <div className="block md:hidden relative w-full">
-            <AnimatedWrapper>
-              <div className="transition-quick-pop transition-quick-pop-start delay-lite">
-                <Image
-                  src="/img/compete-and-earn/mobile.webp"
-                  alt="Compete and Earn"
-                  width={655}
-                  height={275}
-                  sizes="100vw"
-                  className="w-full h-auto"
-                />
-              </div>
-            </AnimatedWrapper>
+            <div className="transition-quick-pop">
+              <Image
+                src="/img/compete-and-earn/mobile.webp"
+                alt="Compete and Earn"
+                width={655}
+                height={275}
+                sizes="100vw"
+                className="w-full h-auto"
+              />
+            </div>
           </div>
 
           <div className="hidden md:block relative">
@@ -248,18 +228,14 @@ const Home = () => {
           </div>
 
           <div className="relative flex flex-col items-center md:items-start">
-            <AnimatedWrapper>
-              <h2 className="mb-3 max-w-[400px] section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-                SMASHERS
-                <br />
-                <span className="whitespace-nowrap font-default font-normal">COMPETE & EARN</span>
-              </h2>
-            </AnimatedWrapper>
-            <AnimatedWrapper>
-              <p className="my-0 py-1 md:py-3 section-description transition-vertical-fade transition-vertical-fade-start delay-normal">
-                4 - 16 PLAYERS COMPETE IN A CUT-THROAT BATTLE FOR THE SURVIVAL OF THE FITTEST!
-              </p>
-            </AnimatedWrapper>
+            <h2 className="mb-3 max-w-[400px] section-heading transition-vertical-fade">
+              SMASHERS
+              <br />
+              <span className="whitespace-nowrap font-default font-normal">COMPETE & EARN</span>
+            </h2>
+            <p className="my-0 py-1 md:py-3 section-description transition-vertical-fade">
+              4 - 16 PLAYERS COMPETE IN A CUT-THROAT BATTLE FOR THE SURVIVAL OF THE FITTEST!
+            </p>
             <ThemeBtnGroup
               className="md:justify-start"
               primary={{
@@ -274,21 +250,19 @@ const Home = () => {
         </div>
 
         <div className="hidden md:block w-1/2 relative">
-          <AnimatedWrapper>
-            <div className="transition-quick-pop transition-quick-pop-start delay-normal">
-              <Image
-                src="/img/compete-and-earn/animated/competitors.webp"
-                alt="Compete and Earn"
-                width={668}
-                height={535}
-                sizes="100vw"
-                className="w-full h-auto"
-              />
-            </div>
-          </AnimatedWrapper>
+          <div className="transition-quick-pop">
+            <Image
+              src="/img/compete-and-earn/animated/competitors.webp"
+              alt="Compete and Earn"
+              width={668}
+              height={535}
+              sizes="100vw"
+              className="w-full h-auto"
+            />
+          </div>
           <div className="absolute scrolling-nftl-token">
-            <AnimatedWrapper parallax parallaxDirection="up" parallaxIntensity="extreme">
-              <div className="transition-fade-start transition-fade delay-long">
+            <ParallaxWrapper parallaxDirection="up" parallaxIntensity="extreme">
+              <div className="transition-fade">
                 <Image
                   alt="Scrolling NFTL Token"
                   className="pixelated w-full h-auto"
@@ -298,7 +272,7 @@ const Home = () => {
                   sizes="100vw"
                 />
               </div>
-            </AnimatedWrapper>
+            </ParallaxWrapper>
           </div>
         </div>
       </section>
@@ -306,34 +280,28 @@ const Home = () => {
       {/* NIFTYWORLD */}
       <section className="container section relative flex flex-row flex-wrap items-center">
         <div className="w-full md:w-1/2">
-          <AnimatedWrapper>
-            <div className="transition-fade transition-fade-start delay-normal">
-              <Image
-                src="/img/logos/niftyworld/app_logo.webp"
-                alt="Land in NiftyWorld"
-                width={612}
-                height={482}
-                sizes="100vw"
-                className="w-full h-auto"
-              />
-            </div>
-          </AnimatedWrapper>
+          <div className="transition-fade">
+            <Image
+              src="/img/logos/niftyworld/app_logo.webp"
+              alt="Land in NiftyWorld"
+              width={612}
+              height={482}
+              sizes="100vw"
+              className="w-full h-auto"
+            />
+          </div>
         </div>
         <div className="w-full md:w-1/2 relative pl-0 md:pl-6">
           <div className="purple-bg-orb orb-top-right" />
           <div className="flex flex-col relative items-center md:items-start">
-            <AnimatedWrapper>
-              <h2 className="mb-3 section-title section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-                DISCOVER
-                <br />
-                <span className="whitespace-nowrap font-default font-normal">NIFTYWORLD</span>
-              </h2>
-            </AnimatedWrapper>
-            <AnimatedWrapper>
-              <p className="my-0 py-1 lg:py-3 section-description transition-vertical-fade transition-vertical-fade-start delay-normal">
-                A VIRTUAL SOCIAL HUB LIKE NONE OTHER FOR GAMERS.
-              </p>
-            </AnimatedWrapper>
+            <h2 className="mb-3 section-title section-heading transition-vertical-fade">
+              DISCOVER
+              <br />
+              <span className="whitespace-nowrap font-default font-normal">NIFTYWORLD</span>
+            </h2>
+            <p className="my-0 py-1 lg:py-3 section-description transition-vertical-fade">
+              A VIRTUAL SOCIAL HUB LIKE NONE OTHER FOR GAMERS.
+            </p>
             <ThemeBtnGroup
               className="md:justify-start"
               primary={{ title: 'COMING SOON', disabled: true }}
@@ -345,32 +313,24 @@ const Home = () => {
 
       {/* DASHBOARDS */}
       <section className="section w-screen relative">
-        <AnimatedWrapper>
-          <div className="relative flex-grow transition-fade transition-fade-start delay-lite">
-            <Image
-              src="/img/misc/dashboard.webp"
-              alt="App Dashboard"
-              width={1920}
-              height={1172}
-              className="w-full h-auto"
-              sizes="100vw"
-            />
-            <div className="dark-gradient-overlay" />
-          </div>
-        </AnimatedWrapper>
+        <div className="relative flex-grow transition-fade">
+          <Image
+            src="/img/misc/dashboard.webp"
+            alt="App Dashboard"
+            width={1920}
+            height={1172}
+            className="w-full h-auto"
+            sizes="100vw"
+          />
+          <div className="dark-gradient-overlay" />
+        </div>
 
         <div className="flex flex-col relative w-full items-center px-4 md:absolute md:w-1/2 md:items-start md:h-full md:justify-center md:pl-10 md:top-0 lg:-top-20">
-          <AnimatedWrapper>
-            <h2 className="mb-3 section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-              DASHBOARDS
-            </h2>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="my-0 py-1 py-lg-3 section-description transition-vertical-fade transition-vertical-fade-start delay-normal">
-              ACCESS WEB3-ENABLED PLAYER DASHBOARDS TO SEE YOUR GAME STATS, WINNINGS, AND NIFTY
-              LEAGUE ASSETS.
-            </p>
-          </AnimatedWrapper>
+          <h2 className="mb-3 section-heading transition-vertical-fade">DASHBOARDS</h2>
+          <p className="my-0 py-1 py-lg-3 section-description transition-vertical-fade">
+            ACCESS WEB3-ENABLED PLAYER DASHBOARDS TO SEE YOUR GAME STATS, WINNINGS, AND NIFTY LEAGUE
+            ASSETS.
+          </p>
           <ThemeBtnGroup
             className="md:justify-start"
             primary={{ href: 'https://app.niftyleague.com', title: 'WEB3 APP', external: true }}
@@ -387,17 +347,11 @@ const Home = () => {
             <BouncingNFTL classes={{ token2: 'hidden' }} />
           </div>
 
-          <AnimatedWrapper>
-            <h2 className="mb-3 section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-              NFTL TOKEN
-            </h2>
-          </AnimatedWrapper>
-          <AnimatedWrapper>
-            <p className="py-1 lg:py-3 transition-vertical-fade transition-vertical-fade-start delay-normal">
-              NFTL IS OUR GOVERNANCE &amp; UTILITY TOKEN. GOVERN THE FUTURE OF NIFTY LEAGUE &amp;
-              ACCESS EXCLUSIVE GAME ASSETS.
-            </p>
-          </AnimatedWrapper>
+          <h2 className="mb-3 section-heading transition-vertical-fade">NFTL TOKEN</h2>
+          <p className="py-1 lg:py-3 transition-vertical-fade">
+            NFTL IS OUR GOVERNANCE &amp; UTILITY TOKEN. GOVERN THE FUTURE OF NIFTY LEAGUE &amp;
+            ACCESS EXCLUSIVE GAME ASSETS.
+          </p>
           <ThemeBtnGroup
             className="md:justify-start"
             primary={{
@@ -420,51 +374,43 @@ const Home = () => {
       {/* COMMUNITY */}
       <section className="section container relative flex flex-row flex-wrap items-center">
         <div className="w-full md:w-1/2 flex justify-center md:justify-start">
-          <AnimatedWrapper>
-            <div className="relative flex-grow transition-quick-pop transition-quick-pop-start delay-normal home-community-image">
-              <Image
-                src="/img/leaderboards/podium.webp"
-                alt="The Best Community on Earth"
-                width={382}
-                height={411}
-                className="w-85 h-auto"
-                sizes="100vw"
-              />
-            </div>
-          </AnimatedWrapper>
+          <div className="relative flex-grow transition-quick-pop home-community-image">
+            <Image
+              src="/img/leaderboards/podium.webp"
+              alt="The Best Community on Earth"
+              width={382}
+              height={411}
+              className="w-85 h-auto"
+              sizes="100vw"
+            />
+          </div>
         </div>
 
         <div className="w-full md:w-1/2 flex flex-col items-center md:items-start md:flex-col-reverse">
           <div className="w-full">
-            <AnimatedWrapper>
-              <div className="transition-fade transition-fade-start delay-lite md:-ml-[20px]">
-                <Image
-                  src="/img/degens/community-characters.webp"
-                  alt="Community DEGENs"
-                  width={596}
-                  height={194}
-                  sizes="100vw"
-                  className="w-full h-auto pixelated"
-                />
-              </div>
-            </AnimatedWrapper>
+            <div className="transition-fade md:-ml-[20px]">
+              <Image
+                src="/img/degens/community-characters.webp"
+                alt="Community DEGENs"
+                width={596}
+                height={194}
+                sizes="100vw"
+                className="w-full h-auto pixelated"
+              />
+            </div>
           </div>
 
           <div className="w-full flex flex-col relative text-center md:text-left">
             <div className="purple-bg-orb orb-top-right" />
             <div className="w-full xl:mt-20">
-              <AnimatedWrapper>
-                <h2 className="mb-3 section-title section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-                  COMMUNITY
-                </h2>
-              </AnimatedWrapper>
+              <h2 className="mb-3 section-title section-heading transition-vertical-fade">
+                COMMUNITY
+              </h2>
             </div>
-            <AnimatedWrapper>
-              <p className="py-1 transition-vertical-fade transition-vertical-fade-start delay-normal">
-                WE HATE TO BRAG, BUT OUR COMMUNITY IS TRULY TOP-NOTCH! JOIN OUR DISCORD TO CONNECT
-                WITH OTHERS DEGENS &amp; HELP SHAPE NIFTY LEAGUE&apos;S FUTURE.
-              </p>
-            </AnimatedWrapper>
+            <p className="py-1 transition-vertical-fade">
+              WE HATE TO BRAG, BUT OUR COMMUNITY IS TRULY TOP-NOTCH! JOIN OUR DISCORD TO CONNECT
+              WITH OTHERS DEGENS &amp; HELP SHAPE NIFTY LEAGUE&apos;S FUTURE.
+            </p>
             <ThemeBtnGroup
               className="md:justify-start"
               primary={{
@@ -481,11 +427,7 @@ const Home = () => {
 
       {/* SPONSORS */}
       <section className="section w-screen relative text-center">
-        <AnimatedWrapper>
-          <h2 className="my-3 lg:my-5 section-heading transition-vertical-fade transition-vertical-fade-start delay-lite">
-            PROUDLY BACKED BY
-          </h2>
-        </AnimatedWrapper>
+        <h2 className="my-3 lg:my-5 section-heading transition-vertical-fade">PROUDLY BACKED BY</h2>
         <DeferredSponsors />
         <ThemeBtnGroup
           primary={{ href: '/careers', title: 'JOIN THE TEAM' }}

--- a/apps/web/src/components/BouncingNFTL/index.tsx
+++ b/apps/web/src/components/BouncingNFTL/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 
 import { cn } from '@nl/ui/utils'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 interface ComponentProps {
   classes?: { token1?: string; token2?: string; token3?: string }
@@ -15,8 +15,8 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
         classes?.token1
       )}
     >
-      <AnimatedWrapper parallax parallaxDirection="right">
-        <div className="animate-bounce-coin1 transition-fade transition-fade-start delay-normal">
+      <ParallaxWrapper parallaxDirection="right">
+        <div className="animate-bounce-coin1 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-1.webp"
             alt="Bouncing NFTL Left"
@@ -26,7 +26,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="100vw"
           />
         </div>
-      </AnimatedWrapper>
+      </ParallaxWrapper>
     </div>
     <div
       className={cn(
@@ -34,8 +34,8 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
         classes?.token2
       )}
     >
-      <AnimatedWrapper parallax parallaxDirection="left">
-        <div className="animate-bounce-coin2 transition-fade transition-fade-start delay-long">
+      <ParallaxWrapper parallaxDirection="left">
+        <div className="animate-bounce-coin2 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-2.webp"
             alt="Bouncing NFTL Right"
@@ -45,13 +45,13 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="100vw"
           />
         </div>
-      </AnimatedWrapper>
+      </ParallaxWrapper>
     </div>
     <div
       className={cn('absolute bottom-[-500px] left-[calc(50%-100px)] w-[246px]', classes?.token3)}
     >
-      <AnimatedWrapper parallax parallaxDirection="down">
-        <div className="animate-bounce-coin3 transition-fade transition-fade-start delay-long-offset">
+      <ParallaxWrapper parallaxDirection="down">
+        <div className="animate-bounce-coin3 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-3.webp"
             alt="Bouncing NFTL Bottom"
@@ -61,7 +61,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="100vw"
           />
         </div>
-      </AnimatedWrapper>
+      </ParallaxWrapper>
     </div>
   </>
 )

--- a/apps/web/src/components/MintOMatic/index.tsx
+++ b/apps/web/src/components/MintOMatic/index.tsx
@@ -1,10 +1,10 @@
 import Image from 'next/image'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 const MintOMatic = () => {
   return (
     <>
-      <AnimatedWrapper parallax parallaxDirection="down" parallaxIntensity="normal">
+      <ParallaxWrapper parallaxDirection="down" parallaxIntensity="normal">
         <div className="relative">
           <Image
             src="/img/mint-o-matic/animated/top.webp"
@@ -16,34 +16,30 @@ const MintOMatic = () => {
             style={{ width: '100%', height: 'auto' }}
           />
         </div>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <div className="absolute home-nftl-token-image flex-grow">
-          <Image
-            src="/img/mint-o-matic/animated/nftl-token-coin.webp"
-            alt="NFTL Token Coin"
-            width={1470}
-            height={1778}
-            className="pixelated"
-            sizes="100vw"
-            style={{ width: '100%', height: 'auto' }}
-          />
-        </div>
-      </AnimatedWrapper>
-      <AnimatedWrapper>
-        <div className="absolute animate-blink home-nftl-token-image flex-grow">
-          <Image
-            src="/img/mint-o-matic/animated/nftl-token-tears.webp"
-            alt="NFTL Token Tears"
-            width={1470}
-            height={1778}
-            className="pixelated"
-            sizes="100vw"
-            style={{ width: '100%', height: 'auto' }}
-          />
-        </div>
-      </AnimatedWrapper>
-      <AnimatedWrapper parallax parallaxDirection="left" parallaxIntensity="normal">
+      </ParallaxWrapper>
+      <div className="absolute home-nftl-token-image flex-grow">
+        <Image
+          src="/img/mint-o-matic/animated/nftl-token-coin.webp"
+          alt="NFTL Token Coin"
+          width={1470}
+          height={1778}
+          className="pixelated"
+          sizes="100vw"
+          style={{ width: '100%', height: 'auto' }}
+        />
+      </div>
+      <div className="absolute animate-blink home-nftl-token-image flex-grow">
+        <Image
+          src="/img/mint-o-matic/animated/nftl-token-tears.webp"
+          alt="NFTL Token Tears"
+          width={1470}
+          height={1778}
+          className="pixelated"
+          sizes="100vw"
+          style={{ width: '100%', height: 'auto' }}
+        />
+      </div>
+      <ParallaxWrapper parallaxDirection="left" parallaxIntensity="normal">
         <div className="parallax-child absolute home-nftl-token-image home-nftl-token-bottom-image flex-grow">
           <Image
             src="/img/mint-o-matic/animated/bottom.webp"
@@ -55,7 +51,7 @@ const MintOMatic = () => {
             style={{ width: '100%', height: 'auto' }}
           />
         </div>
-      </AnimatedWrapper>
+      </ParallaxWrapper>
     </>
   )
 }

--- a/packages/ui/src/components/custom/console-game/console-game.test.tsx
+++ b/packages/ui/src/components/custom/console-game/console-game.test.tsx
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test'
 mock.module('next/image', () => ({
   default: (props: React.ComponentProps<'img'>) => <img {...props} />,
 }))
-mock.module('@nl/ui/custom/animated-wrapper', () => ({
-  AnimatedWrapper: ({ children }: React.PropsWithChildren) => <>{children}</>,
+mock.module('@nl/ui/custom/parallax-wrapper', () => ({
+  ParallaxWrapper: ({ children }: React.PropsWithChildren) => <>{children}</>,
 }))
 mock.module('@nl/ui/hooks/useOnScreen', () => ({
   useOnScreen: () => true,

--- a/packages/ui/src/components/custom/console-game/index.tsx
+++ b/packages/ui/src/components/custom/console-game/index.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import { memo, useRef, useState, useCallback, useEffect } from 'react'
 import { Button } from '@nl/ui/base/button'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
+import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 import { cn } from '@nl/ui/utils'
 
@@ -95,8 +95,8 @@ export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
         </Button>
       </div>
       <div className={styles.gaming_controller}>
-        <AnimatedWrapper parallax parallaxDirection="down" parallaxIntensity="normal">
-          <div className="animate-hover transition-fade-start transition-fade delay-long">
+        <ParallaxWrapper parallaxDirection="down" parallaxIntensity="normal">
+          <div className="animate-hover transition-fade">
             <Image
               alt="Controller Left"
               className="pixelated"
@@ -108,11 +108,11 @@ export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
               style={{ width: '100%', height: 'auto', objectFit: 'contain' }}
             />
           </div>
-        </AnimatedWrapper>
+        </ParallaxWrapper>
       </div>
       <div className={styles.gaming_controller}>
-        <AnimatedWrapper parallax parallaxDirection="down" parallaxIntensity="normal">
-          <div className="animate-hover transition-fade-start transition-fade delay-long-offset">
+        <ParallaxWrapper parallaxDirection="down" parallaxIntensity="normal">
+          <div className="animate-hover transition-fade">
             <Image
               alt="Controller Right"
               className="pixelated"
@@ -124,7 +124,7 @@ export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
               style={{ width: '100%', height: 'auto', objectFit: 'contain' }}
             />
           </div>
-        </AnimatedWrapper>
+        </ParallaxWrapper>
       </div>
       <div className="dark-gradient-overlay" />
     </div>

--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -235,6 +235,30 @@ describe('AnimatedWrapper and Preloader', () => {
   })
 })
 
+describe('ParallaxWrapper', () => {
+  let ParallaxWrapper: typeof import('./parallax-wrapper').ParallaxWrapper
+
+  beforeEach(async () => {
+    ParallaxWrapper = (await import('./parallax-wrapper')).ParallaxWrapper
+    state.parallax.mockClear()
+  })
+
+  it('keeps parallax behavior in a focused semantic wrapper', () => {
+    render(
+      <ParallaxWrapper component="section" parallaxDirection="up" parallaxIntensity="strong">
+        <p>Parallax content</p>
+      </ParallaxWrapper>
+    )
+
+    expect(screen.getByText('Parallax content').parentElement?.tagName).toBe('SECTION')
+    expect(state.parallax).toHaveBeenCalledWith(expect.anything(), {
+      enabled: true,
+      direction: 'up',
+      intensity: 'strong',
+    })
+  })
+})
+
 describe('authentication forms', () => {
   let LoginForm: typeof import('./auth-form/forms/login').default
   let AuthForm: typeof import('./auth-form').AuthForm

--- a/packages/ui/src/components/custom/parallax-wrapper/index.tsx
+++ b/packages/ui/src/components/custom/parallax-wrapper/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useRef, type ElementType, type HTMLAttributes, type ReactNode } from 'react'
+import { useParallax } from '@nl/ui/hooks/useParallax'
+import type { ParallaxDirection, ParallaxIntensity } from '@nl/ui/hooks/useParallax'
+
+export interface ParallaxWrapperProps extends HTMLAttributes<HTMLElement> {
+  children: ReactNode
+  parallaxDirection?: ParallaxDirection
+  parallaxIntensity?: ParallaxIntensity
+  component?: ElementType
+}
+
+export function ParallaxWrapper({
+  children,
+  parallaxDirection = 'left',
+  parallaxIntensity = 'normal',
+  component: Wrapper = 'div',
+  ...props
+}: ParallaxWrapperProps) {
+  const ref = useRef<HTMLElement>(null)
+
+  useParallax(ref, {
+    enabled: true,
+    direction: parallaxDirection,
+    intensity: parallaxIntensity,
+  })
+
+  return (
+    <Wrapper ref={ref} {...props}>
+      {children}
+    </Wrapper>
+  )
+}
+
+export default ParallaxWrapper

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -203,6 +203,7 @@ const webCommunityPage = 'apps/web/src/app/(main)/community/page.tsx'
 const webTeamPage = 'apps/web/src/app/(main)/team/page.tsx'
 const webCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const animationFreeMarketingPages = [
+  'apps/web/src/app/(main)/page.tsx',
   'apps/web/src/app/(main)/games/page.tsx',
   'apps/web/src/app/(main)/niftyworld/page.tsx',
   'apps/web/src/app/(main)/overview/page.tsx',


### PR DESCRIPTION
## What changed

- Remove ordinary AnimatedWrapper client boundaries from the web homepage and make its static content immediately visible.
- Add the shared ParallaxWrapper component for the small set of genuinely scroll-driven visuals.
- Reuse ParallaxWrapper in BouncingNFTL, MintOMatic, and the shared console-game controllers.
- Keep CSS hover, bounce, image layout, theme classes, and accessible image/link markup intact.

## Why

The homepage was instantiating many visibility observers and client animation wrappers for static text and images. This keeps the route server-rendered while reducing client work and reusing one focused parallax primitive.

## Validation

- bun test --isolate test/contract/route-surface.test.ts
- bun --filter web test
- bun --filter @nl/ui test
- bun --filter smashers test
- bun --filter web type-check
- bun --filter @nl/ui type-check
- bun --filter smashers type-check
- bun --filter web lint
- bun --filter @nl/ui lint
- bun --filter smashers lint (one existing NEXT_PHASE warning)
- bun --filter web build
- bun --filter smashers build
- Prettier check and git diff --check