### PR TITLE
perf(web): load Sentry only for production builds

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,6 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import type { NextConfig } from 'next'
-import { withSentryConfig } from '@sentry/nextjs'
 
 const ENV = (process.env.VERCEL_ENV as 'production' | 'preview' | undefined) ?? 'development'
 
@@ -93,9 +92,7 @@ const nextConfig: NextConfig = {
   },
 }
 
-// Injected content via Sentry wizard below
-
-export default withSentryConfig(nextConfig, {
+const sentryOptions = {
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
@@ -121,6 +118,16 @@ export default withSentryConfig(nextConfig, {
 
   // Capture React component names to see which component a user clicked on.
   // Route grouping is not worth shipping Sentry's manifest on every initial route.
-  routeManifestInjection: false,
+  routeManifestInjection: false as const,
   webpack: { reactComponentAnnotation: { enabled: true }, treeshake: { removeDebugLogging: true } },
-})
+}
+
+// Sentry's config wrapper pulls its webpack plugin and OpenTelemetry graph into
+// every build. Production is the only environment that uploads source maps,
+// uses the tunnel rewrite, or needs component annotations, so keep preview and
+// development builds on the plain Next config path.
+export default process.env.VERCEL_ENV === 'production'
+  ? import('@sentry/nextjs').then(({ withSentryConfig }) =>
+      withSentryConfig(nextConfig, sentryOptions)
+    )
+  : nextConfig

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/nextjs'
-
 export async function register() {
   if (process.env.VERCEL_ENV !== 'production') {
     return
@@ -12,4 +10,11 @@ export async function register() {
   }
 }
 
-export const onRequestError = Sentry.captureRequestError
+export async function onRequestError(
+  ...args: Parameters<(typeof import('@sentry/nextjs'))['captureRequestError']>
+) {
+  if (process.env.VERCEL_ENV !== 'production') return
+
+  const { captureRequestError } = await import('@sentry/nextjs')
+  return captureRequestError(...args)
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1607,6 +1607,25 @@ describe('deferred Sentry client contract', () => {
   })
 })
 
+describe('production-only Sentry server contract', () => {
+  it('keeps the web build wrapper lazy outside production', () => {
+    const source = readFileSync(join(process.cwd(), 'apps/web/next.config.ts'), 'utf8')
+
+    expect(source).not.toContain("import { withSentryConfig } from '@sentry/nextjs'")
+    expect(source).toContain("import('@sentry/nextjs')")
+    expect(source).toContain("process.env.VERCEL_ENV === 'production'")
+  })
+
+  it('keeps request-error capture lazy and production-gated', () => {
+    const source = readFileSync(join(process.cwd(), 'apps/web/src/instrumentation.ts'), 'utf8')
+
+    expect(source).not.toContain("import * as Sentry from '@sentry/nextjs'")
+    expect(source).toContain("import('@sentry/nextjs')")
+    expect(source).toContain("process.env.VERCEL_ENV !== 'production'")
+    expect(source).toContain('captureRequestError(...args)')
+  })
+})
+
 describe('public route dependency contract', () => {
   it('keeps game description disclosure server-rendered and keyboard accessible', () => {
     const source = readFileSync(join(process.cwd(), gameCard), 'utf8')


### PR DESCRIPTION
## Summary

- keep the web app's Sentry build wrapper and request-error capture on the production path
- avoid loading the Sentry build/runtime graph for preview and development builds
- add route-surface contracts for the production-only boundary

## Why

Preview and development builds had Sentry's webpack/OpenTelemetry integration wired at module load even though source maps and telemetry were disabled outside production. This adds unnecessary compile and startup work to the feedback loop.

## Validation

- `bun --filter web lint`
- `bun --filter web type-check`
- `bun --filter web test` (14 passed)
- `bun test test/contract/route-surface.test.ts test/contract/ci-cost-policy.test.ts test/contract/vercel-build-policy.test.ts` (195 passed)
- `bunx prettier --check ...`
- `git diff --check`
- development build passed (37.6s; compile 13.3s)
- production build passed (43.1s; Sentry production compile hook retained)
- development config/request-error lazy path verified
- production config and emitted Sentry artifact verified

## Rollout

No production monitoring behavior is intentionally changed. The PR remains draft so hosted validation stays skipped until the milestone is ready.
