### PR TITLE
chore(ci): gate Vercel builds on release branches and harden staging realignment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Keep pull requests focused and reviewable. Include screenshots or recordings for
 
 The single validation caller keys concurrency by event and pull-request head. A newer update to the same pull request cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
 
-Draft feature work is intentionally cost-aware: local validation is the feedback loop while a pull request is draft. Marking the pull request ready for review starts hosted validation. Vercel projects disable Git-triggered deployments on feature branches through the versioned `git.deploymentEnabled` policy in `apps/*/vercel.json` and continue on `staging` and `main`; manual deployments remain available.
+Draft feature work is intentionally cost-aware: local validation is the feedback loop while a pull request is draft. Marking the pull request ready for review starts hosted validation. Vercel projects disable Git-triggered deployments and ignore builds for every feature branch through the versioned `git.deploymentEnabled` and `ignoreCommand` policies in `apps/*/vercel.json`; Vercel builds run on `staging` and `main`, while manual deployments remain available.
 If a ready pull request is returned to draft, its in-flight hosted validation is cancelled and no replacement validation starts until it is ready again.
 
 Required checks are enforced by branch protection rulesets/branch protection. Do not duplicate their checklists in the pull request description; document validation commands and results instead.

--- a/.github/workflows/re-align-staging.yml
+++ b/.github/workflows/re-align-staging.yml
@@ -45,6 +45,9 @@ jobs:
             # A divergent tree is not necessarily drift: staging may contain
             # legitimate forward work. Preview the exact merge policy used by
             # the PR and compare its resulting tree with staging instead.
+            # When both branches changed a path after their merge base,
+            # staging is authoritative so reconciliation cannot regress a
+            # validated forward change through a clean, non-conflicting merge.
             # Use an isolated worktree so the preview applies the exact same
             # conflict policy as PR creation, including modify/delete paths.
             preview_dir=$(mktemp -d)
@@ -54,6 +57,7 @@ jobs:
             }
             trap cleanup_preview EXIT
             git worktree add --detach "$preview_dir" origin/staging >/dev/null
+            staging_head=$(git -C "$preview_dir" rev-parse HEAD)
             git -C "$preview_dir" config user.name "re-align-preview"
             git -C "$preview_dir" config user.email "re-align-preview@users.noreply.github.com"
 
@@ -83,6 +87,23 @@ jobs:
                 echo "failing closed for review."
                 exit 1
               fi
+            fi
+
+            # The recursive merge strategy only applies -X ours to conflicts.
+            # Restore every path changed by staging since the merge base so a
+            # clean main-side edit cannot overwrite staging's forward work.
+            merge_base=$(git -C "$preview_dir" merge-base "$staging_head" origin/main)
+            while IFS= read -r -d '' changed_path; do
+              if git -C "$preview_dir" cat-file -e "$staging_head:$changed_path" 2>/dev/null; then
+                git -C "$preview_dir" restore --source="$staging_head" --staged --worktree -- "$changed_path"
+              else
+                git -C "$preview_dir" rm --ignore-unmatch -- "$changed_path"
+              fi
+            done < <(git -C "$preview_dir" diff --no-renames --name-only -z "$merge_base" "$staging_head")
+
+            if [ -n "$(git -C "$preview_dir" diff --name-only --diff-filter=U)" ]; then
+              echo "Unable to preserve the staging-first merge policy safely;"
+              exit 1
             fi
 
             MERGED_TREE=$(git -C "$preview_dir" write-tree)
@@ -136,6 +157,7 @@ jobs:
           BOT_EMAIL+="@users.noreply.github.com"
           git config user.email "$BOT_EMAIL"
           git checkout -b "$BRANCH" origin/staging
+          staging_head=$(git rev-parse HEAD)
 
           resolve_ours_conflicts() {
             local conflicted_path
@@ -171,6 +193,28 @@ jobs:
               exit 1
             fi
             git commit --no-edit
+          fi
+
+          # Keep staging authoritative for every path it changed after the
+          # merge base, not only paths Git classified as conflicts. Main-only
+          # changes still flow into the reconciliation commit.
+          merge_base=$(git merge-base "$staging_head" origin/main)
+          while IFS= read -r -d '' changed_path; do
+            if git cat-file -e "$staging_head:$changed_path" 2>/dev/null; then
+              git restore --source="$staging_head" --staged --worktree -- "$changed_path"
+            else
+              git rm --ignore-unmatch -- "$changed_path"
+            fi
+          done < <(git diff --no-renames --name-only -z "$merge_base" "$staging_head")
+
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "Unable to preserve the staging-first merge policy safely;"
+            git merge --abort 2>/dev/null || true
+            exit 1
+          fi
+
+          if ! git diff --cached --quiet; then
+            git commit --amend --no-edit
           fi
           git push -u origin "$BRANCH"
 

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -7,6 +7,7 @@
       "staging": true
     }
   },
