### PR TITLE
perf(app): keep public URLs registry-free

### DIFF
--- a/apps/app/src/constants/public-urls.ts
+++ b/apps/app/src/constants/public-urls.ts
@@ -1,4 +1,7 @@
 const DEGEN_MAINNET_CONTRACT_ADDRESS = '0x986aea67C7d6A15036e18678065eb663Fc5BE883'
+const NFTL_IMX_CONTRACT_ADDRESS = '0xB0d7e9Ff5fb8E739c4990f7920d8047AcfAe4884'
 
 export const DEGEN_PURCHASE_URL = (id: string | number) =>
   `https://opensea.io/item/ethereum/${DEGEN_MAINNET_CONTRACT_ADDRESS}/${id}`
+
+export const NFTL_PURCHASE_URL = `https://quickswap.exchange/#/analytics/v3/token/${NFTL_IMX_CONTRACT_ADDRESS}`

--- a/apps/app/src/constants/url.ts
+++ b/apps/app/src/constants/url.ts
@@ -1,5 +1,3 @@
-import { immutableZkEvm } from 'viem/chains'
-import { getContractAddress, NFTL_IMX_CONTRACT } from './contracts'
 import {
   BASE_API_URL,
   DEGEN_BASE_API_URL,
@@ -20,7 +18,7 @@ export {
   PROFILE_RENAME_API,
   WALLET_VERIFICATION,
 } from './auth-urls'
-export { DEGEN_PURCHASE_URL } from './public-urls'
+export { DEGEN_PURCHASE_URL, NFTL_PURCHASE_URL } from './public-urls'
 
 const NEXT_PUBLIC_NETWORK = process.env.NEXT_PUBLIC_NETWORK as string
 
@@ -58,12 +56,6 @@ export const GET_PRODUCT = (productId: string, currency: string) =>
 // Leaderboards
 export const GET_RANK_BY_USER_ID_API = `${BASE_API_URL}/GetRank`
 export const LEADERBOARD_USERNAMES_API_URL = `${BASE_API_URL}/profiles/public/profiles`
-
-// QUICKSWAP URL FOR NFTL PURCHASE
-export const NFTL_PURCHASE_URL = `https://quickswap.exchange/#/analytics/v3/token/${getContractAddress(
-  immutableZkEvm.id,
-  NFTL_IMX_CONTRACT
-)}`
 
 // DEGEN URLs
 export const DEGEN_COLLECTION_URL = 'https://opensea.io/collection/niftydegen'

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1627,6 +1627,21 @@ describe('production-only Sentry server contract', () => {
 })
 
 describe('public route dependency contract', () => {
+  it('keeps public purchase URLs independent from the contract registry', () => {
+    const source = readFileSync(join(process.cwd(), 'apps/app/src/constants/url.ts'), 'utf8')
+    const publicUrls = readFileSync(
+      join(process.cwd(), 'apps/app/src/constants/public-urls.ts'),
+      'utf8'
+    )
+
+    expect(source).not.toContain("from './contracts'")
+    expect(source).toContain(
+      "export { DEGEN_PURCHASE_URL, NFTL_PURCHASE_URL } from './public-urls'"
+    )
+    expect(publicUrls).toContain('0xB0d7e9Ff5fb8E739c4990f7920d8047AcfAe4884')
+    expect(publicUrls).toContain('NFTL_PURCHASE_URL')
+  })
+
   it('keeps game description disclosure server-rendered and keyboard accessible', () => {
     const source = readFileSync(join(process.cwd(), gameCard), 'utf8')
 


### PR DESCRIPTION
## Summary
- move the fixed Immutable NFTL purchase URL beside the other public URLs
- remove the deployment/ABI registry import from the shared URL barrel
- add a route contract for the exact public address and export

## Why
The public URL module imported the full contract registry solely to resolve one fixed NFTL address. That registry statically imports four deployment files with large inline ABIs (roughly 77–154 KB each), creating avoidable public-route graph pressure. The runtime contract behavior remains unchanged everywhere it is actually needed.

## Validation
- `bun --filter app type-check`
- `bun --filter app lint`
- `bun test test/contract/route-surface.test.ts` (186 passed, 0 failed)
- Prettier check
- `git diff --check`
- app production build: 21 routes generated successfully
- exact URL preserved: `https://quickswap.exchange/#/analytics/v3/token/0xB0d7e9Ff5fb8E739c4990f7920d8047AcfAe4884`

## Cost control
Draft PR intentionally left in draft. Hosted validation and Vercel preview builds should remain skipped until this milestone is explicitly marked ready.
