### PR TITLE
perf(app): defer bridge form until dialog open

### DIFF
--- a/apps/app/src/components/dialog/BridgeButtonDialog/index.tsx
+++ b/apps/app/src/components/dialog/BridgeButtonDialog/index.tsx
@@ -1,12 +1,23 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { Button } from '@nl/ui/base/button'
 import { Dialog, DialogContent, DialogTrigger } from '@/components/dialog'
-import BridgeForm from './BridgeForm'
 import BridgeSuccess from './BridgeSuccess'
 
 type BridgeButtonDialogProps = { balance: number; loading: boolean }
+
+const BridgeFormLoading = () => (
+  <div className="py-8 text-center" role="status" aria-live="polite" aria-busy="true">
+    Loading bridge options
+  </div>
+)
+
+const BridgeForm = dynamic(() => import('./BridgeForm'), {
+  ssr: false,
+  loading: BridgeFormLoading,
+})
 
 const BridgeButtonDialog = ({ balance, loading }: BridgeButtonDialogProps) => {
   const [successDialogOpen, setSuccessDialogOpen] = useState(false)

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
 const appManifest = 'apps/app/package.json'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
+const bridgeDialog = 'apps/app/src/components/dialog/BridgeButtonDialog/index.tsx'
 const privateShellIconSources = [
   'apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx',
   'apps/app/src/app/_layout/_MainLayout/_Header/index.tsx',
@@ -47,6 +48,14 @@ describe('app performance contracts', () => {
 
     expect(source).toContain('id="device-stats"')
     expect(source).toContain('strategy="lazyOnload"')
+  })
+
+  it('loads the bridge form only after its dialog opens', () => {
+    const source = readFileSync(bridgeDialog, 'utf8')
+
+    expect(source).not.toContain("import BridgeForm from './BridgeForm'")
+    expect(source).toContain("dynamic(() => import('./BridgeForm')")
+    expect(source).toContain('Loading bridge options')
   })
 
   it('uses native shallow copies for primitive responsive-table selection state', () => {


### PR DESCRIPTION
## Summary
- remove the static bridge-form import from the Overview dialog
- load the Axelar-backed form only when the dialog is opened
- retain an accessible loading status and add a regression contract

## Validation
- `bun test test/contract/app-performance.test.ts`
- `bunx prettier --check apps/app/src/components/dialog/BridgeButtonDialog/index.tsx test/contract/app-performance.test.ts`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app test` (167 pass, 1,180 expects)
- `bun run --cwd apps/app build` (21 routes)
- `git diff --check`

The public and initial route bundles remain wallet-free; this milestone removes the bridge form from the Overview route's eager client graph while preserving the existing dialog behavior.