### PR TITLE
perf(app): slim degen layout icon graph

### DIFF
--- a/apps/app/src/components/extended/DegensTopNav/index.tsx
+++ b/apps/app/src/components/extended/DegensTopNav/index.tsx
@@ -1,6 +1,7 @@
+import { Grid3X3, LayoutGrid } from 'lucide-react'
+
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
 import { ToggleGroup, ToggleGroupItem } from '@nl/ui/base/toggle-group'
-import { Icon } from '@nl/ui/base/icon'
 import { Input } from '@nl/ui/custom/input'
 import DegenSortOptions from '@/constants/sort'
 
@@ -63,14 +64,14 @@ const DegensTopNav = ({
           value="gridView"
           aria-label="GridView"
         >
-          <Icon name="layout-grid" size="lg" />
+          <LayoutGrid absoluteStrokeWidth aria-hidden="true" size={24} strokeWidth={1.5} />
         </ToggleGroupItem>
         <ToggleGroupItem
           className={`${styles.layoutModeButton} data-[state=on]:bg-[rgba(88,32,214,0.2)]`}
           value="gridOn"
           aria-label="GridOn"
         >
-          <Icon name="grid-3x3" size="lg" />
+          <Grid3X3 absoluteStrokeWidth aria-hidden="true" size={24} strokeWidth={1.5} />
         </ToggleGroupItem>
       </ToggleGroup>
     </div>

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -255,6 +255,7 @@ const deferredLeaderboards = 'apps/app/src/components/providers/DeferredLeaderbo
 const degensPage = 'apps/app/src/app/(public-routes)/degens/page.tsx'
 const degensRouteBoundary = 'apps/app/src/app/(public-routes)/degens/DegenRoute.tsx'
 const degensClientPage = 'apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx'
+const degensTopNav = 'apps/app/src/components/extended/DegensTopNav/index.tsx'
 const publicMainLayout = 'apps/app/src/app/_layout/_PublicMainLayout/index.tsx'
 const publicNavigation = 'apps/app/src/components/providers/PublicNavigation.tsx'
 const publicMobileNavigation = 'apps/app/src/components/providers/PublicMobileNavigation.tsx'
@@ -305,6 +306,7 @@ describe('public degen loading contract', () => {
     const pageSource = readFileSync(join(process.cwd(), degensPage), 'utf8')
     const routeBoundarySource = readFileSync(join(process.cwd(), degensRouteBoundary), 'utf8')
     const clientPageSource = readFileSync(join(process.cwd(), degensClientPage), 'utf8')
+    const topNavSource = readFileSync(join(process.cwd(), degensTopNav), 'utf8')
 
     expect(pageSource).not.toContain("'use client'")
     expect(pageSource).toContain("from './DegenRoute'")
@@ -317,6 +319,8 @@ describe('public degen loading contract', () => {
     expect(clientPageSource).toContain("'use client'")
     expect(clientPageSource).toContain("from 'lucide-react'")
     expect(clientPageSource).not.toContain("from '@nl/ui/base/icon'")
+    expect(topNavSource).toContain("from 'lucide-react'")
+    expect(topNavSource).not.toContain("from '@nl/ui/base/icon'")
   })
 })
 


### PR DESCRIPTION
## Summary
- replace the public degen layout toggle's two shared icon-registry calls with direct Lucide imports
- preserve the existing 24px size, stroke settings, theme inheritance, and accessible toggle labels
- extend the public degen loading contract to protect both the page and top-nav boundaries

## Performance impact
The `/degens` client graph now avoids the shared icon registry for all of its public navigation and layout icons, keeping that registry out of the route's client dependency path.

## Validation
- `bun test apps/app/src/components/extended/DegensTopNav/index.test.tsx` — 1 pass
- `bun test test/contract/route-surface.test.ts` — 175 pass / 779 expects
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app test` — 166 pass / 1170 expects
- `bunx prettier --check apps/app/src/components/extended/DegensTopNav/index.tsx test/contract/route-surface.test.ts`
- `bun run --cwd apps/app build`

All local checks passed.