### PR TITLE
perf(web): remove decorative coin scroll runtime

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -11,9 +11,6 @@ describe('home page', () => {
     mock.module('@/components/MainLayout', () => ({
       default: ({ children }: PropsWithChildren) => <>{children}</>,
     }))
-    mock.module('@nl/ui/custom/parallax-wrapper', () => ({
-      ParallaxWrapper: ({ children }: PropsWithChildren) => <>{children}</>,
-    }))
     mock.module('@/components/BouncingNFTL', () => ({ default: () => null }))
     mock.module('@/components/MintOMatic', () => ({ default: () => null }))
     mock.module('@/components/Sponsors', () => ({ default: () => null }))

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image'
 
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
-import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 import BouncingNFTL from '@/components/BouncingNFTL'
 import {
@@ -263,7 +262,7 @@ const Home = () => {
             />
           </div>
           <div className="absolute scrolling-nftl-token">
-            <ParallaxWrapper parallaxDirection="up" parallaxIntensity="extreme">
+            <div>
               <div className="transition-fade">
                 <Image
                   alt="Scrolling NFTL Token"
@@ -274,7 +273,7 @@ const Home = () => {
                   sizes="246px"
                 />
               </div>
-            </ParallaxWrapper>
+            </div>
           </div>
         </div>
       </section>

--- a/apps/web/src/components/BouncingNFTL/index.tsx
+++ b/apps/web/src/components/BouncingNFTL/index.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image'
 
 import { cn } from '@nl/ui/utils'
-import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
 
 interface ComponentProps {
   classes?: { token1?: string; token2?: string; token3?: string }
@@ -15,7 +14,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
         classes?.token1
       )}
     >
-      <ParallaxWrapper parallaxDirection="right">
+      <div>
         <div className="animate-bounce-coin1 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-1.webp"
@@ -26,7 +25,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="226px"
           />
         </div>
-      </ParallaxWrapper>
+      </div>
     </div>
     <div
       className={cn(
@@ -34,7 +33,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
         classes?.token2
       )}
     >
-      <ParallaxWrapper parallaxDirection="left">
+      <div>
         <div className="animate-bounce-coin2 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-2.webp"
@@ -45,12 +44,12 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="226px"
           />
         </div>
-      </ParallaxWrapper>
+      </div>
     </div>
     <div
       className={cn('absolute bottom-[-500px] left-[calc(50%-100px)] w-[246px]', classes?.token3)}
     >
-      <ParallaxWrapper parallaxDirection="down">
+      <div>
         <div className="animate-bounce-coin3 transition-fade">
           <Image
             src="/img/compete-and-earn/animated/token-3.webp"
@@ -61,7 +60,7 @@ const BouncingNFTL = ({ classes }: ComponentProps): React.ReactNode => (
             sizes="246px"
           />
         </div>
-      </ParallaxWrapper>
+      </div>
     </div>
   </>
 )

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1378,6 +1378,20 @@ describe('web marketing page boundary contract', () => {
 })
 
 describe('web marketing image sizing contract', () => {
+  it('keeps decorative homepage coins out of the client scroll graph', () => {
+    const homeSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
+    const bouncingNftlSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/BouncingNFTL/index.tsx'),
+      'utf8'
+    )
+
+    expect(homeSource).not.toContain("from '@nl/ui/custom/parallax-wrapper'")
+    expect(bouncingNftlSource).not.toContain("from '@nl/ui/custom/parallax-wrapper'")
+    expect(bouncingNftlSource).toContain('animate-bounce-coin1')
+    expect(bouncingNftlSource).toContain('animate-bounce-coin2')
+    expect(bouncingNftlSource).toContain('animate-bounce-coin3')
+  })
+
   it('uses rendered-width image hints for the home page artwork', () => {
     const homeSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
     const bouncingNftlSource = readFileSync(


### PR DESCRIPTION
## Summary
- remove the homepage decorative coin parallax client boundary and global scroll listener
- preserve the existing DOM wrappers, image sizing, fade effects, bounce animations, layout, and theme styling
- add a route contract preventing the runtime from returning to the homepage client graph

## Validation
- `bun test 'apps/web/src/app/(main)/page.test.tsx'`
- `bun test test/contract/route-surface.test.ts`
- `bun --filter web test`
- `bun --filter web lint`
- `bun --filter web type-check`
- `bun --filter web build`
- `bunx prettier --check ...`
- `git diff --check`
