### PR TITLE
perf(app): defer verification wallet graph

### DIFF
--- a/apps/app/src/app/verification/VerificationClient.tsx
+++ b/apps/app/src/app/verification/VerificationClient.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+import type { Nonce, UUID_Token } from '@/types/auth'
+import useAuth from '@/hooks/useAuth'
+import useSignAuthMsg from '@/hooks/useSignAuthMsg'
+
+export default function VerificationClient(): React.ReactNode {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token') as UUID_Token | undefined
+  const nonce = searchParams.get('nonce') as Nonce | undefined
+  const { signMessage, isError, isSuccess } = useSignAuthMsg({ token, nonce })
+  const { isConnected, handleConnectWallet } = useAuth()
+  const [msgSent, setMsgSent] = useState(false)
+
+  useEffect(() => {
+    const signMsg = async () => {
+      if (!isConnected) handleConnectWallet()
+      if (isConnected && nonce && token) {
+        signMessage()
+        setMsgSent(true)
+      }
+    }
+
+    if (!msgSent) void signMsg()
+  }, [handleConnectWallet, isConnected, msgSent, nonce, signMessage, token])
+
+  return (
+    <main className="container p-10 text-center" role="status" aria-live="polite">
+      {isError || isSuccess ? (
+        <>
+          {isError && 'Error signing message'}
+          {isSuccess &&
+            'Successfully verified account! Please return to the Nifty League desktop app'}
+        </>
+      ) : (
+        <>
+          {isConnected
+            ? 'Please sign message to verify address ownership'
+            : 'Please connect your wallet'}
+        </>
+      )}
+    </main>
+  )
+}

--- a/apps/app/src/app/verification/VerificationRouteBoundary.tsx
+++ b/apps/app/src/app/verification/VerificationRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const VerificationClient = dynamic(() => import('./VerificationClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading wallet verification" />,
+})
+
+export default function VerificationRouteBoundary() {
+  return <VerificationClient />
+}

--- a/apps/app/src/app/verification/page.tsx
+++ b/apps/app/src/app/verification/page.tsx
@@ -1,48 +1,5 @@
-'use client'
+import VerificationRouteBoundary from './VerificationRouteBoundary'
 
