### PR TITLE
perf(web): limit overview image preloads

### DIFF
--- a/apps/web/src/components/LearnCards/index.tsx
+++ b/apps/web/src/components/LearnCards/index.tsx
@@ -8,18 +8,27 @@ interface LearnCardProps {
   external?: boolean
   image: string
   link: string
+  priority?: boolean
   subtitle: string
   title: string
 }
 
-const LearnCard = ({ btnText, external, image, link, subtitle, title }: LearnCardProps) => {
+const LearnCard = ({
+  btnText,
+  external,
+  image,
+  link,
+  priority = false,
+  subtitle,
+  title,
+}: LearnCardProps) => {
   return (
     <div className="relative flex items-center w-full h-full rounded-2xl overflow-hidden">
       <div className="absolute inset-0">
         <div>
           <Image
             alt={`${title} card background`}
-            priority
+            priority={priority}
             src={image}
             width={552}
             height={310}
@@ -52,13 +61,14 @@ const LearnCard = ({ btnText, external, image, link, subtitle, title }: LearnCar
 const LearnCards = () => {
   return (
     <div className="flex flex-wrap -mx-1 sm:-mx-2 pt-3 lg:pt-5 lg:mt-3">
-      {LEARN_CARDS.map(({ btnText, external, image, link, subtitle, title }) => (
+      {LEARN_CARDS.map(({ btnText, external, image, link, subtitle, title }, index) => (
         <div key={title} className="w-full sm:w-1/2 p-2">
           <LearnCard
             btnText={btnText}
             external={external}
             image={image}
             link={link}
+            priority={index === 0}
             subtitle={subtitle}
             title={title}
           />

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1175,6 +1175,17 @@ describe('web marketing image sizing contract', () => {
       expect(readFileSync(join(process.cwd(), file), 'utf8')).toContain(hint)
     }
   })
+
+  it('preloads only the first Overview learn card', () => {
+    const learnCardsSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/LearnCards/index.tsx'),
+      'utf8'
+    )
+
+    expect(learnCardsSource).toContain('priority={priority}')
+    expect(learnCardsSource).toContain('priority={index === 0}')
+    expect(learnCardsSource).not.toContain('            priority\n')
+  })
 })
 
 describe('web marketing animation boundary contract', () => {


### PR DESCRIPTION
## Summary
- make the learn-card priority behavior explicit
- preload only the first Overview card image for the initial content
- leave the remaining card images lazy so they do not compete with first paint

## Validation
- route and home-page tests: 175 passed, 747 expectations
- Web type-check, lint, and production build passed
- Prettier and diff checks passed

Ready for the gated staging checks.