### PR TITLE
perf(shared): preserve deferred Sentry capture

### DIFF
--- a/apps/app/src/app/global-error.tsx
+++ b/apps/app/src/app/global-error.tsx
@@ -3,10 +3,12 @@
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
+import { sentryOptions } from '@/constants/sentry'
+
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
-      captureException(error)
+      captureException(error, sentryOptions)
     )
   }, [error])
 

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { headerFont } from '@nl/ui/fonts/header'
 import { subheaderFont } from '@nl/ui/fonts/subheader'
 import { cn } from '@nl/ui/utils'
 
+import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
 
 export const metadata: Metadata = {
@@ -70,15 +71,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       className={cn(defaultFont.variable, headerFont.variable, subheaderFont.variable, 'dark')}
     >
       <DeferredAnalytics />
-      <DeferredSentry
-        enabled={process.env.VERCEL_ENV === 'production'}
-        options={{
-          dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
-          sendDefaultPii: true,
-          tracesSampleRate: 0.1,
-          debug: false,
-        }}
-      />
+      <DeferredSentry enabled={process.env.VERCEL_ENV === 'production'} options={sentryOptions} />
 
       <body suppressHydrationWarning>
         {children}

--- a/apps/app/src/constants/sentry.ts
+++ b/apps/app/src/constants/sentry.ts
@@ -1,0 +1,6 @@
+export const sentryOptions = {
+  dsn: 'https://f020bae820a14d61a9f226eb08fcfbb8@o1377979.ingest.us.sentry.io/6689430',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+} as const

--- a/apps/smashers/src/app/global-error.tsx
+++ b/apps/smashers/src/app/global-error.tsx
@@ -3,10 +3,12 @@
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
+import { sentryOptions } from '@/constants/sentry'
+
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
-      captureException(error)
+      captureException(error, sentryOptions)
     )
   }, [error])
 

--- a/apps/smashers/src/app/layout.tsx
+++ b/apps/smashers/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { specialFont } from '@nl/ui/fonts/special'
 import { subheaderFont } from '@nl/ui/fonts/subheader'
 import { cn } from '@nl/ui/utils'
 
+import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
 
 export const metadata: Metadata = {
@@ -91,15 +92,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       )}
     >
       <DeferredAnalytics />
-      <DeferredSentry
-        enabled={process.env.VERCEL_ENV === 'production'}
-        options={{
-          dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
-          sendDefaultPii: true,
-          tracesSampleRate: 0.1,
-          debug: false,
-        }}
-      />
+      <DeferredSentry enabled={process.env.VERCEL_ENV === 'production'} options={sentryOptions} />
 
       <body suppressHydrationWarning>{children}</body>
     </html>

--- a/apps/smashers/src/constants/sentry.ts
+++ b/apps/smashers/src/constants/sentry.ts
@@ -1,0 +1,6 @@
+export const sentryOptions = {
+  dsn: 'https://34e7ae2cd1c7fb58c7aeace4dd19fc3a@o1377979.ingest.us.sentry.io/4506384689659904',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+} as const

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -3,10 +3,12 @@
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
+import { sentryOptions } from '@/constants/sentry'
+
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     void import('@nl/sentry-client/bootstrap').then(({ captureException }) =>
-      captureException(error)
+      captureException(error, sentryOptions)
     )
   }, [error])
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { headerFont } from '@nl/ui/fonts/header'
 import { specialFont } from '@nl/ui/fonts/special'
 import { cn } from '@nl/ui/utils'
 
+import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
 
 export const metadata: Metadata = {
@@ -66,15 +67,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       suppressHydrationWarning
       className={cn(defaultFont.variable, headerFont.variable, specialFont.variable, 'dark')}
     >
-      <DeferredSentry
-        enabled={process.env.VERCEL_ENV === 'production'}
-        options={{
-          dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
-          sendDefaultPii: true,
-          tracesSampleRate: 0.1,
-          debug: false,
-        }}
-      />
+      <DeferredSentry enabled={process.env.VERCEL_ENV === 'production'} options={sentryOptions} />
       <body suppressHydrationWarning>{children}</body>
     </html>
   )

--- a/apps/web/src/constants/sentry.ts
+++ b/apps/web/src/constants/sentry.ts
@@ -1,0 +1,6 @@
+export const sentryOptions = {
+  dsn: 'https://97a944f1560b45018f013090ced577b3@o1377979.ingest.us.sentry.io/4504089815351296',
+  sendDefaultPii: true,
+  tracesSampleRate: 0.1,
+  debug: false,
+} as const

