### PR TITLE
perf(web): keep desktop navbar server-rendered

### DIFF
--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -156,7 +156,7 @@ describe('Navbar', () => {
     },
   ]
 
-  it('renders active desktop, grouped, external, action, and mobile links', () => {
+  it('renders desktop, grouped, external, action, and mobile links', () => {
     render(
       <Navbar
         navItems={navItems}
@@ -165,9 +165,7 @@ describe('Navbar', () => {
     )
 
     expect(screen.getByRole('img', { name: 'Home' })).not.toBeNull()
-    expect(screen.getAllByRole('link', { name: /About/ })[0]?.getAttribute('data-active')).toBe(
-      'true'
-    )
+    expect(screen.getAllByRole('link', { name: /About/ })[0]?.getAttribute('href')).toBe('/about')
     fireEvent.click(screen.getByText('Products'))
     expect(screen.getAllByRole('link', { name: /Docs/ })[0]?.getAttribute('target')).toBe('_blank')
     expect(screen.getByRole('link', { name: 'Game' })?.getAttribute('rel')).toBe('noreferrer')

--- a/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
+++ b/packages/ui/src/components/custom/navbar/ActiveNavLink.tsx
@@ -3,8 +3,9 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
-import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import { cn } from '@nl/ui/utils'
+
+import { NAV_LINK_CONTENT_CLASS, NavLinkContent } from './NavLinkContent'
 
 export interface ActiveNavLinkProps extends Omit<
   React.ComponentProps<typeof Link>,
@@ -35,21 +36,13 @@ export default function ActiveNavLink({
       data-active={isActive}
       aria-current={isActive ? 'page' : undefined}
       className={cn(
-        'bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 flex flex-col gap-1 rounded-sm px-3 py-2 outline-none transition-colors',
+        NAV_LINK_CONTENT_CLASS,
         isActive && 'bg-primary/40 text-primary-foreground',
         className
       )}
       {...props}
     >
-      <span className="w-full leading-none">
-        {title}
-        {external && <ExternalIcon />}
-      </span>
-      {description && (
-        <span className="w-full text-xs leading-snug text-muted-foreground line-clamp-2">
-          {description}
-        </span>
-      )}
+      <NavLinkContent description={description} external={external} title={title} />
     </Link>
   )
 }

--- a/packages/ui/src/components/custom/navbar/NavLinkContent.tsx
+++ b/packages/ui/src/components/custom/navbar/NavLinkContent.tsx
@@ -1,0 +1,26 @@
+import { ExternalIcon } from '@nl/ui/custom/external-icon'
+
+export const NAV_LINK_CONTENT_CLASS =
+  'bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 flex flex-col gap-1 rounded-sm px-3 py-2 outline-none transition-colors'
+
+interface NavLinkContentProps {
+  description?: string
+  external?: boolean
+  title: string
+}
+
+export function NavLinkContent({ description, external, title }: NavLinkContentProps) {
+  return (
+    <>
+      <span className="w-full leading-none">
+        {title}
+        {external && <ExternalIcon />}
+      </span>
+      {description && (
+        <span className="w-full text-xs leading-snug text-muted-foreground line-clamp-2">
+          {description}
+        </span>
+      )}
+    </>
+  )
+}

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -2,11 +2,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Fragment } from 'react'
 
-import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import { cn } from '@nl/ui/utils'
 
-import ActiveNavLink from './ActiveNavLink'
 import MobileNavTrigger from './MobileNavTrigger'
+import { NAV_LINK_CONTENT_CLASS, NavLinkContent } from './NavLinkContent'
 
 export interface NavPage {
   title: string
@@ -37,10 +36,29 @@ export interface NavbarProps {
 const DESKTOP_LINK_CLASS =
   'inline-flex h-9 w-max items-center justify-center rounded-md bg-transparent px-3 py-2 text-lg font-bold uppercase outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none'
 
+function DesktopNavLink({
+  className,
+  description,
+  external,
+  href,
+  title,
+}: NavPage & { className?: string }) {
+  return (
+    <Link
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer' : undefined}
+      className={cn(NAV_LINK_CONTENT_CLASS, className)}
+    >
+      <NavLinkContent description={description} external={external} title={title} />
+    </Link>
+  )
+}
+
 function ListItem({ page }: { page: NavPage }) {
   return (
     <li>
-      <ActiveNavLink
+      <DesktopNavLink
         className="text-base font-medium"
         description={page.description}
         external={page.external}
@@ -84,7 +102,7 @@ function DropdownMenuItem({ group, pages }: GroupedMenuItemData) {
 function SingleMenuItem({ type: _type, ...page }: SingleMenuItemData) {
   return (
     <li>
-      <ActiveNavLink className={DESKTOP_LINK_CLASS} {...page} />
+      <DesktopNavLink className={DESKTOP_LINK_CLASS} {...page} />
     </li>
   )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -240,6 +240,7 @@ const gltfRouteBoundary =
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
+const sharedWebNavLinkContent = 'packages/ui/src/components/custom/navbar/NavLinkContent.tsx'
 const sharedWebMobileTrigger = 'packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx'
 const sharedConsoleGame = 'packages/ui/src/components/custom/console-game/index.tsx'
 const sharedDeferredConsoleGame =
@@ -1382,15 +1383,25 @@ describe('web public navigation contract', () => {
     const sharedNavbarSource = readFileSync(join(process.cwd(), sharedWebNavbar), 'utf8')
     const mobileTriggerSource = readFileSync(join(process.cwd(), sharedWebMobileTrigger), 'utf8')
     const mobileNavbarSource = readFileSync(join(process.cwd(), sharedWebMobileNavbar), 'utf8')
+    const sharedNavLinkContentSource = readFileSync(
+      join(process.cwd(), sharedWebNavLinkContent),
+      'utf8'
+    )
 
     expect(navbarSource).not.toContain("'use client'")
     expect(navbarSource).toContain("from '@nl/ui/custom/navbar'")
-    expect(sharedNavbarSource).toContain("import ActiveNavLink from './ActiveNavLink'")
+    expect(sharedNavbarSource).not.toContain("import ActiveNavLink from './ActiveNavLink'")
+    expect(sharedNavbarSource).toContain('function DesktopNavLink')
     expect(sharedNavbarSource).toContain('navbar-scroll-frame')
     expect(sharedNavbarSource).not.toContain('useScrollDetection')
     expect(sharedNavbarSource).toContain('<details')
     expect(sharedNavbarSource).not.toContain("from '@nl/ui/base/navigation-menu'")
     expect(sharedNavbarSource).not.toContain("from '@nl/ui/base/sheet'")
+    expect(sharedNavbarSource).not.toContain("from './ActiveNavLink'")
+    expect(mobileNavbarSource).toContain("from './ActiveNavLink'")
+    expect(sharedNavbarSource).toContain("from './NavLinkContent'")
+    expect(sharedNavLinkContentSource).toContain('export function NavLinkContent')
+    expect(sharedNavLinkContentSource).toContain('NAV_LINK_CONTENT_CLASS')
     expect(mobileTriggerSource).toContain("import('./MobileNavMenu')")
     expect(mobileTriggerSource).toContain('ssr: false')
     expect(mobileTriggerSource).toContain("from '@nl/ui/base/icon-button'")


### PR DESCRIPTION
## Summary
- remove the pathname-aware client boundary from desktop marketing navbar links
- keep active-route behavior in the deferred mobile navigation sheet
- share themed/accessibility link markup between desktop and mobile links
- preserve external-link semantics, focus rings, labels, and existing layout/theme classes

## Evidence
- web root first-load JS: 553,421 bytes in the validated build
- `usePathname`/active-link code appears only in the mobile-loaded chunk
- desktop navbar is server-rendered across the shared marketing layouts

## Validation
- `bun --filter @nl/ui type-check`
- `bun --filter @nl/ui lint`
- `bun --filter @nl/ui test` (145 passed)
- `bun test test/contract/route-surface.test.ts` (183 passed)
- `bunx prettier --check ...`
- `env NEXTAUTH_SECRET=local-validation-secret-32-characters VERCEL_ENV=development bun --filter web build`
- `git diff --check`

Hosted validation intentionally remains dormant while this PR is draft.
