### PR TITLE
perf(web): right-size secondary marketing images

### DIFF
--- a/apps/web/src/app/(main)/careers/page.tsx
+++ b/apps/web/src/app/(main)/careers/page.tsx
@@ -15,7 +15,7 @@ const Careers: NextPage = () => (
             width={648}
             height={406}
             priority
-            sizes="100vw"
+            sizes="(min-width: 768px) 50vw, 100vw"
             style={{ width: '100%', height: 'auto' }}
           />
         </div>

--- a/apps/web/src/app/(main)/community/page.tsx
+++ b/apps/web/src/app/(main)/community/page.tsx
@@ -23,7 +23,7 @@ const Community: NextPage = () => {
                 width={445}
                 height={437}
                 priority
-                sizes="100vw"
+                sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 67vw"
                 className="w-full h-auto"
               />
             </div>
@@ -60,7 +60,7 @@ const Community: NextPage = () => {
             alt="Purple eclipse"
             width={704}
             height={704}
-            sizes="100vw"
+            sizes="(min-width: 769px) 80vw, 100vw"
             className="w-full h-auto"
           />
         </span>

--- a/apps/web/src/app/(main)/compete-and-earn/page.tsx
+++ b/apps/web/src/app/(main)/compete-and-earn/page.tsx
@@ -29,7 +29,7 @@ const CompeteAndEarn: NextPage = () => {
                 width={3343}
                 height={2615}
                 priority
-                sizes="100vw"
+                sizes="(min-width: 768px) 50vw, 100vw"
                 style={{ width: '100%', height: 'auto' }}
               />
             </div>

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -32,7 +32,7 @@ const Games: NextPage = () => (
               width={339}
               height={661}
               src="/img/games/smashers/arcade.webp"
-              sizes="100vw"
+              sizes="33vw"
               style={{ width: '100%', height: 'auto', marginBottom: '6rem' }}
             />
           </div>

--- a/apps/web/src/app/(main)/niftyworld/page.tsx
+++ b/apps/web/src/app/(main)/niftyworld/page.tsx
@@ -79,6 +79,7 @@ const NiftyWorld: NextPage = () => {
                       alt="NiftyWorld District Highlight"
                       width={500}
                       height={283}
+                      sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"
                       style={{ width: '100%', height: 'auto', maxWidth: '100%' }}
                     />
                   </div>

--- a/apps/web/src/app/(main)/roadmap/page.tsx
+++ b/apps/web/src/app/(main)/roadmap/page.tsx
@@ -18,7 +18,7 @@ const Roadmap: NextPage = () => {
               width={200}
               height={200}
               priority
-              sizes="100vw"
+              sizes="(min-width: 1170px) 250px, (min-width: 1000px) 200px, (min-width: 850px) 175px, 120px"
               style={{ width: '100%', height: 'auto' }}
             />
           </div>
@@ -44,7 +44,7 @@ const Roadmap: NextPage = () => {
                 width={800}
                 height={800}
                 priority
-                sizes="100vw"
+                sizes="(min-width: 920px) 800px, 600px"
                 style={{ width: '100%', height: 'auto' }}
               />
             </div>

--- a/apps/web/src/components/LearnCards/index.tsx
+++ b/apps/web/src/components/LearnCards/index.tsx
@@ -23,7 +23,7 @@ const LearnCard = ({ btnText, external, image, link, subtitle, title }: LearnCar
             src={image}
             width={552}
             height={310}
-            sizes="100vw"
+            sizes="(min-width: 640px) 50vw, 100vw"
             style={{ objectFit: 'cover', width: '100%', height: 'auto' }}
           />
         </div>

--- a/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
+++ b/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
@@ -50,7 +50,7 @@ const RoadmapCard = ({
             alt={`${title?.toString()}`}
             width={image.width}
             height={image.height}
-            sizes="100vw"
+            sizes="200px"
             style={{ width: '100%', height: 'auto' }}
           />
         </div>
@@ -73,7 +73,7 @@ const RoadmapCard = ({
           alt="satoshi stationary"
           width={200}
           height={200}
-          sizes="100vw"
+          sizes="(min-width: 1170px) 250px, (min-width: 1000px) 200px, (min-width: 850px) 175px, 125px"
           style={{ width: '100%', height: 'auto' }}
         />
       </div>

--- a/apps/web/src/components/Sponsors.tsx
+++ b/apps/web/src/components/Sponsors.tsx
@@ -14,7 +14,7 @@ const SponsorItem = ({ image, url, width, height }: Sponsor): React.ReactNode =>
         src={image}
         width={width}
         height={height}
-        sizes="100vw"
+        sizes="(min-width: 768px) 160px, 80px"
         className="w-full h-auto"
       />
     </div>

--- a/apps/web/src/components/TeamDesktop/index.tsx
+++ b/apps/web/src/components/TeamDesktop/index.tsx
@@ -16,7 +16,7 @@ const TeamDesktop = () => {
                   height={293}
                   src={member.source}
                   width={268}
-                  sizes="100vw"
+                  sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"
                   style={{ width: '100%', height: 'auto' }}
                 />
               </div>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1148,6 +1148,33 @@ describe('web marketing image sizing contract', () => {
     expect(bouncingNftlSource).toContain('sizes="226px"')
     expect(bouncingNftlSource).toContain('sizes="246px"')
   })
+
+  it('uses rendered-width hints for secondary marketing artwork', () => {
+    const expectedHints: Array<[string, string]> = [
+      [
+        'apps/web/src/components/TeamDesktop/index.tsx',
+        'sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"',
+      ],
+      ['apps/web/src/components/Sponsors.tsx', 'sizes="(min-width: 768px) 160px, 80px"'],
+      ['apps/web/src/components/LearnCards/index.tsx', 'sizes="(min-width: 640px) 50vw, 100vw"'],
+      [
+        'apps/web/src/app/(main)/compete-and-earn/page.tsx',
+        'sizes="(min-width: 768px) 50vw, 100vw"',
+      ],
+      ['apps/web/src/app/(main)/careers/page.tsx', 'sizes="(min-width: 768px) 50vw, 100vw"'],
+      ['apps/web/src/app/(main)/games/page.tsx', 'sizes="33vw"'],
+      [
+        'apps/web/src/app/(main)/niftyworld/page.tsx',
+        'sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"',
+      ],
+      ['apps/web/src/app/(main)/roadmap/page.tsx', 'sizes="(min-width: 920px) 800px, 600px"'],
+      ['apps/web/src/components/RoadmapTimeline/roadmapCard.tsx', 'sizes="200px"'],
+    ]
+
+    for (const [file, hint] of expectedHints) {
+      expect(readFileSync(join(process.cwd(), file), 'utf8')).toContain(hint)
+    }
+  })
 })
 
 describe('web marketing animation boundary contract', () => {


### PR DESCRIPTION
## Summary
- tighten image `sizes` hints for team, sponsor, learn-card, game, roadmap, community, careers, and NiftyWorld artwork
- keep full-bleed backgrounds unchanged while fixed and half-column assets request rendered-width variants
- add a contract covering the responsive hints so future image edits do not reintroduce `100vw` overfetching

## Validation
- route-surface contract: 171 passed, 738 expectations
- Web type-check, lint, and production build passed
- Prettier and diff checks passed

Ready for the gated staging checks.