-import { useEffect, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
-import useSignAuthMsg from '@/hooks/useSignAuthMsg'
-import useAuth from '@/hooks/useAuth'
-import type { UUID_Token, Nonce } from '@/types/auth'
-
-const GameVerification = (): React.ReactNode => {
-  const searchParams = useSearchParams()
-  const token = searchParams.get('token') as UUID_Token | undefined
-  const nonce = searchParams.get('nonce') as Nonce | undefined
-  const { signMessage, isError, isSuccess } = useSignAuthMsg({ token, nonce })
-  const { isConnected, handleConnectWallet } = useAuth()
-  const [msgSent, setMsgSent] = useState(false)
-
-  useEffect(() => {
-    const signMsg = async () => {
-      if (!isConnected) handleConnectWallet()
-      if (isConnected && nonce && token) {
-        signMessage()
-        setMsgSent(true)
-      }
-    }
-    // eslint-disable-next-line no-void
-    if (!msgSent) void signMsg()
-  }, [handleConnectWallet, isConnected, msgSent, nonce, signMessage, token])
-
-  return (
-    <main className="container p-10 text-center" role="status" aria-live="polite">
-      {isError || isSuccess ? (
-        <>
-          {isError && 'Error signing message'}
-          {isSuccess &&
-            'Successfully verified account! Please return to the Nifty League desktop app'}
-        </>
-      ) : (
-        <>
-          {isConnected
-            ? 'Please sign message to verify address ownership'
-            : 'Please connect your wallet'}
-        </>
-      )}
-    </main>
-  )
+export default function VerificationPage() {
+  return <VerificationRouteBoundary />
 }
-
-export default GameVerification

--- a/apps/app/src/contexts/WalletAuthContextWrapper.tsx
+++ b/apps/app/src/contexts/WalletAuthContextWrapper.tsx
@@ -3,10 +3,7 @@
 import type { PropsWithChildren } from 'react'
 import { headers } from 'next/headers'
 
-import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
-import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletAuthProvidersBoundary from '@/contexts/WalletAuthProvidersBoundary'
 
 /**
  * The smallest wallet boundary for routes that only authenticate a wallet.
@@ -17,13 +14,5 @@ import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 export default async function WalletAuthContextWrapper({ children }: PropsWithChildren) {
   const cookies = (await headers()).get('cookie')
 
-  return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>
-        <AuthStatusProvider>
-          <AuthTokenProvider>{children}</AuthTokenProvider>
-        </AuthStatusProvider>
-      </Web3ModalProvider>
-    </LocalStorageProvider>
-  )
+  return <WalletAuthProvidersBoundary cookies={cookies}>{children}</WalletAuthProvidersBoundary>
 }

--- a/apps/app/src/contexts/WalletAuthProviders.tsx
+++ b/apps/app/src/contexts/WalletAuthProviders.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+
+import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+type WalletAuthProvidersProps = PropsWithChildren<{ cookies?: string | null }>
+
+export default function WalletAuthProviders({ children, cookies }: WalletAuthProvidersProps) {
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>
+        <AuthStatusProvider>
+          <AuthTokenProvider>{children}</AuthTokenProvider>
+        </AuthStatusProvider>
+      </Web3ModalProvider>
+    </LocalStorageProvider>
+  )
+}

--- a/apps/app/src/contexts/WalletAuthProvidersBoundary.tsx
+++ b/apps/app/src/contexts/WalletAuthProvidersBoundary.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { PropsWithChildren } from 'react'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+type WalletAuthProvidersProps = PropsWithChildren<{ cookies?: string | null }>
+
+const DeferredWalletAuthProviders = dynamic(() => import('./WalletAuthProviders'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading wallet verification" />,
+})
+
+export default function WalletAuthProvidersBoundary({
+  children,
+  cookies,
+}: WalletAuthProvidersProps) {
+  return <DeferredWalletAuthProviders cookies={cookies}>{children}</DeferredWalletAuthProviders>
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -99,7 +99,7 @@ const nftOnlyRouteLayouts = ['apps/app/src/app/(public-routes)/mint-o-matic/layo
 const publicRoutesLayout = 'apps/app/src/app/(public-routes)/layout.tsx'
 const stalePublicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.tsx'
 const walletStorageBoundaries = [
-  'apps/app/src/contexts/WalletAuthContextWrapper.tsx',
+  'apps/app/src/contexts/WalletAuthProviders.tsx',
   'apps/app/src/contexts/WalletFeatureProviders.tsx',
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
@@ -269,6 +269,11 @@ const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
 const smashersBackButton = 'apps/smashers/src/components/Header/BackButton/index.tsx'
 const verificationPage = 'apps/app/src/app/verification/page.tsx'
 const verificationLayout = 'apps/app/src/app/verification/layout.tsx'
+const verificationClient = 'apps/app/src/app/verification/VerificationClient.tsx'
+const verificationRouteBoundary = 'apps/app/src/app/verification/VerificationRouteBoundary.tsx'
+const walletAuthContextWrapper = 'apps/app/src/contexts/WalletAuthContextWrapper.tsx'
+const walletAuthProviders = 'apps/app/src/contexts/WalletAuthProviders.tsx'
+const walletAuthProvidersBoundary = 'apps/app/src/contexts/WalletAuthProvidersBoundary.tsx'
 
 describe('external route surface contract', () => {
   for (const [app, files] of Object.entries(appRouteContracts)) {
@@ -765,6 +770,33 @@ describe('verification route shell contract', () => {
     expect(
       existsSync(join(process.cwd(), 'apps/app/src/app/(public-routes)/verification/page.tsx'))
     ).toBe(false)
+  })
+
+  it('defers wallet providers and verification interactions until after the initial shell', () => {
+    const pageSource = readFileSync(join(process.cwd(), verificationPage), 'utf8')
+    const routeBoundarySource = readFileSync(join(process.cwd(), verificationRouteBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), verificationClient), 'utf8')
+    const wrapperSource = readFileSync(join(process.cwd(), walletAuthContextWrapper), 'utf8')
+    const providersSource = readFileSync(join(process.cwd(), walletAuthProviders), 'utf8')
+    const providersBoundarySource = readFileSync(
+      join(process.cwd(), walletAuthProvidersBoundary),
+      'utf8'
+    )
+
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './VerificationRouteBoundary'")
+    expect(routeBoundarySource).toContain("import('./VerificationClient')")
+    expect(routeBoundarySource).toContain('ssr: false')
+    expect(routeBoundarySource).toContain("from '@nl/ui/custom/route-loading'")
+    expect(clientSource).toContain('useSearchParams')
+    expect(clientSource).toContain('useSignAuthMsg')
+    expect(wrapperSource).toContain("from '@/contexts/WalletAuthProvidersBoundary'")
+    expect(wrapperSource).not.toContain("from '@/contexts/Web3ModalContext'")
+    expect(providersBoundarySource).toContain("import('./WalletAuthProviders')")
+    expect(providersBoundarySource).toContain('ssr: false')
+    expect(providersBoundarySource).toContain("from '@nl/ui/custom/route-loading'")
+    expect(providersSource).toContain("from '@/contexts/Web3ModalContext'")
+    expect(providersSource).toContain("from '@/contexts/AuthTokenContext'")
   })
 })
 


### PR DESCRIPTION
## Summary
- keep the verification route shell server-rendered
- defer wallet providers and signing interactions behind accessible shared route loading
- preserve cookie hydration and wallet verification behavior

## Measured impact
- App `/verification`: 622,013 B -> 529,883 B first-load uncompressed JavaScript
- Reduction: 92,130 B
- Other App route bundle sizes unchanged

## Local validation
- `bun test test/contract/route-surface.test.ts` — 178 passed
- `bun run --cwd apps/app test` — 167 passed
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app build`
- Prettier check and `git diff --check`

Draft until local validation is complete; ready promotion is intentional.