### PR TITLE
perf(app): defer dashboard overview client graph

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewClient.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
+
+const loadMyComics = () => import('./MyComics')
+const loadMyItems = () => import('./MyItems')
+const loadMyDegens = () => import('./MyDegens')
+const loadMyNFTL = () => import('./_MyNFTL')
+const loadMyStats = () => import('./MyStats')
+
+const DashboardOverviewContent = (): React.ReactNode => {
+  return (
+    <div className="flex h-inherit flex-col gap-8 lg:flex-row">
+      <div className="flex w-full flex-col gap-8 lg:w-[45.8333%]">
+        <div className="w-full">
+          <DeferredDashboardSection label="My Tokens" load={loadMyNFTL} />
+        </div>
+        <div className="w-full">
+          <DeferredDashboardSection label="My Stats" load={loadMyStats} />
+        </div>
+      </div>
+      <div className="flex w-full flex-col gap-8 lg:w-[54.1667%]">
+        <div className="w-full">
+          <DeferredDashboardSection label="My DEGENs" load={loadMyDegens} />
+        </div>
+        <div className="w-full">
+          <DeferredDashboardSection label="My Comics" load={loadMyComics} />
+        </div>
+        <div className="w-full">
+          <DeferredDashboardSection label="My Items" load={loadMyItems} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const DashboardOverview = (): React.ReactNode => (
+  <DashboardDataBoundary>
+    <DashboardOverviewContent />
+  </DashboardDataBoundary>
+)
+
+export default DashboardOverview

--- a/apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const DashboardOverviewClient = dynamic(() => import('./DashboardOverviewClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading dashboard overview" />,
+})
+
+export default function DashboardOverviewRouteBoundary(): React.ReactNode {
+  return <DashboardOverviewClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/page.tsx
@@ -1,44 +1,5 @@
-'use client'
+import DashboardOverviewRouteBoundary from './DashboardOverviewRouteBoundary'
 
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-import DeferredDashboardSection from '@/components/providers/DeferredDashboardSection'
-
-const loadMyComics = () => import('./MyComics')
-const loadMyItems = () => import('./MyItems')
-const loadMyDegens = () => import('./MyDegens')
-const loadMyNFTL = () => import('./_MyNFTL')
-const loadMyStats = () => import('./MyStats')
-
-const DashboardOverviewContent = (): React.ReactNode => {
-  return (
-    <div className="flex h-inherit flex-col gap-8 lg:flex-row">
-      <div className="flex w-full flex-col gap-8 lg:w-[45.8333%]">
-        <div className="w-full">
-          <DeferredDashboardSection label="My Tokens" load={loadMyNFTL} />
-        </div>
-        <div className="w-full">
-          <DeferredDashboardSection label="My Stats" load={loadMyStats} />
-        </div>
-      </div>
-      <div className="flex w-full flex-col gap-8 lg:w-[54.1667%]">
-        <div className="w-full">
-          <DeferredDashboardSection label="My DEGENs" load={loadMyDegens} />
-        </div>
-        <div className="w-full">
-          <DeferredDashboardSection label="My Comics" load={loadMyComics} />
-        </div>
-        <div className="w-full">
-          <DeferredDashboardSection label="My Items" load={loadMyItems} />
-        </div>
-      </div>
-    </div>
-  )
+export default function DashboardOverviewPage(): React.ReactNode {
+  return <DashboardOverviewRouteBoundary />
 }
-
-const DashboardOverview = (): React.ReactNode => (
-  <DashboardDataBoundary>
-    <DashboardOverviewContent />
-  </DashboardDataBoundary>
-)
-
-export default DashboardOverview

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -104,6 +104,10 @@ const walletStorageBoundaries = [
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
 const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
+const dashboardOverviewBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewRouteBoundary.tsx'
+const dashboardOverviewClient =
+  'apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewClient.tsx'
 const dashboardDegens = 'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx'
 const dashboardDegensContent =
   'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx'
@@ -848,7 +852,6 @@ describe('private provider loading contract', () => {
     expect(source).toContain("from '@/contexts/TokensBalanceContext'")
 
     for (const file of [
-      'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx',
       'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
       'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx',
       'apps/app/src/app/(private-routes)/dashboard/items/page.tsx',
@@ -856,6 +859,9 @@ describe('private provider loading contract', () => {
     ]) {
       expect(readFileSync(join(process.cwd(), file), 'utf8')).toContain('DashboardDataBoundary')
     }
+    expect(readFileSync(join(process.cwd(), dashboardOverviewClient), 'utf8')).toContain(
+      'DashboardDataBoundary'
+    )
 
     expect(
       readFileSync(
@@ -951,13 +957,20 @@ describe('shared value equality contract', () => {
 })
 
 describe('dashboard overview loading contract', () => {
-  it('defers dashboard sections behind the shared loading boundary', () => {
-    const source = readFileSync(join(process.cwd(), dashboardOverview), 'utf8')
+  it('defers the overview client graph behind the shared route loading boundary', () => {
+    const pageSource = readFileSync(join(process.cwd(), dashboardOverview), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), dashboardOverviewBoundary), 'utf8')
+    const source = readFileSync(join(process.cwd(), dashboardOverviewClient), 'utf8')
     const nftlSource = readFileSync(
       join(process.cwd(), 'apps/app/src/app/(private-routes)/dashboard/overview/_MyNFTL/index.tsx'),
       'utf8'
     )
 
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './DashboardOverviewRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./DashboardOverviewClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading dashboard overview" />')
     expect(source).toContain('import DeferredDashboardSection')
     expect(source).toContain("const loadMyComics = () => import('./MyComics')")
     expect(source).toContain("const loadMyItems = () => import('./MyItems')")


### PR DESCRIPTION
## What changed

- Split the dashboard overview into a server route entry, an accessible themed route loading boundary, and the existing client content.
- Kept the dashboard data boundary and all five deferred overview sections unchanged inside the client graph.
- Added route-surface contracts for the server/client split and loading behavior.

## Why

The overview route was marked as a client entry, which pulled its client graph into the initial dashboard load even though the page already deferred its data-heavy sections. Deferring the route graph reduces the JavaScript needed before the dashboard can begin loading.

## Measured impact

The production app build reduced uncompressed first-load JavaScript for /dashboard and /dashboard/overview from 615,431 bytes to 603,964 bytes: 11,467 bytes (~1.9%). Other dashboard route first-load sizes were unchanged.

## Validation

- bun --filter app build
- bun --filter app test — 167 pass
- bun test test/contract/route-surface.test.ts — 178 pass
- bun --filter app lint
- Prettier check on changed files

Hosted CI and Vercel remain skipped while this PR is draft under the repository cost-control policy.
