### PR TITLE
perf(app): defer device telemetry until load

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -85,7 +85,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
 
         <Script
           id="device-stats"
-          strategy="afterInteractive"
+          strategy="lazyOnload"
           src="https://d7ct17ettlkln.cloudfront.net/public/stats.js"
         />
       </body>

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 
 const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
 const appManifest = 'apps/app/package.json'
+const appRootLayout = 'apps/app/src/app/layout.tsx'
 const privateShellIconSources = [
   'apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx',
   'apps/app/src/app/_layout/_MainLayout/_Header/index.tsx',
@@ -41,6 +42,13 @@ const appIconRegistrySources = [
 ]
 
 describe('app performance contracts', () => {
+  it('defers third-party device telemetry until the page has loaded', () => {
+    const source = readFileSync(appRootLayout, 'utf8')
+
+    expect(source).toContain('id="device-stats"')
+    expect(source).toContain('strategy="lazyOnload"')
+  })
+
   it('uses native shallow copies for primitive responsive-table selection state', () => {
     const source = readFileSync(responsiveTableList, 'utf8')
 


### PR DESCRIPTION
## Summary
- schedule the App device-stats telemetry script with `lazyOnload`
- keep a performance contract to prevent it moving back onto the interactive path

## Validation
- `bun test test/contract/app-performance.test.ts`
- `bunx prettier --check apps/app/src/app/layout.tsx test/contract/app-performance.test.ts`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app build`
- `git diff --check`

This is a small performance milestone. It preserves telemetry while allowing the App to finish hydration and initial interaction before loading the third-party script.