### PR TITLE
fix(ci): avoid re-alignment worktree lock races

### DIFF
--- a/.github/workflows/re-align-staging.yml
+++ b/.github/workflows/re-align-staging.yml
@@ -93,13 +93,17 @@ jobs:
             # Restore every path changed by staging since the merge base so a
             # clean main-side edit cannot overwrite staging's forward work.
             merge_base=$(git -C "$preview_dir" merge-base "$staging_head" origin/main)
+            changed_paths_file=$(mktemp)
+            git -C "$preview_dir" diff --no-renames --name-only -z \
+              "$merge_base" "$staging_head" > "$changed_paths_file"
             while IFS= read -r -d '' changed_path; do
               if git -C "$preview_dir" cat-file -e "$staging_head:$changed_path" 2>/dev/null; then
                 git -C "$preview_dir" restore --source="$staging_head" --staged --worktree -- "$changed_path"
               else
                 git -C "$preview_dir" rm --ignore-unmatch -- "$changed_path"
               fi
-            done < <(git -C "$preview_dir" diff --no-renames --name-only -z "$merge_base" "$staging_head")
+            done < "$changed_paths_file"
+            rm -f "$changed_paths_file"
 
             if [ -n "$(git -C "$preview_dir" diff --name-only --diff-filter=U)" ]; then
               echo "Unable to preserve the staging-first merge policy safely;"
@@ -199,13 +203,17 @@ jobs:
           # merge base, not only paths Git classified as conflicts. Main-only
           # changes still flow into the reconciliation commit.
           merge_base=$(git merge-base "$staging_head" origin/main)
+          changed_paths_file=$(mktemp)
+          git diff --no-renames --name-only -z \
+            "$merge_base" "$staging_head" > "$changed_paths_file"
           while IFS= read -r -d '' changed_path; do
             if git cat-file -e "$staging_head:$changed_path" 2>/dev/null; then
               git restore --source="$staging_head" --staged --worktree -- "$changed_path"
             else
               git rm --ignore-unmatch -- "$changed_path"
             fi
-          done < <(git diff --no-renames --name-only -z "$merge_base" "$staging_head")
+          done < "$changed_paths_file"
+          rm -f "$changed_paths_file"
 
           if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
             echo "Unable to preserve the staging-first merge policy safely;"

--- a/test/contract/ci-cost-policy.test.ts
+++ b/test/contract/ci-cost-policy.test.ts
@@ -25,4 +25,18 @@ describe('hosted validation cost policy', () => {
     expect(source).toContain('github.event.pull_request.draft != true')
     expect(source).toContain('startsWith(github.event.pull_request.head.ref')
   })
+
+  it('materializes re-alignment paths before mutating the worktree index', () => {
+    const source = readWorkflow('re-align-staging.yml')
+
+    expect(source).toContain('changed_paths_file=$(mktemp)')
+    expect(source).toContain('> "$changed_paths_file"')
+    expect(source).toContain('done < "$changed_paths_file"')
+    expect(source).not.toContain(
+      'done < <(git -C "$preview_dir" diff --no-renames --name-only -z "$merge_base" "$staging_head")'
+    )
+    expect(source).not.toContain(
+      'done < <(git diff --no-renames --name-only -z "$merge_base" "$staging_head")'
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- materialize the staging-changed path list before restoring paths in the re-alignment preview and PR worktree
- prevent concurrent `git diff` index refresh and `git restore`/`git rm` mutations from racing on `index.lock`
- add a contract regression test for the safe sequencing

## Validation
- `actionlint .github/workflows/re-align-staging.yml .github/workflows/validation.yml .github/workflows/opencode-security.yml`
- Prettier checks for changed workflow and test files
- `bun test test/contract/ci-cost-policy.test.ts test/contract/vercel-build-policy.test.ts` (10 passed)
- live staging-first merge simulation already passed on the preceding policy revision

This is a follow-up to PR #583 and addresses the runner-only lock race observed during its first live re-alignment run.