### PR TITLE
perf(app): defer dashboard degen filters

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
@@ -12,7 +12,6 @@ import { Dialog } from '@nl/ui/base/dialog'
 import { Icon } from '@nl/ui/base/icon'
 
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
-import DegensFilter from '@/components/extended/DegensFilter'
 import DEFAULT_STATIC_FILTER from '@/components/extended/DegensFilter/constants'
 import {
   tranformDataByFilter,
@@ -32,6 +31,7 @@ import usePagination from '@/hooks/usePagination'
 import type { DegenFilter } from '@/types/degenFilter'
 import type { Degen } from '@/types/degens'
 import EmptyState from '@/components/EmptyState'
+import DeferredDegensFilter from '@/components/providers/DeferredDegensFilter'
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
 import DeferredRenameDegenDialog from '@/components/providers/DeferredRenameDegenDialog'
 import useNFTsBalances from '@/hooks/balances/useNFTsBalances'
@@ -221,7 +221,7 @@ const DashboardDegensPageContent = (): React.ReactNode => {
 
   const renderDrawer = useCallback(
     () => (
-      <DegensFilter
+      <DeferredDegensFilter
         onFilter={handleFilter}
         defaultFilterValues={defaultValues as DegenFilter}
         searchTerm={searchTerm}

--- a/apps/app/src/components/extended/DegensFilter/utils.ts
+++ b/apps/app/src/components/extended/DegensFilter/utils.ts
@@ -8,9 +8,6 @@ import { HYDRAS } from '@/constants/hydras'
 export const tranformDataByFilter = (
   degens: Degen[],
   {
-    // prices = [],
-    // multipliers = [],
-    // rentals = [],
     backgrounds = [],
     cosmetics = [],
     searchTerm = [],
@@ -22,9 +19,6 @@ export const tranformDataByFilter = (
 ): Degen[] => {
   const result = degens.filter(
     ({
-      // price,
-      // multiplier,
-      // rental_count,
       background = '',
       id = '',
       name = '',
@@ -95,18 +89,6 @@ export const tranformDataByFilter = (
   } else if (sort === 'idDown') {
     result.sort((a, b) => Number(b.id) - Number(a.id))
   }
-  // else if (sort === 'priceUp') {
-  //   result.sort((a, b) => Number(a.price) - Number(b.price));
-  // } else if (sort === 'priceDown') {
-  //   result.sort((a, b) => Number(b.price) - Number(a.price));
-  // } else if (sort === 'mostRented') {
-  //   result.sort((a, b) => Number(b.total_rented) - Number(a.total_rented));
-  // } else if (sort === 'leastRented') {
-  //   result.sort((a, b) => Number(a.total_rented) - Number(b.total_rented));
-  // } else if (sort === 'recentRented') {
-  //   result.sort((a, b) => b.last_rented_at - a.last_rented_at);
-  // }
-
   return result
 }
 
@@ -163,9 +145,6 @@ export const getDefaultFilterValueFromData = (degens: Degen[] | undefined) => {
 // Needs to be divisible by 2, 3, or 4
 export const DEGENS_PER_PAGE = 12
 
-// MUI Grid size map (24-column grid so fractional 1.5/12 spans are integers):
-//   gridView: xs=12 -> 24, sm=6 -> 12, md=4 -> 8, lg/xl=4|3 -> 8|6
-//   list:     xs=6 -> 12, sm=4 -> 8, md=3 -> 6, lg/xl=3|2 -> 6|4
 export const getGridSizeClass = (isGridView: boolean, isDrawerOpen: boolean) => {
   if (isGridView) {
     return isDrawerOpen

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -899,7 +899,12 @@ describe('dashboard DEGEN loading contract', () => {
     expect(pageSource).not.toContain("from '@/components/cards/DegenCard/DashboardDegenCard'")
     expect(pageSource).not.toContain("from '@/components/extended/DegensFilter'")
     expect(contentSource).toContain("import('@/components/cards/DegenCard/DashboardDegenCard')")
-    expect(contentSource).toContain("from '@/components/extended/DegensFilter'")
+    expect(contentSource).toContain(
+      "import DeferredDegensFilter from '@/components/providers/DeferredDegensFilter'"
+    )
+    expect(contentSource).not.toContain(
+      "import DegensFilter from '@/components/extended/DegensFilter'"
+    )
     expect(contentSource).toContain('DashboardDegensPageContent')
   })
 })


### PR DESCRIPTION
## Summary
- reuse the existing accessible `DeferredDegensFilter` loader in the dashboard degen drawer
- keep the 1,167-line cosmetics map out of the dashboard route's eager client graph
- remove stale commented-out filter/sorting code and the outdated MUI grid note
- add a route contract preventing the direct filter import from returning

## Validation
- `bun --filter app test` (166 passed)
- `bun --filter app type-check`
- `bun --filter app lint`
- `bunx prettier --check ...`
- `bun test --isolate test/contract/route-surface.test.ts` (167 passed)
- `bun --filter app build` (21 routes generated)

This draft is intentionally cost-controlled; hosted feature validation is expected to remain skipped until the PR is marked ready.
