### PR TITLE
perf(app): slim private shell icon graph

### DIFF
--- a/apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx
+++ b/apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, ReactNode, SetStateAction, useCallback } from 'react'
+import { X } from 'lucide-react'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
-import { Icon } from '@nl/ui/base/icon'
 import { ScrollArea } from '@nl/ui/base/scroll-area'
 
 const appHeaderHeight = 60
@@ -70,7 +70,7 @@ const CollapsibleSidebarLayout = ({
             className="absolute right-3 top-3 z-[1101] cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-foreground/10"
             onClick={handleDrawerOpen}
           >
-            <Icon name="x" size="md" />
+            <X aria-hidden="true" absoluteStrokeWidth size={20} strokeWidth={1.5} />
           </button>
         )}
         <ScrollArea

--- a/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx
@@ -2,9 +2,9 @@
 
 import { useAccount, useSwitchChain } from 'wagmi'
 import { immutableZkEvm, immutableZkEvmTestnet } from 'viem/chains'
+import { Info, TriangleAlert } from 'lucide-react'
 
 import { Button } from '@nl/ui/base/button'
-import { Icon } from '@nl/ui/base/icon'
 import { TARGET_NETWORK } from '@/constants/networks'
 
 export default function NetworkWarning() {
@@ -23,7 +23,11 @@ export default function NetworkWarning() {
       }
       style={{ zIndex: 1, position: 'absolute' }}
     >
-      <Icon name={isConnectedToIMX ? 'info' : 'triangle-alert'} size="lg" strokeWidth={2.5} />
+      {isConnectedToIMX ? (
+        <Info aria-hidden="true" absoluteStrokeWidth size={24} strokeWidth={2.5} />
+      ) : (
+        <TriangleAlert aria-hidden="true" absoluteStrokeWidth size={24} strokeWidth={2.5} />
+      )}
       <span aria-live="polite" className="px-2 text-xl font-semibold">
         {isConnectedToIMX
           ? `You're connected to Immutable zkEVM! Switch back to ${TARGET_NETWORK.label}`

--- a/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
@@ -1,9 +1,8 @@
 import { Button } from '@nl/ui/base/button'
+import { Menu } from 'lucide-react'
 
 import { useNavigation } from '@/contexts/NavigationContext'
 
-// assets
-import { Icon } from '@nl/ui/base/icon'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import LogoSection from '../_LogoSection'
 
@@ -40,7 +39,7 @@ const Header = () => {
           onClick={toggleDrawer}
           aria-label="toggle sidebar"
         >
-          <Icon name="menu" />
+          <Menu aria-hidden="true" absoluteStrokeWidth size={20} strokeWidth={1.5} />
         </Button>
       </div>
       <div className="hidden items-center justify-between gap-4 lg:flex">

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
+import { AppNavIcon } from '@/components/AppNavIcon'
 
 // project imports
 import { cn } from '@nl/ui/utils'
-import { Icon } from '@nl/ui/base/icon'
 import { NavGroupProps } from '../_NavGroup'
 import NavItem from '../_NavItem'
 
@@ -71,7 +71,7 @@ const NavCollapse = ({ menu, level }: NavCollapseProps) => {
         onClick={handleClick}
       >
         <span className="my-auto" style={{ minWidth: !menu.icon ? 18 : 36 }}>
-          <Icon name={menu?.icon ?? 'dot'} size="lg" className="ml-1" />
+          <AppNavIcon name={menu?.icon ?? 'dot'} size="lg" className="ml-1" />
         </span>
         <span className="flex flex-1 flex-col">
           <span style={{ color: 'inherit' }}>{menu.title}</span>
@@ -81,7 +81,7 @@ const NavCollapse = ({ menu, level }: NavCollapseProps) => {
             </span>
           )}
         </span>
-        <Icon
+        <AppNavIcon
           name="chevron-down"
           size="md"
           className={cn('transition-transform', open && 'rotate-180 transform')}

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavGroup/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavGroup/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 // project imports
-import type { IconName } from '@nl/ui/base/icon'
+import type { AppNavIconName } from '@/components/AppNavIcon'
 import NavItem from '../_NavItem'
 import NavCollapse from '../_NavCollapse'
 
@@ -12,7 +12,7 @@ export interface NavGroupProps {
     id?: string
     type?: string
     children?: NavGroupProps['item'][]
-    icon?: IconName
+    icon?: AppNavIconName
     title?: ReactNode | string
     caption?: ReactNode | string
     color?: 'primary' | 'secondary' | 'default' | undefined

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { AppNavIcon } from '@/components/AppNavIcon'
 
 import { cn } from '@nl/ui/utils'
-import { Icon } from '@nl/ui/base/icon'
 import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { useNavigation } from '@/contexts/NavigationContext'
 
@@ -34,7 +34,7 @@ const NavItem = ({ item, level }: NavItemProps) => {
   const inner = (
     <>
       <span className="my-auto" style={{ minWidth: !item?.icon ? 18 : 36 }}>
-        <Icon name={item?.icon ?? 'dot'} size="lg" />
+        <AppNavIcon name={item?.icon ?? 'dot'} size="lg" />
       </span>
       <span className="flex-1">
         <span

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_OnboardingCard/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_OnboardingCard/index.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react'
+import { BookOpenCheck } from 'lucide-react'
 
 import { Avatar, AvatarFallback } from '@nl/ui/base/avatar'
 import { Card, CardContent } from '@nl/ui/base/card'
 import { Progress } from '@nl/ui/base/progress'
-import { Icon } from '@nl/ui/base/icon'
 
 // styles
 import styles from './OnboardingCard.module.css'
@@ -42,7 +42,12 @@ const OnboardingCard = () => {
                 }}
               >
                 <AvatarFallback>
-                  <Icon name="book-open-check" />
+                  <BookOpenCheck
+                    aria-hidden="true"
+                    absoluteStrokeWidth
+                    size={20}
+                    strokeWidth={1.5}
+                  />
                 </AvatarFallback>
               </Avatar>
             </div>

--- a/apps/app/src/components/AppNavIcon.test.tsx
+++ b/apps/app/src/components/AppNavIcon.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { AppNavIcon } from './AppNavIcon'
+
+describe('AppNavIcon', () => {
+  it('keeps mapped navigation icons decorative and preserves theme defaults', () => {
+    const { container, rerender } = render(
+      <AppNavIcon name="layout-grid" size="lg" color="blue" fill="dim" />
+    )
+    const icon = container.querySelector('svg')
+
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+    expect(icon?.getAttribute('width')).toBe('24')
+    expect(icon?.getAttribute('height')).toBe('24')
+    expect(icon?.getAttribute('fill')).toBe('var(--color-muted-foreground)')
+    expect(icon?.getAttribute('stroke')).toBe('var(--color-blue)')
+    expect(icon?.getAttribute('class')).toContain('lucide-layout-grid')
+
+    rerender(<AppNavIcon name="settings" aria-label="Settings" />)
+    const labeledIcon = container.querySelector('svg')
+
+    expect(labeledIcon?.getAttribute('aria-hidden')).toBeNull()
+    expect(labeledIcon?.getAttribute('aria-label')).toBe('Settings')
+  })
+})

--- a/apps/app/src/components/AppNavIcon.tsx
+++ b/apps/app/src/components/AppNavIcon.tsx
@@ -1,0 +1,89 @@
+import {
+  Cat,
+  ChevronDown,
+  ChevronRight,
+  Dot,
+  Gamepad,
+  House,
+  LayoutGrid,
+  ListOrdered,
+  ListTree,
+  Settings,
+  Sparkles,
+  Tally1,
+  User,
+} from 'lucide-react'
+import type { LucideIcon, LucideProps } from 'lucide-react'
+
+const DEFAULT_SIZES = { xs: 14, sm: 18, md: 20, lg: 24, xl: 28 } as const
+
+const DEFAULT_COLORS = {
+  foreground: 'var(--color-foreground)',
+  dim: 'var(--color-muted-foreground)',
+  dark: 'var(--color-dark)',
+  light: 'var(--color-light)',
+  error: 'var(--color-error)',
+  warning: 'var(--color-warning)',
+  success: 'var(--color-success)',
+  info: 'var(--color-info)',
+  blue: 'var(--color-blue)',
+  purple: 'var(--color-purple)',
+  gray: 'var(--color-base-500)',
+} as const
+
+const iconMap = {
+  cat: Cat,
+  'chevron-down': ChevronDown,
+  'chevron-right': ChevronRight,
+  dot: Dot,
+  gamepad: Gamepad,
+  house: House,
+  'layout-grid': LayoutGrid,
+  'list-ordered': ListOrdered,
+  'list-tree': ListTree,
+  settings: Settings,
+  sparkles: Sparkles,
+  'tally-1': Tally1,
+  user: User,
+} as const satisfies Record<string, LucideIcon>
+
+type AppNavIconName = keyof typeof iconMap
+type AppNavIconSize = keyof typeof DEFAULT_SIZES
+type AppNavIconColor = keyof typeof DEFAULT_COLORS | (string & {})
+
+interface AppNavIconProps extends Omit<LucideProps, 'color' | 'fill' | 'size'> {
+  name?: AppNavIconName
+  size?: AppNavIconSize | number
+  color?: AppNavIconColor
+  fill?: AppNavIconColor
+}
+
+function AppNavIcon({
+  absoluteStrokeWidth = true,
+  color = 'currentColor',
+  fill = 'none',
+  name,
+  size = 'md',
+  strokeWidth = 1.5,
+  ...props
+}: AppNavIconProps) {
+  const IconComponent = (name && iconMap[name]) || Dot
+  const iconSize = typeof size === 'number' ? size : DEFAULT_SIZES[size]
+  const iconColor = DEFAULT_COLORS[color as keyof typeof DEFAULT_COLORS] || color
+  const iconFill = DEFAULT_COLORS[fill as keyof typeof DEFAULT_COLORS] || fill
+
+  return (
+    <IconComponent
+      absoluteStrokeWidth={absoluteStrokeWidth}
+      color={iconColor}
+      fill={iconFill}
+      size={iconSize}
+      strokeWidth={strokeWidth}
+      aria-hidden={props['aria-label'] ? undefined : 'true'}
+      {...props}
+    />
+  )
+}
+
+export { AppNavIcon }
+export type { AppNavIconColor, AppNavIconName, AppNavIconProps, AppNavIconSize }

--- a/apps/app/src/components/extended/Breadcrumbs.tsx
+++ b/apps/app/src/components/extended/Breadcrumbs.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState, useCallback } from 'react'
 import Link from 'next/link'
 
-import { Icon, type IconName } from '@nl/ui/base/icon'
+import { AppNavIcon } from '@/components/AppNavIcon'
+import type { AppNavIconName } from '@/components/AppNavIcon'
 import { cn } from '@nl/ui/utils'
 
 // project imports
@@ -33,7 +34,7 @@ interface BreadCrumbsProps {
   maxItems?: number
   navigation?: NavItemTypeObject
   rightAlign?: boolean
-  separator?: IconName
+  separator?: AppNavIconName
   title?: boolean
   titleBottom?: boolean
   sx?: BreadCrumbSxProps
@@ -94,7 +95,7 @@ const Breadcrumbs = ({
   }, [navigation, getCollapse])
 
   // item separator
-  const separatorIcon = <Icon name={separator || 'tally-1'} size="sm" />
+  const separatorIcon = <AppNavIcon name={separator || 'tally-1'} size="sm" />
 
   let mainContent
   let itemContent
@@ -103,8 +104,12 @@ const Breadcrumbs = ({
   // collapse item
   if (main && main.type === 'collapse') {
     mainContent = (
-      <Link href="#" className="flex items-center text-sm font-medium text-foreground no-underline">
-        {icons && <Icon name={main.icon ?? 'list-tree'} style={iconStyle} />}
+      <Link
+        key="main"
+        href="#"
+        className="flex items-center text-sm font-medium text-foreground no-underline"
+      >
+        {icons && <AppNavIcon name={main.icon ?? 'list-tree'} style={iconStyle} />}
         {main.title}
       </Link>
     )
@@ -114,10 +119,11 @@ const Breadcrumbs = ({
   if (item && item.type === 'item') {
     itemContent = (
       <span
+        key="item"
         className="flex items-center text-sm font-medium text-muted-foreground"
         style={{ textDecoration: 'none' }}
       >
-        {icons && <Icon name={item.icon ?? 'list-tree'} style={iconStyle} />}
+        {icons && <AppNavIcon name={item.icon ?? 'list-tree'} style={iconStyle} />}
         {item.title}
       </span>
     )
@@ -154,9 +160,13 @@ const Breadcrumbs = ({
                     className="flex items-center text-sm font-medium no-underline"
                     style={{ color: 'inherit' }}
                   >
-                    {icons && <Icon name="house" color="blue" fill="dim" style={iconStyle} />}
+                    {icons && <AppNavIcon name="house" color="blue" fill="dim" style={iconStyle} />}
                     {icon && (
-                      <Icon name="house" color="blue" style={{ ...iconStyle, marginRight: 0 }} />
+                      <AppNavIcon
+                        name="house"
+                        color="blue"
+                        style={{ ...iconStyle, marginRight: 0 }}
+                      />
                     )}
                     {!icon && 'Dashboard'}
                   </Link>,

--- a/apps/app/src/components/presentation.test.tsx
+++ b/apps/app/src/components/presentation.test.tsx
@@ -20,8 +20,8 @@ beforeEach(async () => {
       <img alt={alt ?? ''} {...props} />
     ),
   }))
-  mock.module('@nl/ui/base/icon', () => ({
-    Icon: ({ name }: { name: string }) => <span data-icon={name}>{name}</span>,
+  mock.module('@/components/AppNavIcon', () => ({
+    AppNavIcon: ({ name }: { name: string }) => <span data-icon={name}>{name}</span>,
   }))
   mock.module('@nl/ui/custom/external-icon', () => ({ ExternalIcon: () => <span>external</span> }))
   window.history.replaceState({}, '', '/')

--- a/apps/app/src/types/index.ts
+++ b/apps/app/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { IconName } from '@nl/ui/base/icon'
+import type { AppNavIconName } from '@/components/AppNavIcon'
 
 // Local MUI-compatible minimal types (MUI support dropped)
 export type Theme = {
@@ -30,7 +30,7 @@ export type NavItemTypeObject = { items: NavItemType[] }
 
 export type NavItemType = {
   id?: string
-  icon?: IconName
+  icon?: AppNavIconName
   target?: boolean
   external?: string
   url?: string | undefined

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -3,6 +3,16 @@ import { readFileSync } from 'node:fs'
 
 const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
 const appManifest = 'apps/app/package.json'
+const privateShellIconSources = [
+  'apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Header/index.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Header/NetworkWarning.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavGroup/index.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx',
+  'apps/app/src/app/_layout/_MainLayout/_Sidebar/_OnboardingCard/index.tsx',
+  'apps/app/src/components/extended/Breadcrumbs.tsx',
+]
 
 describe('app performance contracts', () => {
   it('uses native shallow copies for primitive responsive-table selection state', () => {
@@ -26,5 +36,16 @@ describe('app performance contracts', () => {
     const manifest = JSON.parse(readFileSync(appManifest, 'utf8'))
     expect(manifest.dependencies?.lodash).toBeUndefined()
     expect(manifest.devDependencies?.['@types/lodash']).toBeUndefined()
+  })
+
+  it('keeps the private shell off the shared icon registry', () => {
+    for (const file of privateShellIconSources) {
+      expect(readFileSync(file, 'utf8')).not.toContain("from '@nl/ui/base/icon'")
+    }
+
+    const appNavIconSource = readFileSync('apps/app/src/components/AppNavIcon.tsx', 'utf8')
+    expect(appNavIconSource).toContain("from 'lucide-react'")
+    expect(appNavIconSource).toContain("'layout-grid': LayoutGrid")
+    expect(appNavIconSource).toContain("'list-ordered': ListOrdered")
   })
 })


### PR DESCRIPTION
## Summary
- replace the private shell shared icon registry with direct Lucide imports
- add a small AppNavIcon adapter for dynamic menu and breadcrumb icons
- preserve theme colors, sizing, strokes, and decorative accessibility semantics

## Validation
- `bun run type-check` (apps/app)
- `bun run lint` (apps/app)
- App unit suite: 166 passing
- AppNavIcon regression test: 1 passing
- `bun test --isolate test/contract/app-performance.test.ts`
- `bun run build` (apps/app), 21 routes generated
- Prettier check

Targets staging as a focused performance milestone.