### PR TITLE
perf(web): defer GLTF viewer client graph

### DIFF
--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx
@@ -15,7 +15,7 @@ const TokenMenu = dynamic(() => import('./TokenMenu'), { ssr: false })
 const ModelView = dynamic(() => import('./ModelView'), { ssr: false })
 const ModelActions = dynamic(() => import('./ModelActions'), { ssr: false })
 
-interface DegenViewsProps {
+export interface DegenViewsProps {
   tokenId: string
   initialImage: ReactNode
   spriteImage: ReactNode

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViewsRouteBoundary.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViewsRouteBoundary.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+import type { DegenViewsProps } from './DegenViews'
+
+const DegenViewsClient = dynamic(() => import('./DegenViews'), {
+  loading: () => <RouteLoading label="Loading DEGEN viewer" />,
+})
+
+export default function DegenViewsRouteBoundary(props: DegenViewsProps): React.ReactNode {
+  return <DegenViewsClient {...props} />
+}

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 import { DEGEN_BASE_SPRITE_URL, LEGGIES } from '@/constants/degens'
 
-import DegenViews from './components/DegenViews'
+import DegenViewsRouteBoundary from './components/DegenViewsRouteBoundary'
 import styles from './gltf.module.css'
 
 interface DegenViewsPageProps {
@@ -15,7 +15,7 @@ export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
   const spriteSrc = `${DEGEN_BASE_SPRITE_URL}/${tokenId}.gif`
 
   return (
-    <DegenViews
+    <DegenViewsRouteBoundary
       tokenId={tokenId}
       initialImage={
         <Image

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -209,6 +209,8 @@ const webHomePage = 'apps/web/src/app/(main)/page.tsx'
 const webOverviewPage = 'apps/web/src/app/(main)/overview/page.tsx'
 const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
 const gltfClient = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
+const gltfRouteBoundary =
+  'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViewsRouteBoundary.tsx'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
@@ -338,11 +340,15 @@ describe('GLTF viewer loading contract', () => {
   it('keeps the initial NFT shell server-rendered and browser controls isolated', () => {
     const pageSource = readFileSync(join(process.cwd(), gltfPage), 'utf8')
     const clientSource = readFileSync(join(process.cwd(), gltfClient), 'utf8')
+    const routeBoundarySource = readFileSync(join(process.cwd(), gltfRouteBoundary), 'utf8')
 
     expect(pageSource).not.toContain("'use client'")
     expect(pageSource).toContain('await params')
     expect(pageSource).toContain("from 'next/image'")
-    expect(pageSource).toContain("from './components/DegenViews'")
+    expect(pageSource).toContain("from './components/DegenViewsRouteBoundary'")
+    expect(routeBoundarySource).toContain("dynamic(() => import('./DegenViews')")
+    expect(routeBoundarySource).not.toContain('ssr: false')
+    expect(routeBoundarySource).toContain('<RouteLoading label="Loading DEGEN viewer" />')
     expect(clientSource).toContain("'use client'")
     expect(clientSource).not.toContain("from 'next/image'")
     expect(clientSource).toContain("dynamic(() => import('./ModelView')")


### PR DESCRIPTION
## What changed

- Added a client route boundary for the GLTF viewer and moved the interactive DegenViews graph behind a Next dynamic import.
- Kept the server page responsible for token metadata and priority image/sprite/logo rendering.
- Kept the existing model, token menu, and accessible themed loading behavior unchanged.
- Added a route contract covering the boundary and SSR behavior.

## Why

The GLTF route eagerly imported the full interactive viewer even though its browser-only controls were already split internally. The outer viewer graph was therefore included in the initial route load.

## Measured impact

The production web build reduced /gltf/[tokenId] from 580,755 to 544,531 uncompressed first-load JavaScript bytes: 36,224 bytes (~6.2%). Other measured web routes were unchanged.

## Validation

- bun --filter web build
- bun --filter web test — 14 pass
- bun --filter web lint
- bun --filter web type-check
- bun test test/contract/route-surface.test.ts — 178 pass
- Prettier check and git diff --check

This is opened as a draft so hosted CI and Vercel remain cost-controlled until the milestone is promoted to ready.
