### PR TITLE
perf(app): slim public degen icon graph

### DIFF
--- a/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
+++ b/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
@@ -3,9 +3,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 import { Button } from '@nl/ui/base/button'
-import { Icon } from '@nl/ui/base/icon'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
@@ -177,7 +177,11 @@ const AllDegensPage = (): React.ReactNode => {
               aria-label={isDrawerOpen ? 'Hide filters' : 'Show filters'}
               onClick={() => setIsDrawerOpen(!isDrawerOpen)}
             >
-              <Icon name={isDrawerOpen ? 'chevron-left' : 'chevron-right'} size="xl" />
+              {isDrawerOpen ? (
+                <ChevronLeft absoluteStrokeWidth aria-hidden="true" size={28} strokeWidth={1.5} />
+              ) : (
+                <ChevronRight absoluteStrokeWidth aria-hidden="true" size={28} strokeWidth={1.5} />
+              )}
             </Button>
             {filteredData.length} Degens
           </div>
@@ -200,7 +204,7 @@ const AllDegensPage = (): React.ReactNode => {
             onClick={() => jump(currentPage - 1)}
             aria-label="Previous page"
           >
-            <Icon name="chevron-left" />
+            <ChevronLeft absoluteStrokeWidth aria-hidden="true" size={20} strokeWidth={1.5} />
           </Button>
           {pageItems.map((p) =>
             p === 'ellipsis-start' || p === 'ellipsis-end' ? (
@@ -227,7 +231,7 @@ const AllDegensPage = (): React.ReactNode => {
             onClick={() => jump(currentPage + 1)}
             aria-label="Next page"
           >
-            <Icon name="chevron-right" />
+            <ChevronRight absoluteStrokeWidth aria-hidden="true" size={20} strokeWidth={1.5} />
           </Button>
         </div>
       </div>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -315,6 +315,8 @@ describe('public degen loading contract', () => {
     expect(routeBoundarySource).toContain('aria-busy="true"')
     expect(routeBoundarySource).toContain("from '@nl/ui/base/skeleton'")
     expect(clientPageSource).toContain("'use client'")
+    expect(clientPageSource).toContain("from 'lucide-react'")
+    expect(clientPageSource).not.toContain("from '@nl/ui/base/icon'")
   })
 })
 


### PR DESCRIPTION
## Summary
- replace the public degen browser's three shared icon-registry calls with direct Lucide chevrons
- preserve the existing 28px drawer icon and 20px pagination icons, stroke settings, and accessible button labels
- add a route contract preventing the full icon registry from returning to this public client boundary

## Performance impact
The `/degens` client boundary no longer imports the shared icon registry for two chevrons, reducing its dependency graph while leaving the route boundary, interaction behavior, and theme styling unchanged.

## Validation
- `bun test test/contract/route-surface.test.ts` — 175 pass / 777 expects
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app test` — 166 pass / 1171 expects
- `bunx prettier --check "apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx" test/contract/route-surface.test.ts`
- `bun run --cwd apps/app build`

All local checks passed.