### PR TITLE
perf(app): slim public shell controls

### DIFF
--- a/apps/app/src/components/providers/PublicDesktopSidebarToggle.tsx
+++ b/apps/app/src/components/providers/PublicDesktopSidebarToggle.tsx
@@ -3,7 +3,7 @@
 import { Menu } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
-import { Button } from '@nl/ui/base/button'
+import { IconButton } from '@nl/ui/base/icon-button'
 
 const PUBLIC_NAVIGATION_SELECTOR = '[data-public-navigation]'
 
@@ -17,7 +17,7 @@ export default function PublicDesktopSidebarToggle() {
   }, [open])
 
   return (
-    <Button
+    <IconButton
       type="button"
       variant="ghost"
       size="icon"
@@ -28,6 +28,6 @@ export default function PublicDesktopSidebarToggle() {
       aria-controls="public-desktop-navigation"
     >
       <Menu aria-hidden="true" absoluteStrokeWidth size={24} />
-    </Button>
+    </IconButton>
   )
 }

--- a/apps/app/src/components/providers/PublicMobileNavigationTrigger.tsx
+++ b/apps/app/src/components/providers/PublicMobileNavigationTrigger.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import { Menu } from 'lucide-react'
 import { useState } from 'react'
 
-import { Button } from '@nl/ui/base/button'
+import { IconButton } from '@nl/ui/base/icon-button'
 
 const PublicMobileNavigation = dynamic(() => import('./PublicMobileNavigation'), {
   ssr: false,
@@ -15,7 +15,7 @@ export default function PublicMobileNavigationTrigger() {
 
   return (
     <>
-      <Button
+      <IconButton
         type="button"
         variant="ghost"
         size="icon"
@@ -26,7 +26,7 @@ export default function PublicMobileNavigationTrigger() {
         aria-controls="public-mobile-navigation"
       >
         <Menu aria-hidden="true" absoluteStrokeWidth size={24} />
-      </Button>
+      </IconButton>
       {open ? <PublicMobileNavigation open={open} onOpenChange={setOpen} /> : null}
     </>
   )

--- a/packages/ui/src/components/base/base-components.test.tsx
+++ b/packages/ui/src/components/base/base-components.test.tsx
@@ -38,6 +38,7 @@ import {
   DialogTrigger,
 } from '@nl/ui/base/dialog'
 import { Icon } from '@nl/ui/base/icon'
+import { IconButton } from '@nl/ui/base/icon-button'
 import { Input } from '@nl/ui/base/input'
 import { Label } from '@nl/ui/base/label'
 import {
@@ -110,6 +111,9 @@ describe('base visual primitives', () => {
         <Button asChild variant="link">
           <a href="/button">Button link</a>
         </Button>
+        <IconButton aria-label="Open menu">
+          <span aria-hidden="true">+</span>
+        </IconButton>
         <Card>
           <CardHeader>
             <CardTitle>Title</CardTitle>
@@ -135,6 +139,7 @@ describe('base visual primitives', () => {
 
     expect(screen.getByRole('alert')?.textContent).toContain('Danger')
     expect(screen.getByRole('button', { name: 'Save' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Open menu' })?.getAttribute('type')).toBe('button')
     expect((screen.getByLabelText('Name') as HTMLInputElement)?.value).toBe('Degen')
     expect(screen.getByLabelText('status icon')).not.toBeNull()
     expect(screen.getByRole('progressbar', { name: 'progress' })).not.toBeNull()

--- a/packages/ui/src/components/base/button-variants.tsx
+++ b/packages/ui/src/components/base/button-variants.tsx
@@ -1,0 +1,30 @@
+import { cva } from 'class-variance-authority'
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/80',
+        destructive:
+          'bg-destructive text-white shadow-xs hover:bg-destructive/80 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        dashed:
+          'border border-dashed bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 hover:border-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+        muted:
+          'bg-dark/60 hover:bg-dark/40 dark:bg-muted/60 dark:hover:bg-muted text-white shadow-xs ',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  }
+)

--- a/packages/ui/src/components/base/button.tsx
+++ b/packages/ui/src/components/base/button.tsx
@@ -1,37 +1,9 @@
 import * as React from 'react'
 import { Slot as SlotPrimitive } from 'radix-ui'
-import { cva, type VariantProps } from 'class-variance-authority'
+import type { VariantProps } from 'class-variance-authority'
 
 import { cn } from '@nl/ui/utils'
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/80',
-        destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/80 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
-        outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
-        dashed:
-          'border border-dashed bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 hover:border-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
-        muted:
-          'bg-dark/60 hover:bg-dark/40 dark:bg-muted/60 dark:hover:bg-muted text-white shadow-xs ',
-      },
-      size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
-      },
-    },
-    defaultVariants: { variant: 'default', size: 'default' },
-  }
-)
+import { buttonVariants } from './button-variants'
 
 function Button({
   className,
@@ -51,4 +23,5 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }
+export { buttonVariants } from './button-variants'

--- a/packages/ui/src/components/base/icon-button.tsx
+++ b/packages/ui/src/components/base/icon-button.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from 'react'
+import type { VariantProps } from 'class-variance-authority'
+
+import { cn } from '@nl/ui/utils'
+
+import { buttonVariants } from './button-variants'
+
+type IconButtonProps = ComponentProps<'button'> & VariantProps<typeof buttonVariants>
+
+function IconButton({
+  className,
+  variant = 'ghost',
+  size = 'icon',
+  type = 'button',
+  ...props
+}: IconButtonProps) {
+  return (
+    <button
+      type={type}
+      data-slot="icon-button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { IconButton }

--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -3,9 +3,11 @@
 import type { ComponentType } from 'react'
 import { useEffect, useRef, useState } from 'react'
 
-import { Button } from '@nl/ui/base/button'
 import { Skeleton } from '@nl/ui/base/skeleton'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+import { cn } from '@nl/ui/utils'
+
+import { buttonVariants } from '../../base/button-variants'
 
 interface DeferredSectionProps {
   label: string
@@ -75,9 +77,13 @@ export function DeferredSection({
           role="alert"
         >
           <p>{label} could not be loaded.</p>
-          <Button variant="outline" onClick={() => setRetryCount((count) => count + 1)}>
+          <button
+            type="button"
+            className={cn(buttonVariants({ variant: 'outline' }))}
+            onClick={() => setRetryCount((count) => count + 1)}
+          >
             Retry
-          </Button>
+          </button>
         </div>
       ) : LoadedSection ? (
         <LoadedSection />

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -255,6 +255,7 @@ const publicDesktopSidebarToggle =
   'apps/app/src/components/providers/PublicDesktopSidebarToggle.tsx'
 const publicMobileNavigationTrigger =
   'apps/app/src/components/providers/PublicMobileNavigationTrigger.tsx'
+const publicIconButton = 'packages/ui/src/components/base/icon-button.tsx'
 const publicMainContent = 'apps/app/src/components/providers/PublicMainContent.tsx'
 const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
 const verificationPage = 'apps/app/src/app/verification/page.tsx'
@@ -657,6 +658,7 @@ describe('public app shell contract', () => {
     )
     const mainContentSource = readFileSync(join(process.cwd(), publicMainContent), 'utf8')
     const linksSource = readFileSync(join(process.cwd(), publicNavLinks), 'utf8')
+    const iconButtonSource = readFileSync(join(process.cwd(), publicIconButton), 'utf8')
 
     expect(navigationSource).not.toContain("'use client'")
     expect(navigationSource).toContain("from './PublicDesktopSidebarToggle'")
@@ -666,11 +668,13 @@ describe('public app shell contract', () => {
     expect(navigationSource).not.toContain("from '@nl/ui/base/scroll-area'")
     expect(navigationSource).not.toContain("from '@nl/ui/base/icon'")
     expect(navigationSource).not.toContain("from '@/components/extended/Breadcrumbs'")
-    expect(desktopToggleSource).toContain("from '@nl/ui/base/button'")
+    expect(desktopToggleSource).toContain("from '@nl/ui/base/icon-button'")
+    expect(desktopToggleSource).not.toContain("from '@nl/ui/base/button'")
     expect(desktopToggleSource).toContain('data-sidebar-open')
     expect(desktopToggleSource).toContain('aria-controls="public-desktop-navigation"')
     expect(mobileTriggerSource).toContain("import('./PublicMobileNavigation')")
-    expect(mobileTriggerSource).toContain("from '@nl/ui/base/button'")
+    expect(mobileTriggerSource).toContain("from '@nl/ui/base/icon-button'")
+    expect(mobileTriggerSource).not.toContain("from '@nl/ui/base/button'")
     expect(mainContentSource).toContain('usePathname')
     expect(mobileSource).toContain("from '@nl/ui/base/sheet'")
     expect(mobileSource).toContain('<SheetTitle')
@@ -679,6 +683,9 @@ describe('public app shell contract', () => {
     expect(linksSource).not.toContain("from '@nl/ui/base/icon'")
     expect(linksSource).toContain("from 'lucide-react'")
     expect(linksSource).toContain("aria-current={isSelected ? 'page' : undefined}")
+    expect(iconButtonSource).toContain("from './button-variants'")
+    expect(iconButtonSource).not.toContain("from 'radix-ui'")
+    expect(iconButtonSource).toContain("type = 'button'")
   })
 })
 
@@ -1063,7 +1070,10 @@ describe('shared below-fold loading contract', () => {
     const source = readFileSync(join(process.cwd(), sharedDeferredSection), 'utf8')
 
     expect(source).toContain("from '@nl/ui/base/skeleton'")
-    expect(source).toContain("from '@nl/ui/base/button'")
+    expect(source).toContain("from '../../base/button-variants'")
+    expect(source).not.toContain("from '@nl/ui/base/button'")
+    expect(source).toContain('<button')
+    expect(source).toContain('type="button"')
     expect(source).toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(source).toContain('role="status"')
     expect(source).toContain('role="alert"')


### PR DESCRIPTION
## Summary
- extract shared shadcn button variants so native controls reuse the existing theme and focus treatment
- add an accessible native `IconButton` for the public desktop/mobile navigation toggles without pulling Radix Slot into the public shell
- use the shared variants on the deferred-section retry button, preserving keyboard behavior and styling while keeping the eager graph smaller

## Measured impact
- apps/app public homepage initial JavaScript: 665,776 bytes -> 662,496 bytes in the before/after production builds (~3.2 KB, ~0.5% reduction)
- the rebuilt Web marketing routes and app public routes contain no Radix Slot signatures in their initial client chunks

## Validation
- `bun test packages/ui/src/components/base` — 143 passed
- `bun test apps/app/src` — 166 passed
- `bun test test/contract/route-surface.test.ts packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx` — 176 passed
- `bun run type-check` in apps/app, apps/web, apps/smashers, and packages/ui — passed
- lint in apps/app, apps/web, and packages/ui — passed
- production builds in apps/app, apps/web, and apps/smashers — passed

Hosted Vercel and heavyweight CI are intentionally limited to this ready PR by the repository budget policy.