### PR TITLE
perf(app): keep degen browser shell responsive

### DIFF
--- a/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
+++ b/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 
@@ -29,10 +28,9 @@ import DegensTopNav from '@/components/extended/DegensTopNav'
 import DeferredDegenCard from '@/components/providers/DeferredDegenCard'
 import DeferredDegensFilter from '@/components/providers/DeferredDegensFilter'
 import DeferredPublicDegenDialog from '@/components/providers/DeferredPublicDegenDialog'
+import DegenSearchParamsBoundary from './DegenSearchParamsBoundary'
 
-const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'), {
-  ssr: false,
-})
+const CollapsibleSidebarLayout = dynamic(() => import('@/app/_layout/_CollapsibleSidebarLayout'))
 
 const AllDegensPage = (): React.ReactNode => {
   const [degens, setDegens] = useState<Degen[]>([])
@@ -44,8 +42,8 @@ const AllDegensPage = (): React.ReactNode => {
   const [filteredData, setFilteredData] = useState<Degen[]>([])
   const [selectedDegen, setSelectedDegen] = useState<Degen>()
   const [isDegenModalOpen, setIsDegenModalOpen] = useState<boolean>(false)
-  const searchParams = useSearchParams()
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined)
+  const [searchParams, setSearchParams] = useState<Record<string, string>>({})
   const [layoutMode, setLayoutMode] = useState<string>('gridView')
 
   const { data } = useFetch<{ [id: number]: Degen }>(
@@ -71,7 +69,7 @@ const AllDegensPage = (): React.ReactNode => {
     setDefaultValues(getDefaultFilterValueFromData(originalDegens))
     // Filter out rent disabled degens in Feed
     setDegens(originalDegens)
-    const params = Object.fromEntries(searchParams.entries())
+    const params = searchParams
     let newDegens = originalDegens
     if (hasEntries(params)) {
       if (params.searchTerm) setSearchTerm(params.searchTerm)
@@ -88,7 +86,11 @@ const AllDegensPage = (): React.ReactNode => {
       setDegens([])
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [originalDegens])
+  }, [originalDegens, searchParams])
+
+  const handleSearchParamsChange = useCallback((nextSearchParams: Record<string, string>) => {
+    setSearchParams(nextSearchParams)
+  }, [])
 
   const handleChangeSearchTerm: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> = (
     e
@@ -253,6 +255,9 @@ const AllDegensPage = (): React.ReactNode => {
 
   return (
     <>
+      <Suspense fallback={null}>
+        <DegenSearchParamsBoundary onChange={handleSearchParamsChange} />
+      </Suspense>
       <div className="flex h-full flex-col justify-start align-top gap-4 pl-2">
         <div className="pl-4 pr-6">
           <DegensTopNav

--- a/apps/app/src/app/(public-routes)/degens/DegenRoute.tsx
+++ b/apps/app/src/app/(public-routes)/degens/DegenRoute.tsx
@@ -4,19 +4,35 @@ import dynamic from 'next/dynamic'
 
 import { Skeleton } from '@nl/ui/base/skeleton'
 
-const AllDegensPage = dynamic(() => import('./AllDegensPage'), {
-  ssr: false,
-  loading: () => (
+const loadingCards = Array.from({ length: 12 }, (_, index) => index)
+
+function DegenRouteLoading() {
+  return (
     <div
-      className="flex min-h-[40vh] items-center justify-center p-6"
+      className="flex min-h-[40vh] flex-col gap-4 p-6"
       role="status"
       aria-live="polite"
       aria-busy="true"
     >
       <span className="sr-only">Loading degens</span>
-      <Skeleton aria-hidden="true" className="h-8 w-8 rounded-full" />
+      <div aria-hidden="true" className="flex flex-col gap-2 sm:flex-row">
+        <Skeleton className="h-8 flex-1" />
+        <div className="flex gap-2">
+          <Skeleton className="h-8 w-36" />
+          <Skeleton className="h-8 w-16" />
+        </div>
+      </div>
+      <div aria-hidden="true" className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {loadingCards.map((index) => (
+          <Skeleton key={index} className="aspect-square w-full rounded-md" />
+        ))}
+      </div>
     </div>
-  ),
+  )
+}
+
+const AllDegensPage = dynamic(() => import('./AllDegensPage'), {
+  loading: () => <DegenRouteLoading />,
 })
 
 export default function DegenRoute() {

--- a/apps/app/src/app/(public-routes)/degens/DegenSearchParamsBoundary.tsx
+++ b/apps/app/src/app/(public-routes)/degens/DegenSearchParamsBoundary.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+
+interface DegenSearchParamsBoundaryProps {
+  onChange: (searchParams: Record<string, string>) => void
+}
+
+export default function DegenSearchParamsBoundary({
+  onChange,
+}: DegenSearchParamsBoundaryProps): null {
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    onChange(Object.fromEntries(searchParams.entries()))
+  }, [onChange, searchParams])
+
+  return null
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -293,6 +293,8 @@ const deferredLeaderboards = 'apps/app/src/components/providers/DeferredLeaderbo
 const degensPage = 'apps/app/src/app/(public-routes)/degens/page.tsx'
 const degensRouteBoundary = 'apps/app/src/app/(public-routes)/degens/DegenRoute.tsx'
 const degensClientPage = 'apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx'
+const degensSearchParamsBoundary =
+  'apps/app/src/app/(public-routes)/degens/DegenSearchParamsBoundary.tsx'
 const degensTopNav = 'apps/app/src/components/extended/DegensTopNav/index.tsx'
 const publicMainLayout = 'apps/app/src/app/_layout/_PublicMainLayout/index.tsx'
 const publicNavigation = 'apps/app/src/components/providers/PublicNavigation.tsx'
@@ -348,7 +350,7 @@ describe('public leaderboard loading contract', () => {
 })
 
 describe('public degen loading contract', () => {
-  it('keeps the interactive degen browser out of the route entry chunk', () => {
+  it('keeps the interactive degen browser split while server-rendering its shell', () => {
     const pageSource = readFileSync(join(process.cwd(), degensPage), 'utf8')
     const routeBoundarySource = readFileSync(join(process.cwd(), degensRouteBoundary), 'utf8')
     const clientPageSource = readFileSync(join(process.cwd(), degensClientPage), 'utf8')
@@ -357,13 +359,21 @@ describe('public degen loading contract', () => {
     expect(pageSource).not.toContain("'use client'")
     expect(pageSource).toContain("from './DegenRoute'")
     expect(routeBoundarySource).toContain("dynamic(() => import('./AllDegensPage')")
-    expect(routeBoundarySource).toContain('ssr: false')
-    expect(routeBoundarySource).toContain('role="status"')
-    expect(routeBoundarySource).toContain('aria-live="polite"')
-    expect(routeBoundarySource).toContain('aria-busy="true"')
+    expect(routeBoundarySource).not.toContain('ssr: false')
     expect(routeBoundarySource).toContain("from '@nl/ui/base/skeleton'")
     expect(clientPageSource).toContain("'use client'")
     expect(clientPageSource).toContain("from 'lucide-react'")
+    expect(clientPageSource).toContain('<Suspense fallback={null}>')
+    expect(clientPageSource).not.toContain('ssr: false')
+    expect(routeBoundarySource).toContain('role="status"')
+    expect(routeBoundarySource).toContain('aria-live="polite"')
+    expect(routeBoundarySource).toContain('aria-busy="true"')
+    const searchParamsBoundarySource = readFileSync(
+      join(process.cwd(), degensSearchParamsBoundary),
+      'utf8'
+    )
+    expect(searchParamsBoundarySource).toContain('useSearchParams')
+    expect(searchParamsBoundarySource).toContain('Object.fromEntries')
     expect(clientPageSource).not.toContain("from '@nl/ui/base/icon'")
     expect(topNavSource).toContain("from 'lucide-react'")
     expect(topNavSource).not.toContain("from '@nl/ui/base/icon'")


### PR DESCRIPTION
## Summary
- keep the public DEGEN browser statically delivered while allowing its interactive island to render with SSR
- isolate `useSearchParams` behind a Suspense boundary so the route stays buildable and static
- replace the spinner-only loading state with a themed, accessible toolbar and card skeleton shell

## Why
The previous route disabled SSR for the interactive page and showed only a centered spinner during the first load. This keeps the interactive graph code-split while improving the first viewport and preserving the existing shadcn theme/accessibility contracts.

## Validation
- `bun test test/contract/route-surface.test.ts` — 183 passed
- `bun --filter app test` — 168 passed
- `bun --filter app lint` — passed
- `bun --filter app type-check` — passed
- `bun --filter app build` — passed; `/degens` remains static
- initial route entry: 5 JS files, 97.5 KB total on candidate vs 97.0 KB baseline
- first route HTML main shell: 1.87 KB with 12 skeleton cards vs 426-byte spinner-only baseline
