### PR TITLE
perf(smashers): slim deferred marketing sections

### DIFF
--- a/apps/smashers/src/components/DegensSection/index.tsx
+++ b/apps/smashers/src/components/DegensSection/index.tsx
@@ -1,4 +1,3 @@
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { DegenSpecialsTable } from '@nl/ui/custom/degen-specials-table'
 
 const DegensSection = () => {
@@ -6,20 +5,14 @@ const DegensSection = () => {
     <>
       <div className="mb-10 max-w-3xl mx-auto">
         <div className="mb-5">
-          <AnimatedWrapper>
-            <h2 className="text-center transition-vertical-fade transition-vertical-fade-start delay-lite">
-              Choose your fighter
-            </h2>
-          </AnimatedWrapper>
+          <h2 className="text-center transition-vertical-fade">Choose your fighter</h2>
         </div>
         <div className="relative">
-          <AnimatedWrapper>
-            <p className="text-center transition-vertical-fade transition-vertical-fade-start delay-normal">
-              There are 7 tribes to choose from, each with their own unique special ability. Some
-              characters specialize in melee combat, while others are skilled in ranged attacks or
-              magic.
-            </p>
-          </AnimatedWrapper>
+          <p className="text-center transition-vertical-fade">
+            There are 7 tribes to choose from, each with their own unique special ability. Some
+            characters specialize in melee combat, while others are skilled in ranged attacks or
+            magic.
+          </p>
         </div>
       </div>
 

--- a/apps/smashers/src/components/GameSection/index.tsx
+++ b/apps/smashers/src/components/GameSection/index.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-import { AnimatedWrapper } from '@nl/ui/custom/animated-wrapper'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 
 const GameSection = () => {
@@ -8,61 +7,53 @@ const GameSection = () => {
       <div className="grid grid-cols-1 md:grid-cols-12 gap-6 items-center">
         <div className="md:col-span-12 lg:col-span-6">
           <div className="text-center lg:text-left mb-6">
-            <AnimatedWrapper>
-              <h2 className="transition-vertical-fade transition-vertical-fade-start delay-lite">
-                FREE-TO-PLAY
-                <br />
-                <span className="font-default font-normal">PARTY PLATFORM FIGHTER</span>
-              </h2>
-            </AnimatedWrapper>
+            <h2 className="transition-vertical-fade">
+              FREE-TO-PLAY
+              <br />
+              <span className="font-default font-normal">PARTY PLATFORM FIGHTER</span>
+            </h2>
           </div>
           <div className="text-center lg:text-left">
-            <AnimatedWrapper>
-              <p className="leading-relaxed transition-vertical-fade transition-vertical-fade-start delay-normal">
-                Nifty Smashers is an <strong className="font-semibold">online multiplayer</strong>{' '}
-                that blends elements of a{' '}
-                <strong className="font-semibold">casual party survival</strong> experience with the
-                fast-paced action of a <strong className="font-semibold">platform fighter</strong>!
-                <br />
-                <br />
-                Play on iOS, Android, and Steam with{' '}
-                <strong className="font-semibold">full cross-play support</strong>! Jump in and
-                brawl anytime, anywhere!
-              </p>
-            </AnimatedWrapper>
+            <p className="leading-relaxed transition-vertical-fade">
+              Nifty Smashers is an <strong className="font-semibold">online multiplayer</strong>{' '}
+              that blends elements of a{' '}
+              <strong className="font-semibold">casual party survival</strong> experience with the
+              fast-paced action of a <strong className="font-semibold">platform fighter</strong>!
+              <br />
+              <br />
+              Play on iOS, Android, and Steam with{' '}
+              <strong className="font-semibold">full cross-play support</strong>! Jump in and brawl
+              anytime, anywhere!
+            </p>
           </div>
         </div>
         <div className="md:col-span-12 lg:col-span-6">
-          <AnimatedWrapper>
-            <div className="transition-quick-pop transition-quick-pop-start delay-lite overflow-hidden rounded-[40px]">
-              <ViewportVideo
-                id="level-video"
-                className="h-auto w-full"
-                muted
-                loop
-                playsInline
-                data-keepplaying
-                src="/video/rocket.mp4"
-              />
-            </div>
-          </AnimatedWrapper>
+          <div className="transition-quick-pop overflow-hidden rounded-[40px]">
+            <ViewportVideo
+              id="level-video"
+              className="h-auto w-full"
+              muted
+              loop
+              playsInline
+              data-keepplaying
+              src="/video/rocket.mp4"
+            />
+          </div>
         </div>
       </div>
-      <AnimatedWrapper>
-        <picture className="my-10 block text-center transition-fade-slow transition-fade-start delay-lite">
-          <source type="image/webp" srcSet="/img/games/smashers/party_modes.webp" />
-          <Image
-            src="/img/games/smashers/party_modes.gif"
-            alt="Smashers Party Modes"
-            width={1350}
-            height={556}
-            className="w-full h-auto rounded-[40px]"
-            unoptimized
-            loading="lazy"
-            sizes="(max-width: 768px) 100vw, 1350px"
-          />
-        </picture>
-      </AnimatedWrapper>
+      <picture className="my-10 block text-center transition-fade-slow">
+        <source type="image/webp" srcSet="/img/games/smashers/party_modes.webp" />
+        <Image
+          src="/img/games/smashers/party_modes.gif"
+          alt="Smashers Party Modes"
+          width={1350}
+          height={556}
+          className="w-full h-auto rounded-[40px]"
+          unoptimized
+          loading="lazy"
+          sizes="(max-width: 768px) 100vw, 1350px"
+        />
+      </picture>
     </div>
   )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -215,6 +215,8 @@ const animationFreeMarketingPages = [
   'apps/web/src/app/(main)/lore/page.tsx',
 ]
 const animationFreeMarketingComponents = [
+  'apps/smashers/src/components/GameSection/index.tsx',
+  'apps/smashers/src/components/DegensSection/index.tsx',
   'apps/web/src/components/ThemeBtnGroup/index.tsx',
   'apps/web/src/components/LearnCards/index.tsx',
   'apps/web/src/components/Careers/JobCard.tsx',


### PR DESCRIPTION
## What changed

- Remove default AnimatedWrapper client boundaries from Smashers GameSection and DegensSection.
- Keep both sections behind the existing accessible DeferredSection loaders.
- Preserve the viewport-aware video, lazy party-modes image, layout, spacing, and theme classes.
- Extend the route contract so these static sections cannot regress into hidden client animation boundaries.

## Why

These deferred marketing sections were still shipping visibility observers and hidden-start classes around static content. Removing the wrappers reduces runtime work when the sections load while keeping the interactive video behavior isolated in ViewportVideo.

## Validation

- bun test --isolate test/contract/route-surface.test.ts
- bun --filter smashers test
- bun --filter smashers type-check
- bun --filter smashers lint (one existing NEXT_PHASE warning)
- bun --filter smashers build
- Prettier check and git diff --check