### PR TITLE
perf(web): right-size marketing images

### DIFF
--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -54,7 +54,7 @@ const DesktopIntro = () => {
                 width={175}
                 height={175}
                 className="pixelated w-full h-auto"
-                sizes="100vw"
+                sizes="12vw"
               />
               <div className="absolute home-hero-companion-swing animate-propeller" />
             </div>
@@ -68,7 +68,7 @@ const DesktopIntro = () => {
                 alt="Home Hero Halo"
                 width={133}
                 height={50}
-                sizes="100vw"
+                sizes="9vw"
                 className="w-full h-auto"
               />
             </div>
@@ -84,7 +84,7 @@ const DesktopIntro = () => {
             src="/img/hero/satoshi.webp"
             width={180}
             height={190}
-            sizes="100vw"
+            sizes="226px"
             className="object-cover w-full h-auto"
           />
         </div>
@@ -112,7 +112,7 @@ const DesktopIntro = () => {
             alt="Learn More"
             width={348}
             height={108}
-            sizes="100vw"
+            sizes="407px"
             className="w-full h-auto"
           />
           <p className="m-0 p-0 speech-bubble-text">Learn More!</p>
@@ -256,7 +256,7 @@ const Home = () => {
               alt="Compete and Earn"
               width={668}
               height={535}
-              sizes="100vw"
+              sizes="(min-width: 768px) 50vw, 100vw"
               className="w-full h-auto"
             />
           </div>
@@ -269,7 +269,7 @@ const Home = () => {
                   width={200}
                   height={195}
                   src="/img/compete-and-earn/animated/token-4.webp"
-                  sizes="100vw"
+                  sizes="246px"
                 />
               </div>
             </ParallaxWrapper>
@@ -286,7 +286,7 @@ const Home = () => {
               alt="Land in NiftyWorld"
               width={612}
               height={482}
-              sizes="100vw"
+              sizes="(min-width: 768px) 50vw, 100vw"
               className="w-full h-auto"
             />
           </div>
@@ -381,7 +381,7 @@ const Home = () => {
               width={382}
               height={411}
               className="w-85 h-auto"
-              sizes="100vw"
+              sizes="(min-width: 768px) 382px, 85vw"
             />
           </div>
         </div>
@@ -394,7 +394,7 @@ const Home = () => {
                 alt="Community DEGENs"
                 width={596}
                 height={194}
-                sizes="100vw"
+                sizes="(min-width: 768px) 50vw, 100vw"
                 className="w-full h-auto pixelated"
               />
             </div>

--- a/apps/web/src/components/BouncingNFTL/index.tsx
+++ b/apps/web/src/components/BouncingNFTL/index.tsx
@@ -23,7 +23,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             width={226}
             height={223}
             className="w-full h-auto"
-            sizes="100vw"
+            sizes="226px"
           />
         </div>
       </ParallaxWrapper>
@@ -42,7 +42,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             width={226}
             height={221}
             className="w-full h-auto"
-            sizes="100vw"
+            sizes="226px"
           />
         </div>
       </ParallaxWrapper>
@@ -58,7 +58,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             width={246}
             height={96}
             className="w-full h-auto"
-            sizes="100vw"
+            sizes="246px"
           />
         </div>
       </ParallaxWrapper>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1131,6 +1131,25 @@ describe('web marketing page boundary contract', () => {
   })
 })
 
+describe('web marketing image sizing contract', () => {
+  it('uses rendered-width image hints for the home page artwork', () => {
+    const homeSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
+    const bouncingNftlSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/BouncingNFTL/index.tsx'),
+      'utf8'
+    )
+
+    expect(homeSource).toContain('src="/img/hero/companion-base.webp"')
+    expect(homeSource).toContain('sizes="12vw"')
+    expect(homeSource).toContain('src="/img/hero/halo.webp"')
+    expect(homeSource).toContain('sizes="9vw"')
+    expect(homeSource).toContain('sizes="(min-width: 768px) 50vw, 100vw"')
+    expect(homeSource).toContain('sizes="246px"')
+    expect(bouncingNftlSource).toContain('sizes="226px"')
+    expect(bouncingNftlSource).toContain('sizes="246px"')
+  })
+})
+
 describe('web marketing animation boundary contract', () => {
   for (const file of [...animationFreeMarketingPages, ...animationFreeMarketingComponents]) {
     it(`keeps default marketing content out of the animated client boundary in ${file}`, () => {


### PR DESCRIPTION
## Summary
- tighten `next/image` `sizes` hints for the Web home page artwork
- avoid advertising small hero decorations, half-column artwork, and NFTL tokens as `100vw`
- preserve the existing theme, layout, and server-rendered marketing boundary

## Validation
- route and home-page tests: 173 passed, 735 expectations
- Web type-check, lint, and production build passed
- Prettier and diff checks passed

The image optimizer can now select smaller files for mobile and half-column content. Ready for the gated staging checks.