### PR TITLE
perf(app): defer private dashboard route graphs

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensClient.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+
+const DashboardDegensPageContent = dynamic(() => import('./DashboardDegensContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[32rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading dashboard DEGENs"
+    >
+      <Skeleton className="h-10 w-full rounded" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton key={index} className="h-48 w-full rounded" />
+        ))}
+      </div>
+      <span className="sr-only">Loading dashboard DEGENs</span>
+    </div>
+  ),
+})
+
+export default function DashboardDegensClient(): React.ReactNode {
+  return (
+    <DashboardDataBoundary>
+      <DashboardDegensPageContent />
+    </DashboardDataBoundary>
+  )
+}

--- a/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const DashboardDegensClient = dynamic(() => import('./DashboardDegensClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading dashboard DEGENs" />,
+})
+
+export default function DashboardDegensRouteBoundary(): React.ReactNode {
+  return <DashboardDegensClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/page.tsx
@@ -1,36 +1,5 @@
-'use client'
+import DashboardDegensRouteBoundary from './DashboardDegensRouteBoundary'
 
-import dynamic from 'next/dynamic'
-
-import { Skeleton } from '@nl/ui/base/skeleton'
-
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-
-const DashboardDegensPageContent = dynamic(() => import('./DashboardDegensContent'), {
-  ssr: false,
-  loading: () => (
-    <div
-      className="flex min-h-[32rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading dashboard DEGENs"
-    >
-      <Skeleton className="h-10 w-full rounded" />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 8 }, (_, index) => (
-          <Skeleton key={index} className="h-48 w-full rounded" />
-        ))}
-      </div>
-      <span className="sr-only">Loading dashboard DEGENs</span>
-    </div>
-  ),
-})
-
-export default function DashboardDegensPage() {
-  return (
-    <DashboardDataBoundary>
-      <DashboardDegensPageContent />
-    </DashboardDataBoundary>
-  )
+export default function DashboardDegensPage(): React.ReactNode {
+  return <DashboardDegensRouteBoundary />
 }

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileClient.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+
+const GamerProfilePageContent = dynamic(() => import('./GamerProfileContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading gamer profile"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <Skeleton className="h-56 w-full rounded lg:w-1/3" />
+        <Skeleton className="h-56 w-full rounded lg:flex-1" />
+      </div>
+      <Skeleton className="h-48 w-full rounded" />
+      <span className="sr-only">Loading gamer profile</span>
+    </div>
+  ),
+})
+
+export default function GamerProfileClient(): React.ReactNode {
+  return (
+    <DashboardDataBoundary>
+      <GamerProfilePageContent />
+    </DashboardDataBoundary>
+  )
+}

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const GamerProfileClient = dynamic(() => import('./GamerProfileClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading gamer profile" />,
+})
+
+export default function GamerProfileRouteBoundary(): React.ReactNode {
+  return <GamerProfileClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx
@@ -1,35 +1,5 @@
-'use client'
+import GamerProfileRouteBoundary from './GamerProfileRouteBoundary'
 
-import dynamic from 'next/dynamic'
-
-import { Skeleton } from '@nl/ui/base/skeleton'
-
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-
-const GamerProfilePageContent = dynamic(() => import('./GamerProfileContent'), {
-  ssr: false,
-  loading: () => (
-    <div
-      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading gamer profile"
-    >
-      <div className="flex flex-col gap-4 lg:flex-row">
-        <Skeleton className="h-56 w-full rounded lg:w-1/3" />
-        <Skeleton className="h-56 w-full rounded lg:flex-1" />
-      </div>
-      <Skeleton className="h-48 w-full rounded" />
-      <span className="sr-only">Loading gamer profile</span>
-    </div>
-  ),
-})
-
-export default function GamerProfilePage() {
-  return (
-    <DashboardDataBoundary>
-      <GamerProfilePageContent />
-    </DashboardDataBoundary>
-  )
+export default function GamerProfilePage(): React.ReactNode {
+  return <GamerProfileRouteBoundary />
 }

--- a/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsClient.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+
+const DashboardItemsPageContent = dynamic(() => import('./DashboardItemsContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[32rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading dashboard comics and items"
+    >
+      <Skeleton className="h-10 w-full rounded" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton key={index} className="h-48 w-full rounded" />
+        ))}
+      </div>
+      <span className="sr-only">Loading dashboard comics and items</span>
+    </div>
+  ),
+})
+
+export default function DashboardItemsClient(): React.ReactNode {
+  return (
+    <DashboardDataBoundary>
+      <DashboardItemsPageContent />
+    </DashboardDataBoundary>
+  )
+}

