### PR TITLE
perf(app): lazy-load leaderboard datasets

### DIFF
--- a/apps/app/src/constants/leaderboards/data.test.ts
+++ b/apps/app/src/constants/leaderboards/data.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test'
+
+import { loadLeaderboard } from './data'
+
+describe('leaderboard data loader', () => {
+  it.each([
+    ['crypto_winter', 'score'],
+    ['nftl_burner', 'burnings'],
+    ['nifty_smashers', 'kills'],
+    ['wen_game', 'score'],
+  ])('loads the %s dataset on demand', async (gameType, scoreType) => {
+    const leaderboard = await loadLeaderboard(gameType)
+
+    expect(leaderboard?.[scoreType]).toBeArray()
+    expect(leaderboard?.[scoreType]?.length).toBeGreaterThan(0)
+  })
+
+  it('does not load a dataset for an unknown game', async () => {
+    await expect(loadLeaderboard('unknown')).resolves.toBeUndefined()
+  })
+})

--- a/apps/app/src/constants/leaderboards/data.ts
+++ b/apps/app/src/constants/leaderboards/data.ts
@@ -1,8 +1,3 @@
-import { SMASHERS_LEADERBOARDS } from './leaderboard-smashers'
-import { WEN_GAME_LEADERBOARDS } from './leaderboard-wen-game'
-import { CRYPTO_WINTER_LEADERBOARDS } from './leaderboard-crypto-winter'
-import { MT_GAWX_LEADERBOARDS } from './leaderboard-mt-gawx'
-
 // Keep the archived datasets server-side. The browser only needs the selected page of rows.
 export type LeaderboardRow = {
   rank: number
@@ -11,9 +6,19 @@ export type LeaderboardRow = {
   stats: Record<string, string>
 }
 
-export const LEADERBOARDS: Record<string, Record<string, LeaderboardRow[]>> = {
-  crypto_winter: CRYPTO_WINTER_LEADERBOARDS,
-  nftl_burner: MT_GAWX_LEADERBOARDS,
-  nifty_smashers: SMASHERS_LEADERBOARDS,
-  wen_game: WEN_GAME_LEADERBOARDS,
+type LeaderboardData = Record<string, LeaderboardRow[]>
+
+export const loadLeaderboard = async (gameType: string): Promise<LeaderboardData | undefined> => {
+  switch (gameType) {
+    case 'crypto_winter':
+      return (await import('./leaderboard-crypto-winter')).CRYPTO_WINTER_LEADERBOARDS
+    case 'nftl_burner':
+      return (await import('./leaderboard-mt-gawx')).MT_GAWX_LEADERBOARDS
+    case 'nifty_smashers':
+      return (await import('./leaderboard-smashers')).SMASHERS_LEADERBOARDS
+    case 'wen_game':
+      return (await import('./leaderboard-wen-game')).WEN_GAME_LEADERBOARDS
+    default:
+      return undefined
+  }
 }

--- a/apps/app/src/utils/leaderboard-server.ts
+++ b/apps/app/src/utils/leaderboard-server.ts
@@ -1,5 +1,5 @@
 import { LEADERBOARD_USERNAMES_API_URL } from '@/constants/url'
-import { LEADERBOARDS, type LeaderboardRow } from '@/constants/leaderboards/data'
+import { loadLeaderboard, type LeaderboardRow } from '@/constants/leaderboards/data'
 
 type UserName = { name?: string }
 type UserNames = Record<string, UserName> | UserName[]
@@ -26,7 +26,7 @@ export const fetchScores = async (
   count: number,
   offset: number
 ): Promise<LeaderboardResponse> => {
-  const leaderboard = LEADERBOARDS[gameType]?.[scoreType]
+  const leaderboard = (await loadLeaderboard(gameType))?.[scoreType]
 
   if (!leaderboard || !Array.isArray(leaderboard)) {
     throw new Error('Unknown leaderboard')

--- a/apps/app/src/utils/leaderboard.test.ts
+++ b/apps/app/src/utils/leaderboard.test.ts
@@ -20,15 +20,16 @@ beforeEach(async () => {
       user_id: userId,
       stats: { earnings: '12.5', matches: '5', kills: '3', ...stats },
     })
-    return {
-      LEADERBOARDS: {
-        smashers: {
-          win_rate: [row('0.75', 'user-1')],
-          earnings: [row('99.1', 'user-2')],
-          kills: [row('11', 'user-3')],
-          score: [row('4', 'user-4', { earnings: '', matches: '' })],
-        },
+    const leaderboards: Record<string, Record<string, ReturnType<typeof row>[]>> = {
+      smashers: {
+        win_rate: [row('0.75', 'user-1')],
+        earnings: [row('99.1', 'user-2')],
+        kills: [row('11', 'user-3')],
+        score: [row('4', 'user-4', { earnings: '', matches: '' })],
       },
+    }
+    return {
+      loadLeaderboard: async (gameType: string) => leaderboards[gameType],
     }
   })
 


### PR DESCRIPTION
## What changed
- load only the selected archived leaderboard dataset when the API route handles a request
- keep the browser-facing pagination and score normalization behavior unchanged
- add coverage for each supported game and unknown-game handling

## Why
The leaderboard server utility eagerly imported roughly 80k lines of archived rows for every request and build graph. The loader now creates game-scoped server chunks, reducing eager route evaluation and memory pressure while preserving the existing API contract.

## Validation
- `bun --filter app test src/constants/leaderboards/data.test.ts src/utils/leaderboard.test.ts` — 14 passed
- `bun --filter app type-check` — passed
- `bun --filter app lint` — passed
- `bunx prettier --check apps/app/src/constants/leaderboards/data.ts apps/app/src/constants/leaderboards/data.test.ts apps/app/src/utils/leaderboard-server.ts apps/app/src/utils/leaderboard.test.ts` — passed
- `env NEXTAUTH_SECRET=local-validation-secret-32-characters bun --filter app build` — passed
- draft PR hosted validation intentionally skipped by repository cost controls
