### PR TITLE
perf(web): defer decorative image preloads

### DIFF
--- a/apps/web/src/app/(main)/overview/page.tsx
+++ b/apps/web/src/app/(main)/overview/page.tsx
@@ -48,7 +48,6 @@ const Overview: NextPage = () => (
         src="/img/backgrounds/dgen-network.webp"
         width={1440}
         height={813}
-        priority
         sizes="100vw"
         style={{ width: '100%', height: 'auto', objectFit: 'cover' }}
       />
@@ -59,7 +58,6 @@ const Overview: NextPage = () => (
         src="/img/backgrounds/dgen-network-mobile.webp"
         width={375}
         height={500}
-        priority
         sizes="100vw"
         style={{ width: '100%', height: 'auto', objectFit: 'cover' }}
       />

--- a/apps/web/src/app/(main)/roadmap/page.tsx
+++ b/apps/web/src/app/(main)/roadmap/page.tsx
@@ -43,7 +43,6 @@ const Roadmap: NextPage = () => {
                 alt="moon"
                 width={800}
                 height={800}
-                priority
                 sizes="(min-width: 920px) 800px, 600px"
                 style={{ width: '100%', height: 'auto' }}
               />

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1186,6 +1186,24 @@ describe('web marketing image sizing contract', () => {
     expect(learnCardsSource).toContain('priority={index === 0}')
     expect(learnCardsSource).not.toContain('            priority\n')
   })
+
+  it('does not eagerly preload below-fold decorative artwork', () => {
+    const overviewSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/app/(main)/overview/page.tsx'),
+      'utf8'
+    )
+    const roadmapSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/app/(main)/roadmap/page.tsx'),
+      'utf8'
+    )
+
+    expect(overviewSource).not.toContain('priority')
+    expect(roadmapSource).toContain('src="/img/space/satoshi_move.gif"')
+    expect(roadmapSource).toContain('src="/img/space/moon.webp"')
+    expect(roadmapSource).not.toContain(
+      'src="/img/space/moon.webp"\n                alt="moon"\n                width={800}\n                height={800}\n                priority'
+    )
+  })
 })
 
 describe('web marketing animation boundary contract', () => {


### PR DESCRIPTION
## Summary
- stop eagerly preloading the hidden desktop/mobile Overview backdrops
- stop eagerly preloading the below-fold Roadmap moon artwork
- keep image dimensions and responsive hints unchanged, with a regression contract for the preload policy

## Validation
- route-surface contract: 173 passed, 745 expectations
- Web type-check, lint, and production build passed
- generated Overview HTML emits zero DGEN backdrop preloads
- generated Roadmap HTML emits zero moon preloads

Ready for the gated staging checks.