+  "ignoreCommand": "node ../../scripts/vercel-ignore-build.mjs",
   "buildCommand": "bun --filter api build",
   "functions": {
     "api/index.js": {

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -6,5 +6,6 @@
       "main": true,
       "staging": true
     }
-  }
+  },
+  "ignoreCommand": "node ../../scripts/vercel-ignore-build.mjs"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -6,5 +6,6 @@
       "main": true,
       "staging": true
     }
-  }
+  },
+  "ignoreCommand": "node ../../scripts/vercel-ignore-build.mjs"
 }

--- a/apps/smashers/vercel.json
+++ b/apps/smashers/vercel.json
@@ -6,5 +6,6 @@
       "main": true,
       "staging": true
     }
-  }
+  },
+  "ignoreCommand": "node ../../scripts/vercel-ignore-build.mjs"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -6,5 +6,6 @@
       "main": true,
       "staging": true
     }
-  }
+  },
+  "ignoreCommand": "node ../../scripts/vercel-ignore-build.mjs"
 }

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const BUILD_BRANCHES = new Set(['main', 'staging'])
+
+export const shouldBuild = (branch = process.env.VERCEL_GIT_COMMIT_REF) =>
+  !branch || BUILD_BRANCHES.has(branch)
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  const branch = process.env.VERCEL_GIT_COMMIT_REF
+  const build = shouldBuild(branch)
+
+  console.log(
+    build
+      ? `Vercel build enabled for ${branch || 'manual deployment'}.`
+      : `Vercel build skipped for feature branch ${branch}.`
+  )
+  process.exit(build ? 1 : 0)
+}

--- a/test/contract/vercel-build-policy.test.ts
+++ b/test/contract/vercel-build-policy.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { shouldBuild } from '../../scripts/vercel-ignore-build.mjs'
 
 const projectRoots = ['apps/web', 'apps/app', 'apps/smashers', 'apps/api', 'apps/docs']
 const deploymentEnabled = { '**': false, main: true, staging: true }
+const ignoreCommand = 'node ../../scripts/vercel-ignore-build.mjs'
 
 describe('Vercel build cost policy', () => {
   for (const projectRoot of projectRoots) {
@@ -15,11 +17,19 @@ describe('Vercel build cost policy', () => {
       }
 
       expect(config.git?.deploymentEnabled).toEqual(deploymentEnabled)
-      expect(config.ignoreCommand).toBeUndefined()
+      expect(config.ignoreCommand).toBe(ignoreCommand)
     })
   }
 
   it('keeps every Vercel-connected app on the shared policy', () => {
     expect(projectRoots).toHaveLength(5)
+  })
+
+  it('builds release branches and manual deployments only', () => {
+    expect(shouldBuild('main')).toBe(true)
+    expect(shouldBuild('staging')).toBe(true)
+    expect(shouldBuild('codex/perf-route')).toBe(false)
+    expect(shouldBuild('feat/large-change')).toBe(false)
+    expect(shouldBuild(undefined)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Add Vercel \`ignoreCommand\` policy to skip builds on feature branches, reducing CI cost
- Add shared \`scripts/vercel-ignore-build.mjs\` allowlist script (\`main\` + \`staging\`)
- Extend \`vercel-build-policy\` contract test with branch allowlist assertions
- Update \`CONTRIBUTING.md\` to document the cost-aware deployment policy
- Harden \`re-align-staging.yml\` so staging remains authoritative for every path changed after the merge base, not only conflicts

## Test plan
- \`bun test test/contract/vercel-build-policy.test.ts\` passes locally
- \`bun run lint\` passes
- Existing \`re-align-staging\` workflow preview logic still produces identical trees when main and staging are already aligned

## Risk assessment
**LOW.** Changes are scoped to CI configuration, Vercel project settings, and contract tests. No application code or runtime behavior is modified.