### PR TITLE
perf(web): defer team mobile carousel

### DIFF
--- a/apps/web/src/app/(main)/team/page.tsx
+++ b/apps/web/src/app/(main)/team/page.tsx
@@ -1,10 +1,8 @@
 import type { NextPage } from 'next'
 
-import Carousel from '@/components/Carousel'
-import TeamCardItem from '@/components/Carousel/TeamCardItem'
+import { DeferredTeamCarousel } from '@/components/DeferredTeamSections'
 import ThemeBtnGroup from '@/components/ThemeBtnGroup'
 import TeamDesktop from '@/components/TeamDesktop'
-import { CORE_TEAM, DEGEN_DELEGATES } from '@/constants/team'
 
 const Team: NextPage = () => {
   return (
@@ -45,11 +43,7 @@ const Team: NextPage = () => {
             className="teams-slider slider px-0 block md:hidden"
             style={{ alignItems: 'center', maxWidth: '100%', textAlign: 'center', minHeight: 300 }}
           >
-            <Carousel isMobileViewOnly hideGradient tabletItems={2}>
-              {[...CORE_TEAM, ...DEGEN_DELEGATES].map((item) => (
-                <TeamCardItem key={item.name} {...item} />
-              ))}
-            </Carousel>
+            <DeferredTeamCarousel />
           </div>
           <div className="purple-bg-orb orb-top-left" />
         </section>

--- a/apps/web/src/components/DeferredTeamSections.tsx
+++ b/apps/web/src/components/DeferredTeamSections.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { DeferredSection } from '@nl/ui/custom/deferred-section'
+
+const loadTeamCarousel = () => import('@/components/TeamCarousel')
+
+export function DeferredTeamCarousel() {
+  return (
+    <DeferredSection
+      label="mobile team carousel"
+      load={loadTeamCarousel}
+      minHeightClassName="min-h-[300px]"
+    />
+  )
+}

--- a/apps/web/src/components/TeamCarousel.tsx
+++ b/apps/web/src/components/TeamCarousel.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import Carousel from '@/components/Carousel'
+import TeamCardItem from '@/components/Carousel/TeamCardItem'
+import { CORE_TEAM, DEGEN_DELEGATES } from '@/constants/team'
+
+export default function TeamCarousel() {
+  return (
+    <Carousel isMobileViewOnly hideGradient tabletItems={2}>
+      {[...CORE_TEAM, ...DEGEN_DELEGATES].map((item) => (
+        <TeamCardItem key={item.name} {...item} />
+      ))}
+    </Carousel>
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -273,6 +273,8 @@ const webDefinitions = 'apps/web/src/components/Definitions.tsx'
 const smashersHomePage = 'apps/smashers/src/app/page.tsx'
 const webDeferredHomeSections = 'apps/web/src/components/DeferredHomeSections.tsx'
 const webCommunityDegenCarousel = 'apps/web/src/components/CommunityDegenCarousel.tsx'
+const webDeferredTeamSections = 'apps/web/src/components/DeferredTeamSections.tsx'
+const webTeamCarousel = 'apps/web/src/components/TeamCarousel.tsx'
 const webDeferredOverviewSections = 'apps/web/src/components/DeferredOverviewSections.tsx'
 const webOverviewFAQ = 'apps/web/src/components/OverviewFAQ.tsx'
 const webCareersPage = 'apps/web/src/app/(main)/careers/page.tsx'
@@ -1357,13 +1359,20 @@ describe('web marketing page boundary contract', () => {
     const communitySource = readFileSync(join(process.cwd(), webCommunityPage), 'utf8')
     const teamSource = readFileSync(join(process.cwd(), webTeamPage), 'utf8')
     const carouselSource = readFileSync(join(process.cwd(), webCarousel), 'utf8')
+    const deferredTeamSource = readFileSync(join(process.cwd(), webDeferredTeamSections), 'utf8')
+    const teamCarouselSource = readFileSync(join(process.cwd(), webTeamCarousel), 'utf8')
 
     expect(communitySource).not.toContain("'use client'")
     expect(communitySource).not.toContain('useMediaQuery')
     expect(communitySource).toContain('sliding-background-wrapper')
     expect(teamSource).not.toContain("'use client'")
-    expect(teamSource).toContain("import Carousel from '@/components/Carousel'")
+    expect(teamSource).toContain('DeferredTeamCarousel')
+    expect(teamSource).not.toContain("from '@/components/Carousel'")
     expect(carouselSource).toContain("'use client'")
+    expect(deferredTeamSource).toContain("import('@/components/TeamCarousel')")
+    expect(deferredTeamSource).toContain("from '@nl/ui/custom/deferred-section'")
+    expect(teamCarouselSource).toContain("from '@/components/Carousel'")
+    expect(teamCarouselSource).toContain("from '@/constants/team'")
   })
 })
 


### PR DESCRIPTION
## Summary
- Move the team route mobile-only carousel behind the shared accessible, themed DeferredSection boundary.
- Keep the desktop team grid server-rendered and preserve the existing carousel/card data and styling in a lazy-loaded component.
- Add route-surface contracts for the new boundary.

## Local validation
- bun --filter web build
- bun --filter web lint
- bun --filter web type-check
- bun --filter web test (14 passed)
- bun test test/contract/route-surface.test.ts (179 passed)
- Prettier check and git diff --check
- Production manifest confirms the team route has no eager Carousel client module.

## Cost policy
This PR is intentionally draft. Hosted CI and Vercel feature-branch builds remain skipped until it is converted to ready for review.