### PR TITLE
perf(web): defer homepage DEGEN carousel

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -19,12 +19,6 @@ describe('home page', () => {
     mock.module('@/components/Sponsors', () => ({ default: () => null }))
     mock.module('@/components/ThemeBtnGroup', () => ({ default: () => null }))
     mock.module('@nl/ui/custom/deferred-console-game', () => ({ DeferredConsoleGame: () => null }))
-    // The home page renders the interactive DEGEN carousel through a shared
-    // wrapper; stub the heavy carousel library out for these markup-level
-    // assertions (it is unchanged by this tranche).
-    mock.module('@/components/Carousel', () => ({
-      default: ({ children }: PropsWithChildren) => <div data-testid="carousel">{children}</div>,
-    }))
     mock.module('next/link', () => ({
       default: ({ children, href, ...props }: PropsWithChildren<{ href: string }>) => (
         <a href={href} {...props}>

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -4,12 +4,14 @@ import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 import BouncingNFTL from '@/components/BouncingNFTL'
-import Carousel from '@/components/Carousel'
-import { DeferredMintOMatic, DeferredSponsors } from '@/components/DeferredHomeSections'
+import {
+  DeferredCommunityDegenCarousel,
+  DeferredMintOMatic,
+  DeferredSponsors,
+} from '@/components/DeferredHomeSections'
 import MainLayout from '@/components/MainLayout'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
-import { RenderDegen } from '@/components/Carousel/DegenCardItem'
-import { COMMUNITY_DEGEN_LIST, DEGEN_COLLECTION_URL } from '@/constants/degens'
+import { DEGEN_COLLECTION_URL } from '@/constants/degens'
 
 import '@/styles/home.css'
 
@@ -202,7 +204,7 @@ const Home = () => {
               sizes="(max-width: 576px) 90vw, (max-width: 992px) 80%, 700px"
             />
           </div>
-          <Carousel mobileItems={2}>{COMMUNITY_DEGEN_LIST.map(RenderDegen)}</Carousel>
+          <DeferredCommunityDegenCarousel />
         </div>
       </section>
 

--- a/apps/web/src/components/CommunityDegenCarousel.tsx
+++ b/apps/web/src/components/CommunityDegenCarousel.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import Carousel from '@/components/Carousel'
+import { RenderDegen } from '@/components/Carousel/DegenCardItem'
+import { COMMUNITY_DEGEN_LIST } from '@/constants/degens'
+
+export default function CommunityDegenCarousel() {
+  return <Carousel mobileItems={2}>{COMMUNITY_DEGEN_LIST.map(RenderDegen)}</Carousel>
+}

--- a/apps/web/src/components/DeferredHomeSections.tsx
+++ b/apps/web/src/components/DeferredHomeSections.tsx
@@ -9,6 +9,7 @@ const loadSponsors = () =>
   import('@/components/Sponsors').then(({ default: Sponsors }) => ({
     default: () => <Sponsors sponsors={SPONSORS} />,
   }))
+const loadCommunityDegenCarousel = () => import('@/components/CommunityDegenCarousel')
 
 export function DeferredMintOMatic() {
   return (
@@ -22,4 +23,14 @@ export function DeferredMintOMatic() {
 
 export function DeferredSponsors() {
   return <DeferredSection label="sponsors" load={loadSponsors} minHeightClassName="min-h-[22rem]" />
+}
+
+export function DeferredCommunityDegenCarousel() {
+  return (
+    <DeferredSection
+      label="community DEGEN carousel"
+      load={loadCommunityDegenCarousel}
+      minHeightClassName="min-h-[22rem]"
+    />
+  )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -272,6 +272,7 @@ const staticLegalPages = [
 const webDefinitions = 'apps/web/src/components/Definitions.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
+const webCommunityDegenCarousel = 'apps/web/src/components/CommunityDegenCarousel.tsx'
 const webDeferredOverviewSections = 'apps/web/src/components/DeferredOverviewSections.tsx'
 const webOverviewFAQ = 'apps/web/src/components/OverviewFAQ.tsx'
 const webCareersPage = 'apps/web/src/app/(main)/careers/page.tsx'
@@ -1263,14 +1264,21 @@ describe('shared below-fold loading contract', () => {
   it('defers below-fold marketing sections in web', () => {
     const pageSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
     const deferredSource = readFileSync(join(process.cwd(), webDeferredHomeSections), 'utf8')
+    const carouselSource = readFileSync(join(process.cwd(), webCommunityDegenCarousel), 'utf8')
 
     expect(pageSource).toContain('DeferredMintOMatic')
     expect(pageSource).toContain('DeferredSponsors')
+    expect(pageSource).toContain('DeferredCommunityDegenCarousel')
     expect(pageSource).not.toContain("import('@/components/MintOMatic')")
     expect(pageSource).not.toContain("import('@/components/Sponsors')")
+    expect(pageSource).not.toContain("from '@/components/Carousel'")
+    expect(pageSource).not.toContain("from '@/components/Carousel/DegenCardItem'")
     expect(deferredSource).toContain("import('@/components/MintOMatic')")
     expect(deferredSource).toContain("import('@/components/Sponsors')")
+    expect(deferredSource).toContain("import('@/components/CommunityDegenCarousel')")
     expect(deferredSource).toContain("from '@nl/ui/custom/deferred-section'")
+    expect(carouselSource).toContain("from '@/components/Carousel'")
+    expect(carouselSource).toContain("from '@/constants/degens'")
   })
 
   it('defers the below-fold Overview FAQ interaction bundle', () => {


### PR DESCRIPTION
## Summary
- Move the homepage below-fold community DEGEN carousel behind the shared accessible, themed DeferredSection boundary.
- Keep the existing carousel, DEGEN data, artwork, and interaction behavior in a lazy-loaded component.
- Extend route-surface contracts and remove the now-stale homepage carousel test mock.

## Local validation
- bun --filter web build
- bun --filter web lint
- bun --filter web type-check
- bun --filter web test (14 passed)
- bun test test/contract/route-surface.test.ts (179 passed)
- Prettier check and git diff --check

## Cost policy
This PR is intentionally draft. Hosted CI and Vercel feature-branch builds remain skipped until it is converted to ready for review.