--- a/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const DashboardItemsClient = dynamic(() => import('./DashboardItemsClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading dashboard comics and items" />,
+})
+
+export default function DashboardItemsRouteBoundary(): React.ReactNode {
+  return <DashboardItemsClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerClient.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+
+const ComicsBurnerContent = dynamic(() => import('./ComicsBurnerContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[40rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading comics burner"
+    >
+      <Skeleton className="h-8 w-48 rounded" />
+      <Skeleton className="h-96 w-full rounded" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full rounded" />
+        ))}
+      </div>
+      <span className="sr-only">Loading comics burner</span>
+    </div>
+  ),
+})
+
+export default function ComicsBurnerClient(): React.ReactNode {
+  return (
+    <DashboardDataBoundary>
+      <ComicsBurnerContent />
+    </DashboardDataBoundary>
+  )
+}

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const ComicsBurnerClient = dynamic(() => import('./ComicsBurnerClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading comics burner" />,
+})
+
+export default function ComicsBurnerRouteBoundary(): React.ReactNode {
+  return <ComicsBurnerClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx
@@ -1,37 +1,5 @@
-'use client'
+import ComicsBurnerRouteBoundary from './ComicsBurnerRouteBoundary'
 
-import dynamic from 'next/dynamic'
-
-import { Skeleton } from '@nl/ui/base/skeleton'
-
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-
-const ComicsBurnerContent = dynamic(() => import('./ComicsBurnerContent'), {
-  ssr: false,
-  loading: () => (
-    <div
-      className="flex min-h-[40rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading comics burner"
-    >
-      <Skeleton className="h-8 w-48 rounded" />
-      <Skeleton className="h-96 w-full rounded" />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 8 }, (_, index) => (
-          <Skeleton key={index} className="h-24 w-full rounded" />
-        ))}
-      </div>
-      <span className="sr-only">Loading comics burner</span>
-    </div>
-  ),
-})
-
-export default function ComicsBurnerPage() {
-  return (
-    <DashboardDataBoundary>
-      <ComicsBurnerContent />
-    </DashboardDataBoundary>
-  )
+export default function ComicsBurnerPage(): React.ReactNode {
+  return <ComicsBurnerRouteBoundary />
 }

--- a/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/items/page.tsx
@@ -1,36 +1,5 @@
-'use client'
+import DashboardItemsRouteBoundary from './DashboardItemsRouteBoundary'
 
-import dynamic from 'next/dynamic'
-
-import { Skeleton } from '@nl/ui/base/skeleton'
-
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-
-const DashboardItemsPageContent = dynamic(() => import('./DashboardItemsContent'), {
-  ssr: false,
-  loading: () => (
-    <div
-      className="flex min-h-[32rem] flex-col gap-4 rounded-md border border-border bg-muted p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading dashboard comics and items"
-    >
-      <Skeleton className="h-10 w-full rounded" />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 8 }, (_, index) => (
-          <Skeleton key={index} className="h-48 w-full rounded" />
-        ))}
-      </div>
-      <span className="sr-only">Loading dashboard comics and items</span>
-    </div>
-  ),
-})
-
-export default function DashboardItemsPage() {
-  return (
-    <DashboardDataBoundary>
-      <DashboardItemsPageContent />
-    </DashboardDataBoundary>
-  )
+export default function DashboardItemsPage(): React.ReactNode {
+  return <DashboardItemsRouteBoundary />
 }

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsClient.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsClient.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import { Skeleton } from '@nl/ui/base/skeleton'
+
+import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
+
+const DashboardRentalsPageContent = dynamic(() => import('./DashboardRentalsContent'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading rentals"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <Skeleton className="h-8 w-40 rounded" />
+        <Skeleton className="h-10 w-64 rounded" />
+      </div>
+      <Skeleton className="h-[calc(100vh-320px)] w-full rounded" />
+      <span className="sr-only">Loading rentals</span>
+    </div>
+  ),
+})
+
+export default function DashboardRentalsClient(): React.ReactNode {
+  return (
+    <DashboardDataBoundary>
+      <DashboardRentalsPageContent />
+    </DashboardDataBoundary>
+  )
+}

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsRouteBoundary.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsRouteBoundary.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+import RouteLoading from '@nl/ui/custom/route-loading'
+
+const DashboardRentalsClient = dynamic(() => import('./DashboardRentalsClient'), {
+  ssr: false,
+  loading: () => <RouteLoading label="Loading rentals" />,
+})
+
+export default function DashboardRentalsRouteBoundary(): React.ReactNode {
+  return <DashboardRentalsClient />
+}

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx
@@ -1,35 +1,5 @@
-'use client'
+import DashboardRentalsRouteBoundary from './DashboardRentalsRouteBoundary'
 
