### PR TITLE
perf(web): defer overview FAQ interaction

### DIFF
--- a/apps/web/src/app/(main)/overview/page.tsx
+++ b/apps/web/src/app/(main)/overview/page.tsx
@@ -1,10 +1,9 @@
 import type { NextPage } from 'next'
 import Image from 'next/image'
 
-import { Accordion } from '@nl/ui/custom/accordion'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
+import { DeferredOverviewFAQ } from '@/components/DeferredOverviewSections'
 import LearnCards from '@/components/LearnCards'
-import { FAQS } from '@/constants/faq'
 
 const Overview: NextPage = () => (
   <>
@@ -26,7 +25,7 @@ const Overview: NextPage = () => (
           <div className="purple-bg-orb" style={{ left: 'calc(50% - 200px)', top: '100px' }} />
         </div>
 
-        <Accordion items={FAQS} defaultValue="item-1" />
+        <DeferredOverviewFAQ />
 
         <ThemeBtnGroup
           className="mt-6 xl:mt-8"

--- a/apps/web/src/components/DeferredOverviewSections.tsx
+++ b/apps/web/src/components/DeferredOverviewSections.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { DeferredSection } from '@nl/ui/custom/deferred-section'
+
+const loadOverviewFAQ = () => import('@/components/OverviewFAQ')
+
+export function DeferredOverviewFAQ() {
+  return (
+    <DeferredSection
+      label="frequently asked questions"
+      load={loadOverviewFAQ}
+      minHeightClassName="min-h-[24rem]"
+      rootMargin="480px"
+    />
+  )
+}

--- a/apps/web/src/components/OverviewFAQ.tsx
+++ b/apps/web/src/components/OverviewFAQ.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { Accordion } from '@nl/ui/custom/accordion'
+
+import { FAQS } from '@/constants/faq'
+
+export default function OverviewFAQ() {
+  return <Accordion items={FAQS} defaultValue="item-1" />
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -194,6 +194,7 @@ const routeLoadingFiles = [
   'apps/smashers/src/app/loading.tsx',
 ]
 const webHomePage = 'apps/web/src/app/(main)/page.tsx'
+const webOverviewPage = 'apps/web/src/app/(main)/overview/page.tsx'
 const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
 const gltfClient = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
@@ -233,6 +234,8 @@ const staticLegalPages = [
 const webDefinitions = 'apps/web/src/components/Definitions.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
+const webDeferredOverviewSections = 'apps/web/src/components/DeferredOverviewSections.tsx'
+const webOverviewFAQ = 'apps/web/src/components/OverviewFAQ.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const privateRoutesShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
@@ -1076,6 +1079,19 @@ describe('shared below-fold loading contract', () => {
     expect(deferredSource).toContain("import('@/components/MintOMatic')")
     expect(deferredSource).toContain("import('@/components/Sponsors')")
     expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+  })
+
+  it('defers the below-fold Overview FAQ interaction bundle', () => {
+    const pageSource = readFileSync(join(process.cwd(), webOverviewPage), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), webDeferredOverviewSections), 'utf8')
+    const faqSource = readFileSync(join(process.cwd(), webOverviewFAQ), 'utf8')
+
+    expect(pageSource).toContain('DeferredOverviewFAQ')
+    expect(pageSource).not.toContain("from '@nl/ui/custom/accordion'")
+    expect(deferredSource).toContain("import('@/components/OverviewFAQ')")
+    expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+    expect(faqSource).toContain("from '@nl/ui/custom/accordion'")
+    expect(faqSource).toContain('defaultValue="item-1"')
   })
 
   it('defers below-fold marketing sections in Smashers', () => {


### PR DESCRIPTION
## What changed
- Move the Overview FAQ accordion behind the shared accessible `DeferredSection` boundary.
- Keep the themed FAQ heading, stable spacing, loading status, and retry behavior in the initial route.
- Keep the existing shadcn/Radix accordion and FAQ content in a separately loaded component.

## Why
The below-the-fold FAQ interaction was included in the initial Overview route client graph. Deferring it removes unnecessary interaction code from first load while preserving the same keyboard-accessible accordion once the section approaches the viewport.

## Validation
- `bun test --isolate --preload ./test/happy-dom-setup.ts --preload ./test/preload.ts --preload ./test/setup.ts test/contract/route-surface.test.ts`
- `bun run --cwd apps/web type-check`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web test`
- `bun run --cwd apps/web build`
- `bunx prettier --check apps/web/src/app/(main)/overview/page.tsx apps/web/src/components/DeferredOverviewSections.tsx apps/web/src/components/OverviewFAQ.tsx test/contract/route-surface.test.ts`

The production Overview route initial JavaScript measured 681,585 bytes before this change and 661,412 bytes after it; the FAQ interaction is isolated in a 4,117-byte deferred chunk.
