### PR TITLE
chore(app): simplify degen filter controls

### DIFF
--- a/apps/app/src/components/extended/DegensFilter/index.tsx
+++ b/apps/app/src/components/extended/DegensFilter/index.tsx
@@ -198,6 +198,7 @@ const DegensFilter = ({
         <Title level={3}>Filter Degens</Title>
         <div className="flex flex-row gap-4">
           <Button
+            type="button"
             variant="outline"
             disabled={isParamsEmpty}
             onClick={handleReset}
@@ -238,123 +239,13 @@ const DegensFilter = ({
                   }
                 />
                 <div className="-ml-1 flex flex-row items-center">
-                  <Image src={tribe.icon} alt="Tribe Icon" width={18} height={18} />
+                  <Image src={tribe.icon} alt="" width={18} height={18} />
                   <span className="ml-2 text-base">{tribe.name}</span>
                 </div>
               </label>
             ))}
           </div>
         </FilterAccordion>
-        {/* 
-        <FilterAccordion
-          summary={<Title level={4}>Price</Title>}
-          expanded={false}
-        >
-          <div className="flex flex-col gap-8">
-            <FilterRangeSlider
-              value={pricesRangeValue}
-              min={defaultFilterValues.prices[0]}
-              max={defaultFilterValues.prices[1]}
-              unit=" NFTL"
-              label="Price"
-              onChange={(_, value) => setPricesRangeValue(value as number[])}
-              onChangeCommitted={() => handleChangeCommitted('prices')}
-            />
-          </div>
-        </FilterAccordion> */}
-        {/* <FilterAccordion
-          summary={<Title level={4}>Queue</Title>}
-          expanded={false}
-          length={rentals.length}
-        >
-          <div className="flex flex-col">
-            {rentals.map((item) => (
-              <label
-                key={`Queue${item}`}
-                className={`${styles.inputCheckFormControl} flex items-center`}
-              >
-                <Checkbox
-                  name={`Queue${item}`}
-                  value={item}
-                  checked={rentalsValue.includes(item)}
-                  className={styles.inputCheck}
-                  onCheckedChange={(checked) =>
-                    handleCheckboxChange(
-                      { target: { checked: checked === true, value: item } } as ChangeEvent<HTMLInputElement>,
-                      'rentals',
-                      rentalsValue,
-                      setRentalsValue,
-                    )
-                  }
-                />
-                <span className="text-base">{item}</span>
-              </label>
-            ))}
-          </div>
-        </FilterAccordion> */}
-        {/* <FilterAccordion
-          summary={<Title level={4}>Multiplier</Title>}
-          expanded={false}
-          length={multipliers.length}
-        >
-          <div className="flex flex-col">
-            {multipliers.map((item) => (
-              <label
-                key={`Multiplier${item}`}
-                className={`${styles.inputCheckFormControl} flex items-center`}
-              >
-                <Checkbox
-                  name={`Multiplier${item}`}
-                  value={item}
-                  checked={multipliersValue.includes(item)}
-                  className={styles.inputCheck}
-                  onCheckedChange={(checked) =>
-                    handleCheckboxChange(
-                      { target: { checked: checked === true, value: item } } as ChangeEvent<HTMLInputElement>,
-                      'multipliers',
-                      multipliersValue,
-                      setMultipliersValue,
-                    )
-                  }
-                />
-                <span className="text-base">{item}</span>
-              </label>
-            ))}
-          </div>
-        </FilterAccordion> */}
-        {/* {displayMyItems && (
-          <FilterAccordion
-            summary={<Title level={4}>Wearable</Title>}
-            expanded={false}
-            length={wearables.length}
-          >
-            <div className="flex flex-row flex-wrap">
-              {wearables.map((wearable) => (
-                <label
-                  key={wearable}
-                  className={`${styles.inputCheckFormControl} flex items-center`}
-                  style={{ flex: '0 0 50%' }}
-                >
-                  <Checkbox
-                    name={wearable}
-                    value={wearable}
-                    checked={wearablesValue.includes(wearable)}
-                    className={styles.inputCheck}
-                    onCheckedChange={(checked) =>
-                      handleCheckboxChange(
-                        { target: { checked: checked === true, value: wearable } } as ChangeEvent<HTMLInputElement>,
-                        'wearables',
-                        wearablesValue,
-                        setWearablesValue,
-                      )
-                    }
-                  />
-                  <span className="text-base">{wearable}</span>
-                </label>
-              ))}
-            </div>
-          </FilterAccordion>
-        )} */}
         <FilterAccordion
           summary={<Title level={4}>Background</Title>}
           length={backgrounds.length}
@@ -389,13 +280,14 @@ const DegensFilter = ({
           </div>
         </FilterAccordion>
         {!showMore ? (
-          <span
-            className="mx-3.5 cursor-pointer text-base underline"
-            style={{ lineHeight: '36px' }}
+          <Button
+            type="button"
+            variant="link"
+            className="mx-3.5 h-auto justify-start p-0 py-2 text-base font-normal"
             onClick={() => setShowMore(true)}
           >
             More
-          </span>
+          </Button>
         ) : (
           <>
             {Object.keys(CosmeticsFilter.TRAIT_VALUE_MAP)


### PR DESCRIPTION
## Summary
- remove 115 lines of dead commented-out degen filter UI
- use the shared shadcn Button for the More control instead of a clickable span
- make reset behavior explicit and mark decorative tribe icons as decorative

## Validation
- `bun --filter app test` (166 passed)
- `bun --filter app type-check`
- `bun --filter app lint`
- `bunx prettier --check apps/app/src/components/extended/DegensFilter/index.tsx`
- `bun test --isolate test/contract/route-surface.test.ts` (167 passed)
- `bun --filter app build` (21 routes generated)

This draft is intentionally cost-controlled; hosted feature validation is expected to remain skipped until the PR is marked ready.