-import dynamic from 'next/dynamic'
-
-import { Skeleton } from '@nl/ui/base/skeleton'
-
-import DashboardDataBoundary from '@/components/providers/DashboardDataBoundary'
-
-const DashboardRentalsPageContent = dynamic(() => import('./DashboardRentalsContent'), {
-  ssr: false,
-  loading: () => (
-    <div
-      className="flex min-h-[36rem] flex-col gap-6 rounded-md border border-border bg-muted p-6"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label="Loading rentals"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <Skeleton className="h-8 w-40 rounded" />
-        <Skeleton className="h-10 w-64 rounded" />
-      </div>
-      <Skeleton className="h-[calc(100vh-320px)] w-full rounded" />
-      <span className="sr-only">Loading rentals</span>
-    </div>
-  ),
-})
-
-export default function DashboardRentalsPage() {
-  return (
-    <DashboardDataBoundary>
-      <DashboardRentalsPageContent />
-    </DashboardDataBoundary>
-  )
+export default function DashboardRentalsPage(): React.ReactNode {
+  return <DashboardRentalsRouteBoundary />
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -109,18 +109,38 @@ const dashboardOverviewBoundary =
 const dashboardOverviewClient =
   'apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewClient.tsx'
 const dashboardDegens = 'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx'
+const dashboardDegensBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensRouteBoundary.tsx'
+const dashboardDegensClient =
+  'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensClient.tsx'
 const dashboardDegensContent =
   'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx'
 const dashboardItems = 'apps/app/src/app/(private-routes)/dashboard/items/page.tsx'
+const dashboardItemsBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsRouteBoundary.tsx'
+const dashboardItemsClient =
+  'apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsClient.tsx'
 const dashboardItemsContent =
   'apps/app/src/app/(private-routes)/dashboard/items/DashboardItemsContent.tsx'
 const dashboardBurner = 'apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx'
+const dashboardBurnerBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerRouteBoundary.tsx'
+const dashboardBurnerClient =
+  'apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerClient.tsx'
 const dashboardBurnerContent =
   'apps/app/src/app/(private-routes)/dashboard/items/burner/ComicsBurnerContent.tsx'
 const gamerProfile = 'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx'
+const gamerProfileBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileRouteBoundary.tsx'
+const gamerProfileClient =
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileClient.tsx'
 const gamerProfileContent =
   'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx'
 const dashboardRentals = 'apps/app/src/app/(private-routes)/dashboard/rentals/page.tsx'
+const dashboardRentalsBoundary =
+  'apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsRouteBoundary.tsx'
+const dashboardRentalsClient =
+  'apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsClient.tsx'
 const dashboardRentalsContent =
   'apps/app/src/app/(private-routes)/dashboard/rentals/DashboardRentalsContent.tsx'
 const privateShellBoundary = 'apps/app/src/components/providers/PrivateRoutesBoundary.tsx'
@@ -858,14 +878,17 @@ describe('private provider loading contract', () => {
     expect(source).toContain("from '@/contexts/TokensBalanceContext'")
 
     for (const file of [
-      'apps/app/src/app/(private-routes)/dashboard/degens/page.tsx',
-      'apps/app/src/app/(private-routes)/dashboard/gamer-profile/page.tsx',
-      'apps/app/src/app/(private-routes)/dashboard/items/page.tsx',
-      'apps/app/src/app/(private-routes)/dashboard/items/burner/page.tsx',
+      gamerProfileClient,
+      dashboardItemsClient,
+      dashboardBurnerClient,
+      dashboardRentalsClient,
     ]) {
       expect(readFileSync(join(process.cwd(), file), 'utf8')).toContain('DashboardDataBoundary')
     }
     expect(readFileSync(join(process.cwd(), dashboardOverviewClient), 'utf8')).toContain(
+      'DashboardDataBoundary'
+    )
+    expect(readFileSync(join(process.cwd(), dashboardDegensClient), 'utf8')).toContain(
       'DashboardDataBoundary'
     )
 
@@ -1027,14 +1050,21 @@ describe('dashboard overview loading contract', () => {
 describe('dashboard DEGEN loading contract', () => {
   it('keeps the card and filter graph behind the route loading boundary', () => {
     const pageSource = readFileSync(join(process.cwd(), dashboardDegens), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), dashboardDegensBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), dashboardDegensClient), 'utf8')
     const contentSource = readFileSync(join(process.cwd(), dashboardDegensContent), 'utf8')
 
-    expect(pageSource).toContain("dynamic(() => import('./DashboardDegensContent')")
-    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
-    expect(pageSource).toContain('role="status"')
-    expect(pageSource).toContain('aria-busy="true"')
-    expect(pageSource).not.toContain("from '@/components/cards/DegenCard/DashboardDegenCard'")
-    expect(pageSource).not.toContain("from '@/components/extended/DegensFilter'")
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './DashboardDegensRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./DashboardDegensClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading dashboard DEGENs" />')
+    expect(clientSource).toContain("dynamic(() => import('./DashboardDegensContent')")
+    expect(clientSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(clientSource).toContain('role="status"')
+    expect(clientSource).toContain('aria-busy="true"')
+    expect(clientSource).not.toContain("from '@/components/cards/DegenCard/DashboardDegenCard'")
+    expect(clientSource).not.toContain("from '@/components/extended/DegensFilter'")
     expect(contentSource).toContain("import('@/components/cards/DegenCard/DashboardDegenCard')")
     expect(contentSource).toContain(
       "import DeferredDegensFilter from '@/components/providers/DeferredDegensFilter'"
@@ -1049,15 +1079,22 @@ describe('dashboard DEGEN loading contract', () => {
 describe('dashboard items loading contract', () => {
   it('keeps the comic and item graph behind the route loading boundary', () => {
     const pageSource = readFileSync(join(process.cwd(), dashboardItems), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), dashboardItemsBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), dashboardItemsClient), 'utf8')
     const contentSource = readFileSync(join(process.cwd(), dashboardItemsContent), 'utf8')
 
-    expect(pageSource).toContain("dynamic(() => import('./DashboardItemsContent')")
-    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
-    expect(pageSource).toContain('role="status"')
-    expect(pageSource).toContain('aria-live="polite"')
-    expect(pageSource).toContain('aria-busy="true"')
-    expect(pageSource).not.toContain("from '@/components/cards/ComicCard'")
-    expect(pageSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './DashboardItemsRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./DashboardItemsClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading dashboard comics and items" />')
+    expect(clientSource).toContain("dynamic(() => import('./DashboardItemsContent')")
+    expect(clientSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(clientSource).toContain('role="status"')
+    expect(clientSource).toContain('aria-live="polite"')
+    expect(clientSource).toContain('aria-busy="true"')
+    expect(clientSource).not.toContain("from '@/components/cards/ComicCard'")
+    expect(clientSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).toContain("from '@/components/cards/ComicCard'")
     expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).toContain('DashboardComicsPageContent')
@@ -1067,16 +1104,23 @@ describe('dashboard items loading contract', () => {
 describe('dashboard burner loading contract', () => {
   it('keeps the burner machine and wallet graph behind the route loading boundary', () => {
     const pageSource = readFileSync(join(process.cwd(), dashboardBurner), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), dashboardBurnerBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), dashboardBurnerClient), 'utf8')
     const contentSource = readFileSync(join(process.cwd(), dashboardBurnerContent), 'utf8')
 
-    expect(pageSource).toContain("dynamic(() => import('./ComicsBurnerContent')")
-    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
-    expect(pageSource).toContain('role="status"')
-    expect(pageSource).toContain('aria-live="polite"')
-    expect(pageSource).toContain('aria-busy="true"')
-    expect(pageSource).not.toContain("from 'ethers'")
-    expect(pageSource).not.toContain("from './_components/machine'")
-    expect(pageSource).not.toContain("from '@/hooks/useNetworkContext'")
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './ComicsBurnerRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./ComicsBurnerClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading comics burner" />')
+    expect(clientSource).toContain("dynamic(() => import('./ComicsBurnerContent')")
+    expect(clientSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(clientSource).toContain('role="status"')
+    expect(clientSource).toContain('aria-live="polite"')
+    expect(clientSource).toContain('aria-busy="true"')
+    expect(clientSource).not.toContain("from 'ethers'")
+    expect(clientSource).not.toContain("from './_components/machine'")
+    expect(clientSource).not.toContain("from '@/hooks/useNetworkContext'")
     expect(contentSource).toContain("from 'ethers'")
     expect(contentSource).toContain("from './_components/machine'")
     expect(contentSource).toContain("from '@/hooks/useNetworkContext'")
@@ -1087,15 +1131,22 @@ describe('dashboard burner loading contract', () => {
 describe('gamer profile loading contract', () => {
   it('keeps profile, wallet, and inventory graphs behind the route loading boundary', () => {
     const pageSource = readFileSync(join(process.cwd(), gamerProfile), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), gamerProfileBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), gamerProfileClient), 'utf8')
     const contentSource = readFileSync(join(process.cwd(), gamerProfileContent), 'utf8')
 
-    expect(pageSource).toContain("dynamic(() => import('./GamerProfileContent')")
-    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
-    expect(pageSource).toContain('role="status"')
-    expect(pageSource).toContain('aria-live="polite"')
-    expect(pageSource).toContain('aria-busy="true"')
-    expect(pageSource).not.toContain("from 'wagmi'")
-    expect(pageSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './GamerProfileRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./GamerProfileClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading gamer profile" />')
+    expect(clientSource).toContain("dynamic(() => import('./GamerProfileContent')")
+    expect(clientSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(clientSource).toContain('role="status"')
+    expect(clientSource).toContain('aria-live="polite"')
+    expect(clientSource).toContain('aria-busy="true"')
+    expect(clientSource).not.toContain("from 'wagmi'")
+    expect(clientSource).not.toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).toContain("from 'wagmi'")
     expect(contentSource).toContain("from '@/hooks/balances/useNFTsBalances'")
     expect(contentSource).not.toContain('defaultValue')
@@ -1106,15 +1157,22 @@ describe('gamer profile loading contract', () => {
 describe('dashboard rentals loading contract', () => {
   it('keeps the rental grid and auth query graph behind the route loading boundary', () => {
     const pageSource = readFileSync(join(process.cwd(), dashboardRentals), 'utf8')
+    const boundarySource = readFileSync(join(process.cwd(), dashboardRentalsBoundary), 'utf8')
+    const clientSource = readFileSync(join(process.cwd(), dashboardRentalsClient), 'utf8')
     const contentSource = readFileSync(join(process.cwd(), dashboardRentalsContent), 'utf8')
 
-    expect(pageSource).toContain("dynamic(() => import('./DashboardRentalsContent')")
-    expect(pageSource).toContain("from '@nl/ui/base/skeleton'")
-    expect(pageSource).toContain('role="status"')
-    expect(pageSource).toContain('aria-live="polite"')
-    expect(pageSource).toContain('aria-busy="true"')
-    expect(pageSource).not.toContain("from './MyRentalsDataGrid'")
-    expect(pageSource).not.toContain("from '@tanstack/react-query'")
+    expect(pageSource).not.toContain("'use client'")
+    expect(pageSource).toContain("from './DashboardRentalsRouteBoundary'")
+    expect(boundarySource).toContain("dynamic(() => import('./DashboardRentalsClient')")
+    expect(boundarySource).toContain('ssr: false')
+    expect(boundarySource).toContain('<RouteLoading label="Loading rentals" />')
+    expect(clientSource).toContain("dynamic(() => import('./DashboardRentalsContent')")
+    expect(clientSource).toContain("from '@nl/ui/base/skeleton'")
+    expect(clientSource).toContain('role="status"')
+    expect(clientSource).toContain('aria-live="polite"')
+    expect(clientSource).toContain('aria-busy="true"')
+    expect(clientSource).not.toContain("from './MyRentalsDataGrid'")
+    expect(clientSource).not.toContain("from '@tanstack/react-query'")
     expect(contentSource).toContain("from './MyRentalsDataGrid'")
     expect(contentSource).toContain("from '@tanstack/react-query'")
     expect(contentSource).toContain('My Rentals')


### PR DESCRIPTION
## Summary

- Move the five remaining private dashboard pages behind small server-rendered route wrappers.
- Load each route's client graph only when that route is entered, keeping the existing themed and accessible loading states.
- Keep dashboard data providers inside the deferred client boundary and extend route contracts to protect the split.

## Measured impact

The App production build reduced first-load JavaScript for the private dashboard routes from roughly 611 KB to roughly 604 KB:

| Route | Before | After | Change |
| --- | ---: | ---: | ---: |
| `/dashboard/degens` | 611,408 B | 603,962 B | -7,446 B |
| `/dashboard/items` | 611,295 B | 603,972 B | -7,323 B |
| `/dashboard/items/burner` | 611,358 B | 603,959 B | -7,399 B |
| `/dashboard/gamer-profile` | 611,274 B | 603,959 B | -7,315 B |
| `/dashboard/rentals` | 611,241 B | 603,953 B | -7,288 B |

The shared `/dashboard` and `/dashboard/overview` bundle remains unchanged at about 604 KB.

## Validation

- `bun --filter app build`
- `bun --filter app test` (167 passed)
- `bun --filter app lint`
- `bun test test/contract/route-surface.test.ts` (178 passed)
- `bun test test/contract/app-performance.test.ts test/contract/native-collections.test.ts test/contract/app-item-media.test.ts` (10 passed)
- Prettier check and `git diff --check`

Draft PR intentionally remains local-validation-only until the milestone is ready.