--- a/packages/sentry-client/src/bootstrap.ts
+++ b/packages/sentry-client/src/bootstrap.ts
@@ -1,5 +1,5 @@
 type ClientModule = typeof import('./client')
-type SentryInitOptions = Parameters<(typeof import('@sentry/nextjs'))['init']>[0]
+import type { SentryInitOptions } from './client'
 
 import { registerRouterTransitionCapture, type RouterTransitionArgs } from './router-bridge'
 
@@ -22,7 +22,9 @@ export function scheduleSentryInit(enabled: boolean, options: SentryInitOptions)
     routerCaptureRegistered = true
     registerRouterTransitionCapture((...args: RouterTransitionArgs) => {
       void loadClient()
-        .then(({ captureRouterTransitionStart }) => captureRouterTransitionStart(...args))
+        .then(({ captureRouterTransitionStart, initializeSentry }) =>
+          initializeSentry(options).then(() => captureRouterTransitionStart(...args))
+        )
         .catch(reportClientLoadError)
     })
   }
@@ -40,9 +42,9 @@ export function scheduleSentryInit(enabled: boolean, options: SentryInitOptions)
   }
 }
 
-export function captureException(error: unknown): void {
+export function captureException(error: unknown, options?: SentryInitOptions): void {
   void loadClient()
-    .then(({ captureException: capture }) => capture(error))
+    .then(({ captureException: capture }) => capture(error, options))
     .catch(reportClientLoadError)
 }
 

--- a/packages/sentry-client/src/client.ts
+++ b/packages/sentry-client/src/client.ts
@@ -1,5 +1,5 @@
 type SentryModule = typeof import('@sentry/nextjs')
-type SentryInitOptions = Parameters<SentryModule['init']>[0]
+export type SentryInitOptions = Parameters<SentryModule['init']>[0]
 type RouterTransitionArgs = Parameters<SentryModule['captureRouterTransitionStart']>
 
 let sentryModulePromise: Promise<SentryModule> | undefined
@@ -28,10 +28,9 @@ function getSentryForCapture(): Promise<SentryModule> {
   return sentryInitOptions ? initializeSentry(sentryInitOptions) : loadSentry()
 }
 
-export function captureException(error: unknown): void {
-  void getSentryForCapture()
-    .then(({ captureException: capture }) => capture(error))
-    .catch(reportSentryLoadError)
+export function captureException(error: unknown, options?: SentryInitOptions): void {
+  const sentry = options ? initializeSentry(options) : getSentryForCapture()
+  void sentry.then(({ captureException: capture }) => capture(error)).catch(reportSentryLoadError)
 }
 
 export function captureRouterTransitionStart(...args: RouterTransitionArgs): void {

--- a/packages/sentry-client/src/react.tsx
+++ b/packages/sentry-client/src/react.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 
-type SentryInitOptions = Parameters<(typeof import('@sentry/nextjs'))['init']>[0]
+import type { SentryInitOptions } from './client'
 
 interface DeferredSentryProps {
   enabled: boolean

--- a/packages/sentry-client/src/router-bridge.ts
+++ b/packages/sentry-client/src/router-bridge.ts
@@ -1,6 +1,4 @@
-type SentryModule = typeof import('@sentry/nextjs')
-
-export type RouterTransitionArgs = Parameters<SentryModule['captureRouterTransitionStart']>
+export type RouterTransitionArgs = [href: string, navigationType: string]
 type RouterTransitionCapture = (...args: RouterTransitionArgs) => void
 
 interface RouterTransitionBridge {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1573,6 +1573,7 @@ describe('deferred Sentry client contract', () => {
         expect(source).not.toContain('@nl/sentry-client/bootstrap')
       } else {
         expect(source).toContain("import('@nl/sentry-client/bootstrap')")
+        expect(source).toContain('sentryOptions')
       }
     })
   }


### PR DESCRIPTION
## Summary
- initialize the deferred Sentry client before forwarding queued route transitions
- initialize Sentry before reporting root-layout errors
- share app-specific Sentry options between layouts and global error boundaries
- keep the SDK dynamic and preserve the existing initial bundle boundary

## Validation
- `bun test test/contract/route-surface.test.ts` (183 passed)
- `bun --filter @nl/sentry-client type-check`
- `bun --filter @nl/sentry-client lint`
- `bun --filter web type-check`
- `bun --filter web lint`
- `bun --filter web build`
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun --filter app build`
- `bun --filter smashers type-check`
- `bun --filter smashers lint` (1 existing warning: `NEXT_PHASE` in `turbo.json`)
- `git diff --check`

Hosted validation intentionally remains dormant while this PR is draft.
