### PR TITLE
perf(smashers): slim shared back icon graph

### DIFF
--- a/apps/smashers/src/components/Header/BackButton/index.tsx
+++ b/apps/smashers/src/components/Header/BackButton/index.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link'
-import { Icon } from '@nl/ui/base/icon'
+import { CircleArrowLeft } from 'lucide-react'
+
 import styles from '../Navbar/index.module.css'
 
 export default function BackButton() {
   return (
     <Link href="/">
       <div className={styles.logo_container}>
-        <Icon
+        <CircleArrowLeft
           aria-label="back"
-          name="circle-arrow-left"
           color="#fff"
           size={48}
           strokeWidth={4}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -266,6 +266,7 @@ const publicMobileNavigationTrigger =
 const publicIconButton = 'packages/ui/src/components/base/icon-button.tsx'
 const publicMainContent = 'apps/app/src/components/providers/PublicMainContent.tsx'
 const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
+const smashersBackButton = 'apps/smashers/src/components/Header/BackButton/index.tsx'
 const verificationPage = 'apps/app/src/app/verification/page.tsx'
 const verificationLayout = 'apps/app/src/app/verification/layout.tsx'
 
@@ -401,6 +402,13 @@ describe('Smashers public shell contract', () => {
     expect(rootLayoutSource).not.toContain('FeatureFlagProvider')
     expect(authLayoutSource).toContain('FeatureFlagProvider')
     expect(existsSync(join(process.cwd(), staleSmashersUnityDialog))).toBe(false)
+  })
+
+  it('keeps the shared back control out of the full icon registry graph', () => {
+    const source = readFileSync(join(process.cwd(), smashersBackButton), 'utf8')
+
+    expect(source).toContain("from 'lucide-react'")
+    expect(source).not.toContain("from '@nl/ui/base/icon'")
   })
 })
 


### PR DESCRIPTION
## Summary
- replace the shared Smashers back-to-home icon registry call with a direct Lucide import
- preserve the existing 48px white circle-arrow, stroke width, CSS class, and accessible `back` label
- add a route contract preventing the full icon registry from returning to the shared control

## Performance impact
The public loot/not-found surfaces and auth screens no longer reach the shared icon registry through this one-icon control.

## Validation
- `bun test test/contract/route-surface.test.ts` — 176 pass / 781 expects
- `bun run --cwd apps/smashers type-check`
- `bun run --cwd apps/smashers lint` — 0 errors, 1 existing warning
- `bun run --cwd apps/smashers test` — 15 pass / 43 expects
- `bunx prettier --check apps/smashers/src/components/Header/BackButton/index.tsx test/contract/route-surface.test.ts`
- `bun run --cwd apps/smashers build`

All local checks passed.