### PR TITLE
fix(ci): serialize re-alignment conflict resolution

### DIFF
--- a/.github/workflows/re-align-staging.yml
+++ b/.github/workflows/re-align-staging.yml
@@ -63,6 +63,9 @@ jobs:
 
             resolve_ours_conflicts() {
               local conflicted_path
+              local conflicts_file
+              conflicts_file=$(mktemp)
+              git -C "$preview_dir" diff --name-only --diff-filter=U -z > "$conflicts_file"
               while IFS= read -r -d '' conflicted_path; do
                 if git -C "$preview_dir" cat-file -e "HEAD:$conflicted_path" 2>/dev/null; then
                   git -C "$preview_dir" checkout --ours -- "$conflicted_path"
@@ -70,7 +73,8 @@ jobs:
                 else
                   git -C "$preview_dir" rm -- "$conflicted_path"
                 fi
-              done < <(git -C "$preview_dir" diff --name-only --diff-filter=U -z)
+              done < "$conflicts_file"
+              rm -f "$conflicts_file"
             }
 
             if ! git -C "$preview_dir" merge --no-commit --no-ff -X ours \
@@ -165,6 +169,9 @@ jobs:
 
           resolve_ours_conflicts() {
             local conflicted_path
+            local conflicts_file
+            conflicts_file=$(mktemp)
+            git diff --name-only --diff-filter=U -z > "$conflicts_file"
             while IFS= read -r -d '' conflicted_path; do
               if git cat-file -e "HEAD:$conflicted_path" 2>/dev/null; then
                 git checkout --ours -- "$conflicted_path"
@@ -174,7 +181,8 @@ jobs:
                 # authoritative result and must be recorded explicitly.
                 git rm -- "$conflicted_path"
               fi
-            done < <(git diff --name-only --diff-filter=U -z)
+            done < "$conflicts_file"
+            rm -f "$conflicts_file"
           }
 
           # Merge main into staging. Conflicts keep staging's version (-X ours),

--- a/test/contract/ci-cost-policy.test.ts
+++ b/test/contract/ci-cost-policy.test.ts
@@ -38,5 +38,9 @@ describe('hosted validation cost policy', () => {
     expect(source).not.toContain(
       'done < <(git diff --no-renames --name-only -z "$merge_base" "$staging_head")'
     )
+    expect(source).not.toContain(
+      'done < <(git -C "$preview_dir" diff --name-only --diff-filter=U -z)'
+    )
+    expect(source).not.toContain('done < <(git diff --name-only --diff-filter=U -z)')
   })
 })


### PR DESCRIPTION
## Summary
- materialize conflict paths before resolving them in both re-alignment worktrees
- remove the remaining `git diff` process substitutions that can race with index mutations
- extend the CI cost-policy contract to guard both conflict and staging-path loops

## Validation
- `actionlint .github/workflows/re-align-staging.yml .github/workflows/validation.yml .github/workflows/opencode-security.yml`
- Prettier checks pass
- `bun test test/contract/ci-cost-policy.test.ts test/contract/vercel-build-policy.test.ts` (10 passed)

Follow-up to PR #584; the live workflow showed the remaining runner-only `index.lock` race in conflict resolution.