### PR TITLE
perf(ui): defer viewport video playback observers

### DIFF
--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useRef } from 'react'
+
+import type { ViewportVideoProps } from './index'
+
+const ViewportVideoEnhancer = dynamic(() => import('./ViewportVideoEnhancer'), { ssr: false })
+
+export default function ViewportVideoBoundary({
+  rootMargin = '300px',
+  src,
+  ...props
+}: ViewportVideoProps): React.ReactNode {
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  return (
+    <>
+      <video {...props} ref={videoRef} preload="none">
+        <source src={src} type="video/mp4" />
+      </video>
+      <ViewportVideoEnhancer rootMargin={rootMargin} videoRef={videoRef} />
+    </>
+  )
+}

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, type RefObject } from 'react'
+
+import useMediaQuery from '@nl/ui/hooks/useMediaQuery'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+interface ViewportVideoEnhancerProps {
+  rootMargin: string
+  videoRef: RefObject<HTMLVideoElement | null>
+}
+
+export default function ViewportVideoEnhancer({
+  rootMargin,
+  videoRef,
+}: ViewportVideoEnhancerProps): null {
+  const isNearViewport = useOnScreen(videoRef, rootMargin)
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+  const shouldPlay = isNearViewport && !prefersReducedMotion
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+
+    video.autoplay = shouldPlay
+    video.preload = shouldPlay ? 'metadata' : 'none'
+
+    if (!shouldPlay) {
+      video.pause?.()
+      return
+    }
+
+    const playPromise = video.play?.()
+    playPromise?.catch(() => undefined)
+  }, [shouldPlay, videoRef])
+
+  return null
+}

--- a/packages/ui/src/components/custom/viewport-video/index.tsx
+++ b/packages/ui/src/components/custom/viewport-video/index.tsx
@@ -1,11 +1,11 @@
-'use client'
+import { memo, type VideoHTMLAttributes } from 'react'
 
-import { memo, useEffect, useRef, type VideoHTMLAttributes } from 'react'
+import ViewportVideoBoundary from './ViewportVideoBoundary'
 
