### PR TITLE
perf(ui): slim auth icon dependency graphs

### DIFF
--- a/packages/ui/src/components/custom/auth-form/forms/forgot-password.tsx
+++ b/packages/ui/src/components/custom/auth-form/forms/forgot-password.tsx
@@ -3,11 +3,11 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { Inbox, Loader, Mail } from 'lucide-react'
 
 import { Button } from '@nl/ui/base/button'
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@nl/ui/base/form'
 import { Input } from '@nl/ui/custom/input'
-import { Icon } from '@nl/ui/base/icon'
 
 import { VIEWS } from '../constants'
 
@@ -40,7 +40,12 @@ export function ForgotPasswordForm({ setAuthView, handleResetPassword }: ForgotP
             <FormItem>
               <FormLabel>Email</FormLabel>
               <FormControl>
-                <Input {...field} type="email" autoComplete="on" startIcon={<Icon name="mail" />} />
+                <Input
+                  {...field}
+                  type="email"
+                  autoComplete="on"
+                  startIcon={<Mail absoluteStrokeWidth size={20} strokeWidth={1.5} />}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -48,10 +53,10 @@ export function ForgotPasswordForm({ setAuthView, handleResetPassword }: ForgotP
         />
         <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
           {form.formState.isSubmitting ? (
-            <Icon name="loader" className="animate-spin" />
+            <Loader absoluteStrokeWidth className="animate-spin" size={20} strokeWidth={1.5} />
           ) : (
             <>
-              <Icon name="inbox" />
+              <Inbox absoluteStrokeWidth size={20} strokeWidth={1.5} />
               Email Me
             </>
           )}

--- a/packages/ui/src/components/custom/auth-form/forms/login.tsx
+++ b/packages/ui/src/components/custom/auth-form/forms/login.tsx
@@ -3,13 +3,13 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { KeyRound, Loader, Lock, Mail } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'
 import { Button } from '@nl/ui/base/button'
 import { Checkbox } from '@nl/ui/base/checkbox'
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@nl/ui/base/form'
 import { Input } from '@nl/ui/custom/input'
-import { Icon } from '@nl/ui/base/icon'
 
 import { SocialAuth, type SocialAuthProps } from '../social-auth'
 import { VIEWS } from '../constants'
@@ -75,7 +75,7 @@ export function LoginForm({
                   type="email"
                   autoComplete={view === VIEWS.LOGIN ? 'on' : 'off'}
                   disabled={disabled}
-                  startIcon={<Icon name="mail" />}
+                  startIcon={<Mail absoluteStrokeWidth size={20} strokeWidth={1.5} />}
                 />
               </FormControl>
               <FormMessage />
@@ -94,7 +94,7 @@ export function LoginForm({
                   type="password"
                   autoComplete={view === VIEWS.LOGIN ? 'current-password' : 'new-password'}
                   disabled={disabled}
-                  startIcon={<Icon name="key-round" />}
+                  startIcon={<KeyRound absoluteStrokeWidth size={20} strokeWidth={1.5} />}
                 />
               </FormControl>
               <FormMessage />
@@ -132,10 +132,10 @@ export function LoginForm({
         />
         <Button type="submit" className="w-full" disabled={disabled}>
           {disabled ? (
-            <Icon name="loader" className="animate-spin" />
+            <Loader absoluteStrokeWidth className="animate-spin" size={20} strokeWidth={1.5} />
           ) : (
             <>
-              <Icon name="lock" />
+              <Lock absoluteStrokeWidth size={20} strokeWidth={1.5} />
               {view === VIEWS.LOGIN ? 'Login' : 'Sign Up'}
             </>
           )}

--- a/packages/ui/src/components/custom/auth-form/forms/update-password.tsx
+++ b/packages/ui/src/components/custom/auth-form/forms/update-password.tsx
@@ -3,11 +3,11 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { KeyRound, Loader, Save } from 'lucide-react'
 
 import { Button } from '@nl/ui/base/button'
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@nl/ui/base/form'
 import { Input } from '@nl/ui/custom/input'
-import { Icon } from '@nl/ui/base/icon'
 
 export interface UpdatePasswordFormProps {
   handleUpdatePassword: (values: z.infer<typeof formSchema>) => Promise<void>
@@ -49,7 +49,7 @@ export function UpdatePasswordForm({ handleUpdatePassword }: UpdatePasswordFormP
                   {...field}
                   type="password"
                   autoComplete="current-password"
-                  startIcon={<Icon name="key-round" />}
+                  startIcon={<KeyRound absoluteStrokeWidth size={20} strokeWidth={1.5} />}
                 />
               </FormControl>
               <FormMessage />
@@ -67,7 +67,7 @@ export function UpdatePasswordForm({ handleUpdatePassword }: UpdatePasswordFormP
                   {...field}
                   type="password"
                   autoComplete="new-password"
-                  startIcon={<Icon name="key-round" />}
+                  startIcon={<KeyRound absoluteStrokeWidth size={20} strokeWidth={1.5} />}
                 />
               </FormControl>
               <FormMessage />
@@ -76,10 +76,10 @@ export function UpdatePasswordForm({ handleUpdatePassword }: UpdatePasswordFormP
         />
         <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
           {form.formState.isSubmitting ? (
-            <Icon name="loader" className="animate-spin" />
+            <Loader absoluteStrokeWidth className="animate-spin" size={20} strokeWidth={1.5} />
           ) : (
             <>
-              <Icon name="save" />
+              <Save absoluteStrokeWidth size={20} strokeWidth={1.5} />
               Update Password
             </>
           )}

--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -2,6 +2,7 @@ const stubGlobal = (name, value) => {
   Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
 }
 import type { PropsWithChildren } from 'react'
+import { Mail } from 'lucide-react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, jest, mock } from 'bun:test'
@@ -123,6 +124,14 @@ describe('custom Input', () => {
 
     rerender(<Input id="plain" />)
     expect(screen.getByRole('textbox')?.getAttribute('id')).toBe('plain')
+  })
+
+  it('accepts direct Lucide icons and normalizes their rendered size', () => {
+    const { container } = render(<Input id="direct-icon" startIcon={<Mail />} />)
+    const icon = container.querySelector('svg.lucide-mail')
+
+    expect(icon?.getAttribute('width')).toBe('18')
+    expect(icon?.getAttribute('height')).toBe('18')
   })
 })
 

--- a/packages/ui/src/components/custom/input/index.tsx
+++ b/packages/ui/src/components/custom/input/index.tsx
@@ -9,12 +9,14 @@ import {
   useId,
   useState,
 } from 'react'
+import { AlertCircle, Copy, type LucideProps } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'
 import { Button } from '@nl/ui/base/button'
-import { Icon, type IconProps } from '@nl/ui/base/icon'
 import { Input as BaseInput } from '@nl/ui/base/input'
 import { Label } from '@nl/ui/base/label'
+
+type InputIconProps = Omit<LucideProps, 'size'> & { size?: number | string }
 
 interface InputProps extends React.ComponentProps<'input'> {
   actions?: React.ReactNode
@@ -22,8 +24,8 @@ interface InputProps extends React.ComponentProps<'input'> {
   error?: boolean
   hiddenLabel?: boolean /* adds hidden label for accessibility */
   label?: string
-  endIcon?: React.ReactElement<IconProps>
-  startIcon?: React.ReactElement<IconProps>
+  endIcon?: React.ReactElement<InputIconProps>
+  startIcon?: React.ReactElement<InputIconProps>
 }
 
 function LabelContainer({ children: input, error, id, hiddenLabel, label }: InputProps) {
@@ -92,7 +94,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   }, [])
 
   const invalid = Boolean(ariaInvalid || error)
-  if (invalid) endIcon = <Icon name="alert-circle" color="error" />
+  if (invalid)
+    endIcon = (
+      <AlertCircle absoluteStrokeWidth color="var(--color-error)" size={20} strokeWidth={1.5} />
+    )
 
   // Calculate dynamic right padding
   useLayoutEffect(() => {
@@ -111,7 +116,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         {startIcon && (
           <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             {cloneElement(startIcon, {
-              size: 'sm',
+              size: 18,
               className: cn('text-muted-foreground', startIcon.props?.className),
             })}
           </div>
@@ -152,7 +157,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
                 className="px-2 cursor-copy"
                 aria-live="polite"
               >
-                <Icon name="copy" size="sm" />
+                <Copy absoluteStrokeWidth size={18} strokeWidth={1.5} />
                 {copyLabel}
               </Button>
             )}
@@ -160,7 +165,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
             {endIcon && (
               <div className="pointer-events-none pl-1 pr-2.5">
                 {cloneElement(endIcon, {
-                  size: 'sm',
+                  size: 18,
                   className: cn('text-muted-foreground', endIcon.props?.className),
                 })}
               </div>

--- a/packages/ui/src/components/custom/social-icon-button/index.tsx
+++ b/packages/ui/src/components/custom/social-icon-button/index.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import { Loader } from 'lucide-react'
+
 import { cn } from '@nl/ui/utils'
 import { Button } from '@nl/ui/base/button'
-import { Icon } from '@nl/ui/base/icon'
 
 import * as SocialIcons from './social-icons'
 import buttonStyles from './socials.module.css'
@@ -38,7 +39,11 @@ export function SocialIconButton({
       disabled={disabled}
       onClick={onClick}
     >
-      {loading ? <Icon name="loader" className="animate-spin" /> : <AuthIcon />}
+      {loading ? (
+        <Loader absoluteStrokeWidth className="animate-spin" size={20} strokeWidth={1.5} />
+      ) : (
+        <AuthIcon />
+      )}
       {label && label}
       <span className="sr-only">{provider}</span>
     </Button>

--- a/packages/ui/src/components/custom/theme/index.tsx
+++ b/packages/ui/src/components/custom/theme/index.tsx
@@ -2,9 +2,9 @@
 
 import * as React from 'react'
 import { ThemeProvider as NextThemesProvider, useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
 
 import { Button } from '@nl/ui/base/button'
-import { Icon } from '@nl/ui/base/icon'
 
 export function ThemeProvider({
   children,
@@ -31,7 +31,11 @@ export function ThemeToggle() {
       size="icon"
       onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
     >
-      <Icon name={theme === 'dark' ? 'moon' : 'sun'} className="h-[1.2rem] w-[1.2rem]" />
+      {theme === 'dark' ? (
+        <Moon absoluteStrokeWidth className="h-[1.2rem] w-[1.2rem]" size={20} strokeWidth={1.5} />
+      ) : (
+        <Sun absoluteStrokeWidth className="h-[1.2rem] w-[1.2rem]" size={20} strokeWidth={1.5} />
+      )}
       <span className="sr-only">Toggle theme</span>
     </Button>
   )

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -158,6 +158,14 @@ const staleDownloadGameDialog = 'apps/app/src/components/dialog/DownloadGameDial
 const smashersLoginClient = 'apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx'
 const smashersLoginPage = 'apps/smashers/src/app/(auth_routes)/login/page.tsx'
 const smashersLoginRoute = 'apps/smashers/src/app/(auth_routes)/login/LoginRoute.tsx'
+const sharedAuthIconSources = [
+  'packages/ui/src/components/custom/input/index.tsx',
+  'packages/ui/src/components/custom/auth-form/forms/login.tsx',
+  'packages/ui/src/components/custom/auth-form/forms/forgot-password.tsx',
+  'packages/ui/src/components/custom/auth-form/forms/update-password.tsx',
+  'packages/ui/src/components/custom/social-icon-button/index.tsx',
+  'packages/ui/src/components/custom/theme/index.tsx',
+]
 const smashersProfilePage = 'apps/smashers/src/app/(auth_routes)/profile/page.tsx'
 const smashersProfileRoute = 'apps/smashers/src/app/(auth_routes)/profile/ProfileRoute.tsx'
 const smashersActionButtons = 'apps/smashers/src/components/Header/ActionButtonsGroup/index.tsx'
@@ -424,6 +432,17 @@ describe('Smashers login loading contract', () => {
     expect(routeSource).toContain('role="status"')
     expect(routeSource).toContain('aria-live="polite"')
     expect(routeSource).toContain('aria-busy="true"')
+  })
+})
+
+describe('shared auth icon loading contract', () => {
+  it('keeps small auth controls out of the full icon registry graph', () => {
+    for (const file of sharedAuthIconSources) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+
+      expect(source).toContain("from 'lucide-react'")
+      expect(source).not.toContain("from '@nl/ui/base/icon'")
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- replace full `@nl/ui/base/icon` imports in the shared input, auth forms, social auth button, and theme toggle with direct Lucide icon imports
- preserve input icon compatibility for Lucide/base SVG props, current 18/20px sizing, color aliases, stroke widths, and accessible hidden decorative icons
- add a route contract preventing these small auth controls from regressing to the full icon registry dependency

## Performance impact
The auth/input client graphs no longer need the central multi-icon registry just to render their small controls. This reduces avoidable Lucide module fan-out in Smashers login/profile and app auth/private loading surfaces while preserving the shared component API and theme styling.

## Validation
- `packages/ui`: type-check, lint, full suite 146 passed
- `apps/app`: type-check, lint, production build passed
- `apps/smashers`: type-check, lint, production build passed (one existing turbo env warning)
- `packages/playfab`: type-check, lint, 83 tests passed
- route contracts: 175 passed
- focused auth/input/social/theme tests: 16 passed

Hosted Vercel and CI checks should run only because this PR is ready for review.