### PR TITLE
perf(app): keep public navigation mostly server-rendered

### DIFF
--- a/apps/app/src/components/providers/PublicActiveNavLink.tsx
+++ b/apps/app/src/components/providers/PublicActiveNavLink.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+
+import { cn } from '@nl/ui/utils'
+
+interface PublicActiveNavLinkProps extends Omit<LinkProps, 'href'> {
+  children: ReactNode
+  href: string
+  className?: string
+}
+
+export default function PublicActiveNavLink({
+  children,
+  className,
+  href,
+  ...props
+}: PublicActiveNavLinkProps) {
+  const pathname = usePathname()
+  const isSelected = pathname === href
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'mb-0.5 flex items-start gap-2 rounded-md border border-transparent bg-transparent px-2 py-2 text-left text-sidebar-foreground transition-colors hover:border-purple hover:bg-muted',
+        isSelected && 'border-purple bg-muted font-bold',
+        className
+      )}
+      aria-current={isSelected ? 'page' : undefined}
+      {...props}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/apps/app/src/components/providers/PublicMobileNavigation.tsx
+++ b/apps/app/src/components/providers/PublicMobileNavigation.tsx
@@ -1,16 +1,18 @@
 'use client'
 
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@nl/ui/base/sheet'
+import type { ReactNode } from 'react'
 
 import LogoSection from '@/app/_layout/_MainLayout/_LogoSection'