-import useMediaQuery from '@nl/ui/hooks/useMediaQuery'
-import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
-
-type ViewportVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'autoPlay' | 'preload'> & {
+export type ViewportVideoProps = Omit<
+  VideoHTMLAttributes<HTMLVideoElement>,
+  'autoPlay' | 'preload'
+> & {
   rootMargin?: string
   src: string
 }
@@ -15,34 +15,7 @@ export const ViewportVideo = memo(function ViewportVideo({
   src,
   ...props
 }: ViewportVideoProps) {
-  const videoRef = useRef<HTMLVideoElement>(null)
-  const isNearViewport = useOnScreen(videoRef, rootMargin)
-  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
-  const shouldPlay = isNearViewport && !prefersReducedMotion
-
-  useEffect(() => {
-    const video = videoRef.current
-    if (!video) return
-
-    if (!shouldPlay) {
-      video.pause?.()
-      return
-    }
-
-    const playPromise = video.play?.()
-    playPromise?.catch(() => undefined)
-  }, [shouldPlay])
-
-  return (
-    <video
-      {...props}
-      ref={videoRef}
-      autoPlay={shouldPlay}
-      preload={shouldPlay ? 'metadata' : 'none'}
-    >
-      <source src={src} type="video/mp4" />
-    </video>
-  )
+  return <ViewportVideoBoundary rootMargin={rootMargin} src={src} {...props} />
 })
 
 export default ViewportVideo

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react'
+import { useRef } from 'react'
+import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 const state = { nearViewport: true, reducedMotion: false }
@@ -9,9 +10,11 @@ mock.module('@nl/ui/hooks/useOnScreen', () => ({
 mock.module('@nl/ui/hooks/useMediaQuery', () => ({
   default: () => state.reducedMotion,
 }))
+mock.module('next/dynamic', () => ({ default: () => () => null }))
 
 describe('ViewportVideo', () => {
   let ViewportVideo: typeof import('./index').ViewportVideo
+  let ViewportVideoEnhancer: typeof import('./ViewportVideoEnhancer').default
 
   beforeEach(() => {
     state.nearViewport = true
@@ -20,30 +23,72 @@ describe('ViewportVideo', () => {
 
   beforeEach(async () => {
     ViewportVideo = (await import('./index')).ViewportVideo
+    ViewportVideoEnhancer = (await import('./ViewportVideoEnhancer')).default
   })
 
-  it('only enables playback and metadata loading near the viewport', () => {
-    const { rerender } = render(
+  it('keeps the video markup server-rendered before playback enhancement', () => {
+    const { container } = render(
       <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
     )
-    const video = document.querySelector('[data-testid="video"]') as HTMLVideoElement
+    const video = container.querySelector('[data-testid="video"]') as HTMLVideoElement
 
-    expect(video.autoplay).toBe(true)
-    expect(video.preload).toBe('metadata')
-    expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
-
-    state.nearViewport = false
-    rerender(<ViewportVideo data-testid="video" src="/video/example.mp4" />)
     expect(video.autoplay).toBe(false)
     expect(video.preload).toBe('none')
+    expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
   })
 
-  it('honors reduced-motion preferences even when visible', () => {
+  it('only enables playback and metadata loading near the viewport', async () => {
+    function PlaybackHarness() {
+      const videoRef = useRef<HTMLVideoElement>(null)
+
+      return (
+        <>
+          <video data-testid="video" ref={videoRef} />
+          <ViewportVideoEnhancer rootMargin="300px" videoRef={videoRef} />
+        </>
+      )
+    }
+
+    const { container, unmount } = render(<PlaybackHarness />)
+    const video = container.querySelector('[data-testid="video"]') as HTMLVideoElement
+
+    await waitFor(() => {
+      expect(video.autoplay).toBe(true)
+      expect(video.preload).toBe('metadata')
+    })
+
+    state.nearViewport = false
+    unmount()
+    const deferred = render(<PlaybackHarness />)
+    const deferredVideo = deferred.container.querySelector(
+      '[data-testid="video"]'
+    ) as HTMLVideoElement
+
+    await waitFor(() => {
+      expect(deferredVideo.autoplay).toBe(false)
+      expect(deferredVideo.preload).toBe('none')
+    })
+  })
+
+  it('honors reduced-motion preferences even when visible', async () => {
     state.reducedMotion = true
-    const { container } = render(<ViewportVideo src="/video/example.mp4" />)
+    function PlaybackHarness() {
+      const videoRef = useRef<HTMLVideoElement>(null)
+
+      return (
+        <>
+          <video ref={videoRef} />
+          <ViewportVideoEnhancer rootMargin="300px" videoRef={videoRef} />
+        </>
+      )
+    }
+
+    const { container } = render(<PlaybackHarness />)
     const video = container.querySelector('video') as HTMLVideoElement
 
-    expect(video.autoplay).toBe(false)
-    expect(video.preload).toBe('none')
+    await waitFor(() => {
+      expect(video.autoplay).toBe(false)
+      expect(video.preload).toBe('none')
+    })
   })
 })

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -177,6 +177,11 @@ const networkProvider = 'apps/app/src/contexts/NetworkProvider.tsx'
 const graphQL = 'apps/app/src/hooks/useGraphQL.ts'
 const publicCarousel = 'apps/web/src/components/Carousel/index.tsx'
 const interactivePublicCarousel = 'apps/web/src/components/Carousel/InteractiveCarousel.tsx'
+const viewportVideo = 'packages/ui/src/components/custom/viewport-video/index.tsx'
+const viewportVideoBoundary =
+  'packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx'
+const viewportVideoEnhancer =
+  'packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx'
 const deferredWeb3GameList = 'apps/app/src/app/(public-routes)/games/DeferredWeb3GameList.tsx'
 const staleDownloadGameDialog = 'apps/app/src/components/dialog/DownloadGameDialog.tsx'
 const smashersLoginClient = 'apps/smashers/src/app/(auth_routes)/login/LoginClient.tsx'
@@ -1544,6 +1549,20 @@ describe('public route dependency contract', () => {
     expect(interactive).toContain('react-multi-carousel/lib/styles.css')
     expect(interactive).toContain('ssr={true}')
     expect(interactive).toContain('autoPlay={true}')
+  })
+
+  it('keeps public videos server-rendered while deferring playback observers', () => {
+    const shell = readFileSync(join(process.cwd(), viewportVideo), 'utf8')
+    const boundary = readFileSync(join(process.cwd(), viewportVideoBoundary), 'utf8')
+    const enhancer = readFileSync(join(process.cwd(), viewportVideoEnhancer), 'utf8')
+
+    expect(shell).not.toContain("'use client'")
+    expect(shell).toContain("from './ViewportVideoBoundary'")
+    expect(boundary).toContain("dynamic(() => import('./ViewportVideoEnhancer')")
+    expect(boundary).toContain('preload="none"')
+    expect(enhancer).toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")
+    expect(enhancer).toContain("video.preload = shouldPlay ? 'metadata' : 'none'")
   })
 
   it('keeps API-only constants separate from the contract registry', () => {


### PR DESCRIPTION
## Summary

- Keep the shared `ViewportVideo` HTML shell server-renderable with `preload="none"`.
- Defer the viewport observer, reduced-motion query, and playback effect into a small dynamic enhancer.
- Preserve memoization, viewport-triggered metadata loading/playback, reduced-motion behavior, and existing consumers across Web and Smashers.

## Measured impact

The final Web production build reduced first-load JavaScript for affected routes:

| Route | Before | After | Change |
| --- | ---: | ---: | ---: |
| `/games` | 544,613 B | 543,523 B | -1,090 B |
| `/niftyworld` | 545,550 B | 545,132 B | -418 B |

`/degens`, `/compete-and-earn`, and the already-deferred Smashers home route were unchanged in the measured build.

## Validation

- `bun --filter web build`
- `bun --filter smashers build`
- `bun --filter web test` (14 passed)
- `bun --filter smashers test` (15 passed)
- `bun --filter web lint`
- `bun --filter smashers lint` (0 errors; one existing warning in `next.config.ts`)
- `bun --filter @nl/ui test` (147 passed)
- `bun --filter @nl/ui lint`
- `bun --filter @nl/ui type-check`
- `bun test test/contract/route-surface.test.ts` (179 passed)
- Prettier and `git diff --check`

Draft PR intentionally remains local-validation-only until the milestone is ready.
