### PR TITLE
perf(app): memoize rentals grid data

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
@@ -76,7 +76,10 @@ const MyRentalsDataGrid = ({
   )
 
   const { profile } = usePlayerProfile()
-  const rentals = transformRentals(rows, profile?.id || '', category)
+  const rentals = useMemo(
+    () => transformRentals(rows, profile?.id || '', category),
+    [rows, profile?.id, category]
+  )
 
   const filteredRows = useMemo(() => {
     switch (category) {
@@ -213,7 +216,7 @@ const MyRentalsDataGrid = ({
                 <Button
                   variant="ghost"
                   size="icon"
-                  aria-label="edit"
+                  aria-label="Edit player nickname"
                   onClick={() => handleOpenNickname(params)}
                   className="hidden cursor-pointer group-hover:block"
                 >
@@ -225,11 +228,6 @@ const MyRentalsDataGrid = ({
         },
       },
       { field: 'rentalCategory', headerName: 'Category', width: 150 },
-      // {
-      //   field: 'player',
-      //   headerName: "Who's playing?",
-      //   width: 130,
-      // },
       {
         field: 'degenId',
         headerName: 'Degen ID',
@@ -268,12 +266,6 @@ const MyRentalsDataGrid = ({
         ),
       },
       { field: 'multiplier', headerName: 'Multiplier', width: 150, ...commonColumnProp },
-      // {
-      //   field: 'timePlayed',
-      //   headerName: 'Time Played',
-      //   ...commonColumnProp,
-      //   width: 120,
-      // },
       { field: 'matches', headerName: 'Matches' },
       { field: 'wins', headerName: 'Wins' },
       {
@@ -444,7 +436,7 @@ const MyRentalsDataGrid = ({
         <div className="flex items-center justify-between border-t px-4 py-3">
           <div className="flex items-center gap-2">
             <Select value={String(pageSize)} onValueChange={handlePageSizeChange}>
-              <SelectTrigger className="w-[70px]">
+              <SelectTrigger aria-label="Rows per page" className="w-[70px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -461,6 +453,7 @@ const MyRentalsDataGrid = ({
             <Button
               variant="ghost"
               size="sm"
+              aria-label="Previous page"
               onClick={handlePrevPage}
               disabled={page === 0}
               className="h-8 w-8 cursor-pointer p-0"
@@ -473,6 +466,7 @@ const MyRentalsDataGrid = ({
             <Button
               variant="ghost"
               size="sm"
+              aria-label="Next page"
               onClick={handleNextPage}
               disabled={page === pageCount - 1 || sortedRows.length === 0}
               className="h-8 w-8 cursor-pointer p-0"


### PR DESCRIPTION
## Summary
- memoize rental transformation so pagination, sorting, and dialog state changes do not recompute the full rental dataset
- remove stale commented-out table columns
- improve accessible names for nickname editing, page-size selection, and pagination controls

## Validation
- `bun --filter app test` (166 passed)
- `bun --filter app type-check`
- `bun --filter app lint`
- `bunx prettier --check apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx`
- `bun --filter app build` (21 routes generated)

This draft is intentionally cost-controlled; hosted feature validation is expected to remain skipped until the PR is marked ready.
