### PR TITLE
perf(web): defer careers job cards

### DIFF
--- a/apps/web/src/app/(main)/careers/page.tsx
+++ b/apps/web/src/app/(main)/careers/page.tsx
@@ -1,8 +1,7 @@
 import type { NextPage } from 'next'
 import Image from 'next/image'
 
-import JobCard from '@/components/Careers/JobCard'
-import { JOBS } from '@/constants/careers'
+import { DeferredCareersJobs } from '@/components/DeferredCareersSections'
 
 const Careers: NextPage = () => (
   <div className="container pt-20">
@@ -39,9 +38,7 @@ const Careers: NextPage = () => (
     </section>
 
     <section className="section">
-      {JOBS.map((details) => (
-        <JobCard key={details.id} details={details} />
-      ))}
+      <DeferredCareersJobs />
     </section>
   </div>
 )

--- a/apps/web/src/components/CareersJobs.tsx
+++ b/apps/web/src/components/CareersJobs.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import JobCard from '@/components/Careers/JobCard'
+import { JOBS } from '@/constants/careers'
+
+export default function CareersJobs() {
+  return (
+    <>
+      {JOBS.map((details) => (
+        <JobCard key={details.id} details={details} />
+      ))}
+    </>
+  )
+}

--- a/apps/web/src/components/DeferredCareersSections.tsx
+++ b/apps/web/src/components/DeferredCareersSections.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { DeferredSection } from '@nl/ui/custom/deferred-section'
+
+const loadCareersJobs = () => import('@/components/CareersJobs')
+
+export function DeferredCareersJobs() {
+  return (
+    <DeferredSection
+      label="job openings"
+      load={loadCareersJobs}
+      minHeightClassName="min-h-[30rem]"
+      rootMargin="480px"
+    />
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -236,6 +236,9 @@ const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const webDeferredOverviewSections = 'apps/web/src/components/DeferredOverviewSections.tsx'
 const webOverviewFAQ = 'apps/web/src/components/OverviewFAQ.tsx'
+const webCareersPage = 'apps/web/src/app/(main)/careers/page.tsx'
+const webDeferredCareersSections = 'apps/web/src/components/DeferredCareersSections.tsx'
+const webCareersJobs = 'apps/web/src/components/CareersJobs.tsx'
 const smashersDeferredHomeSections = 'apps/smashers/src/components/DeferredHomeSections.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const privateRoutesShell = 'apps/app/src/components/providers/PrivateRoutesShell.tsx'
@@ -1092,6 +1095,20 @@ describe('shared below-fold loading contract', () => {
     expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
     expect(faqSource).toContain("from '@nl/ui/custom/accordion'")
     expect(faqSource).toContain('defaultValue="item-1"')
+  })
+
+  it('defers the below-fold Careers job accordion bundle', () => {
+    const pageSource = readFileSync(join(process.cwd(), webCareersPage), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), webDeferredCareersSections), 'utf8')
+    const jobsSource = readFileSync(join(process.cwd(), webCareersJobs), 'utf8')
+
+    expect(pageSource).toContain('DeferredCareersJobs')
+    expect(pageSource).not.toContain("from '@/components/Careers/JobCard'")
+    expect(pageSource).not.toContain("from '@/constants/careers'")
+    expect(deferredSource).toContain("import('@/components/CareersJobs')")
+    expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+    expect(jobsSource).toContain("from '@/components/Careers/JobCard'")
+    expect(jobsSource).toContain("from '@/constants/careers'")
   })
 
   it('defers below-fold marketing sections in Smashers', () => {


### PR DESCRIPTION
## What changed
- Move the Careers job-card accordion list behind the shared accessible `DeferredSection` boundary.
- Keep the Careers hero, page heading, themed layout, and loading status in the initial route.
- Keep the existing shadcn/Radix accordion and job data in a separately loaded component.

## Why
The below-the-fold job cards were pulling the full accordion interaction bundle into the initial Careers route. Deferring the list removes that cost from first load while preserving the existing keyboard-accessible job disclosures once the openings section approaches the viewport.

## Validation
- `bun test --isolate --preload ./test/happy-dom-setup.ts --preload ./test/preload.ts --preload ./test/setup.ts test/contract/route-surface.test.ts`
- `bun run --cwd apps/web type-check`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web test`
- `bun run --cwd apps/web build`
- `bunx prettier --check apps/web/src/app/(main)/careers/page.tsx apps/web/src/components/CareersJobs.tsx apps/web/src/components/DeferredCareersSections.tsx test/contract/route-surface.test.ts`

The production Careers route initial JavaScript measured 680,910 bytes before this change and 661,495 bytes after it; the job-card interaction remains in a deferred chunk.
