### PR TITLE
perf(ui): share console visibility observer

### DIFF
--- a/packages/ui/src/components/custom/console-game/console-game.test.tsx
+++ b/packages/ui/src/components/custom/console-game/console-game.test.tsx
@@ -7,10 +7,6 @@ mock.module('next/image', () => ({
 mock.module('@nl/ui/custom/parallax-wrapper', () => ({
   ParallaxWrapper: ({ children }: React.PropsWithChildren) => <>{children}</>,
 }))
-mock.module('@nl/ui/hooks/useOnScreen', () => ({
-  useOnScreen: () => true,
-}))
-
 describe('ConsoleGame', () => {
   let ConsoleGame: typeof import('./index').ConsoleGame
 
@@ -25,5 +21,19 @@ describe('ConsoleGame', () => {
 
     expect(image?.getAttribute('loading')).toBe('lazy')
     expect(video?.getAttribute('preload')).toBe('metadata')
+  })
+
+  it('uses the parent visibility state to pause outside the viewport', () => {
+    const { container, rerender } = render(
+      <ConsoleGame isNearViewport={false} src="/video/example.mp4" />
+    )
+    const video = container.querySelector('video')
+
+    expect(video?.getAttribute('preload')).toBe('none')
+    expect(video?.hasAttribute('autoplay')).toBe(false)
+
+    rerender(<ConsoleGame isNearViewport src="/video/example.mp4" />)
+    expect(video?.getAttribute('preload')).toBe('metadata')
+    expect(video?.hasAttribute('autoplay')).toBe(true)
   })
 })

--- a/packages/ui/src/components/custom/console-game/index.tsx
+++ b/packages/ui/src/components/custom/console-game/index.tsx
@@ -4,16 +4,21 @@ import Image from 'next/image'
 import { memo, useRef, useState, useCallback, useEffect } from 'react'
 import { Button } from '@nl/ui/base/button'
 import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
-import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 import { cn } from '@nl/ui/utils'
 
 import styles from './index.module.css'
 
-export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
-  const rootRef = useRef<HTMLDivElement>(null)
+export interface ConsoleGameProps {
+  isNearViewport?: boolean
+  src: string
+}
+
+export const ConsoleGame = memo(function ConsoleGame({
+  isNearViewport = true,
+  src,
+}: ConsoleGameProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const [isPlaying, setIsPlaying] = useState(false)
-  const isNearViewport = useOnScreen(rootRef, '200px')
 
   const togglePlay = useCallback(() => {
     if (!videoRef.current) return
@@ -42,7 +47,7 @@ export const ConsoleGame = memo(function ConsoleGame({ src }: { src: string }) {
   }, [isNearViewport])
 
   return (
-    <div ref={rootRef} className="relative overflow-hidden">
+    <div className="relative overflow-hidden">
       <div
         style={{ position: 'relative', display: 'flex', flexGrow: 1 }}
         className="md:animation-hidden"

--- a/packages/ui/src/components/custom/deferred-console-game/index.tsx
+++ b/packages/ui/src/components/custom/deferred-console-game/index.tsx
@@ -5,11 +5,13 @@ import type { ComponentType } from 'react'
 import { Skeleton } from '@nl/ui/base/skeleton'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
+import type { ConsoleGameProps } from '../console-game'
+
 interface DeferredConsoleGameProps {
   src: string
 }
 
-type ConsoleGameComponent = ComponentType<DeferredConsoleGameProps>
+type ConsoleGameComponent = ComponentType<ConsoleGameProps>
 
 const DeferredConsoleGame = ({ src }: DeferredConsoleGameProps) => {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -32,7 +34,7 @@ const DeferredConsoleGame = ({ src }: DeferredConsoleGameProps) => {
   return (
     <div ref={rootRef} className="relative aspect-video overflow-hidden">
       {ConsoleGame ? (
-        <ConsoleGame src={src} />
+        <ConsoleGame isNearViewport={isNearViewport} src={src} />
       ) : (
         <Skeleton
           role="img"

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -241,6 +241,9 @@ const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
 const sharedWebMobileTrigger = 'packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx'
+const sharedConsoleGame = 'packages/ui/src/components/custom/console-game/index.tsx'
+const sharedDeferredConsoleGame =
+  'packages/ui/src/components/custom/deferred-console-game/index.tsx'
 const webCommunityPage = 'apps/web/src/app/(main)/community/page.tsx'
 const webTeamPage = 'apps/web/src/app/(main)/team/page.tsx'
 const webCarousel = 'apps/web/src/components/Carousel/index.tsx'
@@ -1258,6 +1261,15 @@ describe('shared console game loading contract', () => {
     expect(smashersSource).toContain('src="/video/smashers.mp4"')
     expect(webSource).toContain('src="/video/smashers.mp4"')
     expect(smashersSource).not.toContain('smashers-960p.mp4')
+  })
+
+  it('shares one viewport observer between the deferred wrapper and loaded player', () => {
+    const consoleGameSource = readFileSync(join(process.cwd(), sharedConsoleGame), 'utf8')
+    const deferredSource = readFileSync(join(process.cwd(), sharedDeferredConsoleGame), 'utf8')
+
+    expect(consoleGameSource).not.toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(consoleGameSource).toContain('isNearViewport?: boolean')
+    expect(deferredSource).toContain('isNearViewport={isNearViewport}')
   })
 })
 


### PR DESCRIPTION
## Summary
- share the deferred console game viewport state with the loaded player
- remove the duplicate IntersectionObserver and preserve autoplay/preload behavior
- add source and component regression coverage

## Validation
- bun --filter @nl/ui test
- bun test test/contract/route-surface.test.ts
- bun --filter web build
- bun --filter smashers build

Targets staging; ready-for-review will be set after local validation.