### PR TITLE
perf(web): slim roadmap icon dependency

### DIFF
--- a/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
+++ b/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
-import { Icon } from '@nl/ui/base/icon'
+import { Check } from 'lucide-react'
+
 import { AnimatedImage } from '@nl/ui/custom/animated-image'
 import { cn } from '@nl/ui/utils'
 import styles from './index.module.css'
@@ -36,7 +37,15 @@ const RoadmapCard = ({
       <div
         className={cn(styles.cd_timeline_checkpoint, { [styles.completed as string]: completed })}
       >
-        {completed && <Icon name="check" strokeWidth={2.5} className="m-auto" />}
+        {completed && (
+          <Check
+            absoluteStrokeWidth
+            aria-hidden="true"
+            className="m-auto"
+            size={20}
+            strokeWidth={2.5}
+          />
+        )}
       </div>
     )}
 

--- a/test/contract/web-roadmap-media.test.ts
+++ b/test/contract/web-roadmap-media.test.ts
@@ -15,7 +15,11 @@ describe('web roadmap animated media policy', () => {
   })
 
   it('routes roadmap cards through the shared animated image primitive', () => {
-    expect(readFileSync(roadmapCard, 'utf8')).toContain('@nl/ui/custom/animated-image')
+    const source = readFileSync(roadmapCard, 'utf8')
+
+    expect(source).toContain('@nl/ui/custom/animated-image')
+    expect(source).toContain("from 'lucide-react'")
+    expect(source).not.toContain("from '@nl/ui/base/icon'")
     expect(readFileSync(roadmapConstants, 'utf8')).toContain('crypto-winter-roadmap.webp')
     expect(readFileSync(roadmapConstants, 'utf8')).toContain('nifty-smashers-roadmap.webp')
   })


### PR DESCRIPTION
## Summary
- replace the roadmap completion check wrapper with a direct Lucide import
- preserve the shared icon wrapper rendering contract: 20px, current color, 2.5 stroke, absolute stroke width, and decorative semantics
- add a route contract preventing the full icon registry from returning to this public component

## Performance impact
The roadmap public route no longer reaches the shared icon registry through this single-icon component, reducing the public marketing dependency graph and keeping the shared registry out of this path.

## Validation
- `bun test test/contract/web-roadmap-media.test.ts`
- `bun run --cwd apps/web type-check`
- `bun run --cwd apps/web lint`
- `bunx prettier --check apps/web/src/components/RoadmapTimeline/roadmapCard.tsx test/contract/web-roadmap-media.test.ts`
- `bun run --cwd apps/web build`
- `bun run --cwd apps/web test`
- `bun test test/contract/route-surface.test.ts`

All local checks passed.