### PR TITLE
perf(ui): slim circular progress icon dependency

### DIFF
--- a/packages/ui/src/components/custom/circular-progress/circular-progress.test.tsx
+++ b/packages/ui/src/components/custom/circular-progress/circular-progress.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+import { CircularProgress } from './index'
+
+describe('CircularProgress', () => {
+  it('renders the lightweight loader with shared size and color aliases', () => {
+    const { container } = render(
+      <CircularProgress size="sm" color="light" fill="none" className="m-auto" />
+    )
+    const spinner = container.querySelector('svg')
+
+    expect(spinner).not.toBeNull()
+    expect(spinner?.getAttribute('width')).toBe('18')
+    expect(spinner?.getAttribute('height')).toBe('18')
+    expect(spinner?.getAttribute('stroke')).toBe('var(--color-light)')
+    expect(spinner?.getAttribute('fill')).toBe('none')
+    expect(spinner?.getAttribute('aria-hidden')).toBe('true')
+    expect(spinner?.getAttribute('class')).toContain('animate-spin')
+    expect(spinner?.getAttribute('class')).toContain('m-auto')
+  })
+
+  it('accepts a numeric size and preserves custom SVG props', () => {
+    const { container } = render(<CircularProgress size={75} color="#fff" data-testid="spinner" />)
+    const spinner = container.querySelector('[data-testid="spinner"]')
+
+    expect(spinner?.getAttribute('width')).toBe('75')
+    expect(spinner?.getAttribute('height')).toBe('75')
+    expect(spinner?.getAttribute('stroke')).toBe('#fff')
+    expect(spinner?.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/packages/ui/src/components/custom/circular-progress/index.tsx
+++ b/packages/ui/src/components/custom/circular-progress/index.tsx
@@ -1,18 +1,56 @@
 'use client'
 
-import { Icon, type IconProps } from '@nl/ui/base/icon'
+import { LoaderCircle, type LucideProps } from 'lucide-react'
 import { cn } from '@nl/ui/utils'
 
+type CircularProgressSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number
+
+const DEFAULT_SIZES = { xs: 14, sm: 18, md: 20, lg: 24, xl: 28 } as const
+
+const DEFAULT_COLORS = {
+  foreground: 'var(--color-foreground)',
+  dim: 'var(--color-muted-foreground)',
+  dark: 'var(--color-dark)',
+  light: 'var(--color-light)',
+  error: 'var(--color-error)',
+  warning: 'var(--color-warning)',
+  success: 'var(--color-success)',
+  info: 'var(--color-info)',
+  blue: 'var(--color-blue)',
+  purple: 'var(--color-purple)',
+  gray: 'var(--color-base-500)',
+} as const
+
+type CircularProgressColor = keyof typeof DEFAULT_COLORS | (string & {})
+
+type CircularProgressProps = Omit<LucideProps, 'size' | 'color' | 'fill'> & {
+  size?: CircularProgressSize
+  color?: CircularProgressColor
+  fill?: CircularProgressColor
+}
+
+const resolveSize = (size: CircularProgressSize) =>
+  typeof size === 'number' ? size : DEFAULT_SIZES[size]
+
+const resolveColor = (color: CircularProgressColor) =>
+  DEFAULT_COLORS[color as keyof typeof DEFAULT_COLORS] ?? color
+
 export function CircularProgress({
+  absoluteStrokeWidth = true,
   className = '',
+  color = 'currentColor',
+  fill = 'none',
   size = 'xl',
+  strokeWidth = 2.5,
   ...props
-}: Omit<IconProps, 'name'>) {
+}: CircularProgressProps) {
   return (
-    <Icon
-      name="loader-circle"
-      size={size}
-      strokeWidth={2.5}
+    <LoaderCircle
+      absoluteStrokeWidth={absoluteStrokeWidth}
+      color={resolveColor(color)}
+      fill={resolveColor(fill)}
+      size={resolveSize(size)}
+      strokeWidth={strokeWidth}
       className={cn('inline-block flex-shrink-0 animate-spin', className)}
       aria-hidden="true"
       {...props}


### PR DESCRIPTION
## Summary
- render CircularProgress directly with lucide-react's LoaderCircle instead of the full shared icon registry
- preserve existing size aliases, theme color aliases, SVG props, spin styling, and decorative accessibility semantics
- add focused regression coverage for aliases, custom sizes, and SVG attributes

## Performance impact
The Web production build reduced the deferred GLTF chunk from 1,097,184 to 1,081,074 bytes: 16,110 bytes smaller (~1.5%). The App production build also completed with the direct LoaderCircle dependency in its loading surfaces.

## Validation
- packages/ui: lint, type-check, 145 tests passed
- apps/web: lint, type-check, production build, 14 tests passed
- apps/app: lint, type-check, production build, 166 tests passed
- route contracts: 174 passed

Hosted Vercel and CI checks should run only because this PR is ready for review.