-import PublicNavLinks from './PublicNavLinks'
 
 interface PublicMobileNavigationProps {
+  children: ReactNode
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
 export default function PublicMobileNavigation({
+  children,
   open,
   onOpenChange,
 }: PublicMobileNavigationProps) {
@@ -28,8 +30,14 @@ export default function PublicMobileNavigation({
           </SheetTitle>
           <SheetDescription className="sr-only">Navigate through the public app</SheetDescription>
         </SheetHeader>
-        <nav aria-label="Primary navigation" className="overflow-y-auto px-4">
-          <PublicNavLinks onNavigate={() => onOpenChange(false)} />
+        <nav
+          aria-label="Primary navigation"
+          className="overflow-y-auto px-4"
+          onClick={(event) => {
+            if ((event.target as HTMLElement).closest('a')) onOpenChange(false)
+          }}
+        >
+          {children}
         </nav>
       </SheetContent>
     </Sheet>

--- a/apps/app/src/components/providers/PublicMobileNavigationTrigger.tsx
+++ b/apps/app/src/components/providers/PublicMobileNavigationTrigger.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import { Menu } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useState } from 'react'
 
 import { IconButton } from '@nl/ui/base/icon-button'
@@ -10,7 +11,7 @@ const PublicMobileNavigation = dynamic(() => import('./PublicMobileNavigation'),
   ssr: false,
 })
 
-export default function PublicMobileNavigationTrigger() {
+export default function PublicMobileNavigationTrigger({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false)
 
   return (
@@ -27,7 +28,11 @@ export default function PublicMobileNavigationTrigger() {
       >
         <Menu aria-hidden="true" absoluteStrokeWidth size={24} />
       </IconButton>
-      {open ? <PublicMobileNavigation open={open} onOpenChange={setOpen} /> : null}
+      {open ? (
+        <PublicMobileNavigation open={open} onOpenChange={setOpen}>
+          {children}
+        </PublicMobileNavigation>
+      ) : null}
     </>
   )
 }

--- a/apps/app/src/components/providers/PublicNavLinks.test.tsx
+++ b/apps/app/src/components/providers/PublicNavLinks.test.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps, PropsWithChildren } from 'react'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+describe('public navigation links', () => {
+  let PublicNavLinks: typeof import('./PublicNavLinks').default
+
+  beforeEach(async () => {
+    mock.module('next/navigation', () => ({
+      usePathname: () => '/degens',
+    }))
+    mock.module('next/link', () => ({
+      default: ({ children, href, ...props }: PropsWithChildren<{ href: string }>) => (
+        <a href={href} {...(props as ComponentProps<'a'>)}>
+          {children}
+        </a>
+      ),
+    }))
+
+    const navLinksModule = await import('./PublicNavLinks')
+    PublicNavLinks = navLinksModule.default
+  })
+
+  it('renders the static menu with an accessible active-page state', () => {
+    render(<PublicNavLinks />)
+
+    const degensLink = screen.getByRole('link', { name: 'DEGENs' })
+    expect(degensLink.getAttribute('href')).toBe('/degens')
+    expect(degensLink.getAttribute('aria-current')).toBe('page')
+    expect(degensLink.className).toContain('font-bold')
+    expect(screen.getByRole('link', { name: 'Games' }).getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/apps/app/src/components/providers/PublicNavLinks.tsx
+++ b/apps/app/src/components/providers/PublicNavLinks.tsx
@@ -1,17 +1,8 @@
-'use client'
-
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 import type { LucideIcon } from 'lucide-react'
 import { Cat, Dot, Gamepad, ListOrdered, Sparkles } from 'lucide-react'
 
-import { cn } from '@nl/ui/utils'
-
 import { PublicItems } from '@/constants/menu-items'
-
-interface PublicNavLinksProps {
-  onNavigate?: () => void
-}
+import PublicActiveNavLink from './PublicActiveNavLink'
 
 const publicLinks = PublicItems.items.flatMap((item) =>
   item.type === 'group' ? (item.children ?? []) : []
@@ -32,36 +23,21 @@ function PublicNavIcon({ name }: { name?: string }) {
   return <IconComponent aria-hidden="true" absoluteStrokeWidth size={24} strokeWidth={1.5} />
 }
 
-export default function PublicNavLinks({ onNavigate }: PublicNavLinksProps) {
-  const pathname = usePathname()
-
+export default function PublicNavLinks() {
   return (
     <>
       <ul className="m-0 list-none p-0">
         {publicLinks.map((item) => {
           if (item.type !== 'item' || !item.url) return null
 
-          const isSelected = pathname === item.url
-          const linkClass = cn(
-            'mb-0.5 flex items-start gap-2 rounded-md border border-transparent bg-transparent px-2 py-2 text-left text-sidebar-foreground transition-colors hover:border-purple hover:bg-muted',
-            isSelected && 'border-purple bg-muted'
-          )
-
           return (
             <li key={item.id || item.url}>
-              <Link
-                href={item.url}
-                className={linkClass}
-                aria-current={isSelected ? 'page' : undefined}
-                onClick={onNavigate}
-              >
+              <PublicActiveNavLink href={item.url}>
                 <span className="my-auto min-w-9">
                   <PublicNavIcon name={item.icon} />
                 </span>
-                <span className={cn('flex-1 text-base', isSelected ? 'font-bold' : 'font-normal')}>
-                  {item.title}
-                </span>
-              </Link>
+                <span className="flex-1 text-base">{item.title}</span>
+              </PublicActiveNavLink>
             </li>
           )
         })}

--- a/apps/app/src/components/providers/PublicNavigation.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.tsx
@@ -31,7 +31,9 @@ export default function PublicNavigation({ children }: PropsWithChildren) {
                 <LogoSection />
               </div>
               <PublicDesktopSidebarToggle />
-              <PublicMobileNavigationTrigger />
+              <PublicMobileNavigationTrigger>
+                <PublicNavLinks />
+              </PublicMobileNavigationTrigger>
             </div>
             <div className="hidden items-center justify-between gap-4 lg:flex">
               {pages.map((page) => (

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -301,6 +301,7 @@ const publicMobileNavigationTrigger =
 const publicIconButton = 'packages/ui/src/components/base/icon-button.tsx'
 const publicMainContent = 'apps/app/src/components/providers/PublicMainContent.tsx'
 const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
+const publicActiveNavLink = 'apps/app/src/components/providers/PublicActiveNavLink.tsx'
 const smashersBackButton = 'apps/smashers/src/components/Header/BackButton/index.tsx'
 const verificationPage = 'apps/app/src/app/verification/page.tsx'
 const verificationLayout = 'apps/app/src/app/verification/layout.tsx'
@@ -767,6 +768,7 @@ describe('public app shell contract', () => {
     )
     const mainContentSource = readFileSync(join(process.cwd(), publicMainContent), 'utf8')
     const linksSource = readFileSync(join(process.cwd(), publicNavLinks), 'utf8')
+    const activeLinkSource = readFileSync(join(process.cwd(), publicActiveNavLink), 'utf8')
     const iconButtonSource = readFileSync(join(process.cwd(), publicIconButton), 'utf8')
 
     expect(navigationSource).not.toContain("'use client'")
@@ -789,9 +791,15 @@ describe('public app shell contract', () => {
     expect(mobileSource).toContain('<SheetTitle')
     expect(mobileSource).toContain('<SheetDescription')
     expect(mobileSource).toContain('id="public-mobile-navigation"')
+    expect(mobileSource).toContain('children')
+    expect(mobileSource).toContain("closest('a')")
+    expect(linksSource).not.toContain("'use client'")
     expect(linksSource).not.toContain("from '@nl/ui/base/icon'")
     expect(linksSource).toContain("from 'lucide-react'")
-    expect(linksSource).toContain("aria-current={isSelected ? 'page' : undefined}")
+    expect(linksSource).toContain("from './PublicActiveNavLink'")
+    expect(activeLinkSource).toContain("'use client'")
+    expect(activeLinkSource).toContain('usePathname')
+    expect(activeLinkSource).toContain("aria-current={isSelected ? 'page' : undefined}")
     expect(iconButtonSource).toContain("from './button-variants'")
     expect(iconButtonSource).not.toContain("from 'radix-ui'")
     expect(iconButtonSource).toContain("type = 'button'")


### PR DESCRIPTION
## Summary
- keep the public navigation menu, icon map, and menu configuration in the server graph
- isolate only pathname-based active styling in a small client link component
- pass the server-rendered links through the deferred mobile Sheet while preserving accessible close behavior and theme classes

## Measured result
The public app route manifest drops the eager `PublicNavLinks` client module and its menu/icon graph. The remaining client modules are limited to the active-link island, shell toggles, main-content route wrapper, deferred mobile trigger, and analytics.

## Validation
- `bun --filter app test` (168 passed)
- `bun --filter app lint`
- `bun --filter app type-check`
- `bun --filter app build`
- `bun test test/contract/route-surface.test.ts` (181 passed)
- focused `PublicNavLinks` test
- `bunx prettier --check ...`
- `git diff --check`
