### PR TITLE
perf(smashers): defer auth providers until route load

### DIFF
--- a/apps/smashers/src/app/(auth_routes)/layout.tsx
+++ b/apps/smashers/src/app/(auth_routes)/layout.tsx
@@ -1,7 +1,6 @@
-import { type PropsWithChildren, Suspense } from 'react'
+import { type PropsWithChildren } from 'react'
 import { type Metadata } from 'next'
-import { AuthProvider } from '@/contexts/AuthProvider'
-import { FeatureFlagProvider } from '@/contexts/FeatureFlagsProvider'
+import AuthProvidersBoundary from '@/contexts/AuthProvidersBoundary'
 import { getServerSession } from '@nl/playfab/utils/auth'
 
 export const metadata: Metadata = {
@@ -13,14 +12,10 @@ export default async function AuthLayout({ children }: PropsWithChildren) {
   const session = await getServerSession()
 
   return (
-    <Suspense fallback={null}>
-      <FeatureFlagProvider>
-        <AuthProvider session={session}>
-          <main id="auth-layout" className="min-h-screen">
-            {children}
-          </main>
-        </AuthProvider>
-      </FeatureFlagProvider>
-    </Suspense>
+    <AuthProvidersBoundary session={session}>
+      <main id="auth-layout" className="min-h-screen">
+        {children}
+      </main>
+    </AuthProvidersBoundary>
   )
 }

--- a/apps/smashers/src/components/Header/index.tsx
+++ b/apps/smashers/src/components/Header/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Image from 'next/image'
 import ActionButtonsGroup from './ActionButtonsGroup'
 import Navbar from './Navbar'

--- a/apps/smashers/src/contexts/AuthProviders.tsx
+++ b/apps/smashers/src/contexts/AuthProviders.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+import type { Session } from 'next-auth'
+
+import { AuthProvider } from './AuthProvider'
+import { FeatureFlagProvider } from './FeatureFlagsProvider'
+
+type AuthProvidersProps = PropsWithChildren<{ session: Session | null }>
+
+export default function AuthProviders({ children, session }: AuthProvidersProps) {
+  return (
+    <FeatureFlagProvider>
+      <AuthProvider session={session}>{children}</AuthProvider>
+    </FeatureFlagProvider>
+  )
+}

--- a/apps/smashers/src/contexts/AuthProvidersBoundary.tsx
+++ b/apps/smashers/src/contexts/AuthProvidersBoundary.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { PropsWithChildren } from 'react'
+import type { Session } from 'next-auth'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+type AuthProvidersProps = PropsWithChildren<{ session: Session | null }>
+
+function AuthProvidersLoading(): React.ReactNode {
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Skeleton aria-hidden="true" className="h-[28rem] w-full max-w-[800px] rounded-xl" />
+      <span className="sr-only">Loading authentication</span>
+    </div>
+  )
+}
+
+const DeferredAuthProviders = dynamic(() => import('./AuthProviders'), {
+  ssr: false,
+  loading: AuthProvidersLoading,
+})
+
+export default function AuthProvidersBoundary({ children, session }: AuthProvidersProps) {
+  return <DeferredAuthProviders session={session}>{children}</DeferredAuthProviders>
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -382,11 +382,17 @@ describe('shared route loading contract', () => {
 describe('Smashers public shell contract', () => {
   it('keeps the homepage server-rendered except for the modal island', () => {
     const pageSource = readFileSync(join(process.cwd(), smashersHomePage), 'utf8')
+    const headerSource = readFileSync(
+      join(process.cwd(), 'apps/smashers/src/components/Header/index.tsx'),
+      'utf8'
+    )
     const actionButtonsSource = readFileSync(join(process.cwd(), smashersActionButtons), 'utf8')
 
     expect(pageSource).not.toContain('HomeInteractive')
     expect(pageSource).toContain("import Header, { type ActiveModal } from '@/components/Header'")
     expect(pageSource).toContain('<main>')
+    expect(headerSource).not.toContain("'use client'")
+    expect(headerSource).toContain("import ActionButtonsGroup from './ActionButtonsGroup'")
     expect(actionButtonsSource).toContain("'use client'")
     expect(actionButtonsSource).not.toContain("from 'next/dynamic'")
     expect(actionButtonsSource).toContain("import('@/components/PlayDialog')")
@@ -395,12 +401,39 @@ describe('Smashers public shell contract', () => {
     expect(actionButtonsSource).toContain('aria-busy={isLoading}')
   })
 
+  it('defers Smashers auth providers behind the auth loading boundary', () => {
+    const layoutSource = readFileSync(join(process.cwd(), smashersAuthLayout), 'utf8')
+    const boundarySource = readFileSync(
+      join(process.cwd(), 'apps/smashers/src/contexts/AuthProvidersBoundary.tsx'),
+      'utf8'
+    )
+    const providersSource = readFileSync(
+      join(process.cwd(), 'apps/smashers/src/contexts/AuthProviders.tsx'),
+      'utf8'
+    )
+
+    expect(layoutSource).toContain("from '@/contexts/AuthProvidersBoundary'")
+    expect(layoutSource).not.toContain("from '@/contexts/AuthProvider'")
+    expect(layoutSource).not.toContain("from '@/contexts/FeatureFlagsProvider'")
+    expect(boundarySource).toContain("dynamic(() => import('./AuthProviders')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain("from '@nl/ui/base/skeleton'")
+    expect(boundarySource).toContain('role="status"')
+    expect(boundarySource).toContain('aria-live="polite"')
+    expect(boundarySource).toContain('aria-busy="true"')
+    expect(providersSource).toContain("from './AuthProvider'")
+    expect(providersSource).toContain("from './FeatureFlagsProvider'")
+  })
+
   it('keeps feature flags scoped to authenticated routes', () => {
     const rootLayoutSource = readFileSync(join(process.cwd(), smashersRootLayout), 'utf8')
-    const authLayoutSource = readFileSync(join(process.cwd(), smashersAuthLayout), 'utf8')
+    const authProvidersSource = readFileSync(
+      join(process.cwd(), 'apps/smashers/src/contexts/AuthProviders.tsx'),
+      'utf8'
+    )
 
     expect(rootLayoutSource).not.toContain('FeatureFlagProvider')
-    expect(authLayoutSource).toContain('FeatureFlagProvider')
+    expect(authProvidersSource).toContain('FeatureFlagProvider')
     expect(existsSync(join(process.cwd(), staleSmashersUnityDialog))).toBe(false)
   })
 


### PR DESCRIPTION
## Summary
- keep the Smashers marketing header server-rendered and isolate the modal actions island
- defer the authenticated-route provider graph behind an accessible shadcn Skeleton boundary
- preserve feature-flag scope and add route-surface contracts

## Measured impact
- Smashers `/profile`: 608,198 B -> 538,146 B first-load uncompressed JS (-70,052 B)
- Smashers `/login`: 608,133 B -> 538,081 B first-load uncompressed JS (-70,052 B)

## Local validation
- `bun test test/contract/route-surface.test.ts`
- `bun run --cwd apps/smashers test`
- `bun run --cwd apps/smashers type-check`
- `bun run --cwd apps/smashers lint` (existing NEXT_PHASE warning only)
- `bun run --cwd apps/smashers build`
- Prettier check and `git diff --check`

Ready to move through the lightweight ready-PR gate after local validation.