### PR TITLE
perf(ui): keep deferred retry controls lightweight

### DIFF
--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -3,9 +3,11 @@
 import type { ComponentType } from 'react'
 import { useEffect, useRef, useState } from 'react'
 
-import { Button } from '@nl/ui/base/button'
 import { Skeleton } from '@nl/ui/base/skeleton'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+import { cn } from '@nl/ui/utils'
+
+import { buttonVariants } from '../../base/button-variants'
 
 interface DeferredSectionProps {
   label: string
@@ -75,13 +77,13 @@ export function DeferredSection({
           role="alert"
         >
           <p>{label} could not be loaded.</p>
-          <Button
+          <button
             type="button"
-            variant="outline"
+            className={cn(buttonVariants({ variant: 'outline' }))}
             onClick={() => setRetryCount((count) => count + 1)}
           >
             Retry
-          </Button>
+          </button>
         </div>
       ) : LoadedSection ? (
         <LoadedSection />

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1301,9 +1301,10 @@ describe('shared below-fold loading contract', () => {
     const source = readFileSync(join(process.cwd(), sharedDeferredSection), 'utf8')
 
     expect(source).toContain("from '@nl/ui/base/skeleton'")
-    expect(source).toContain("from '@nl/ui/base/button'")
-    expect(source).not.toContain("from '../../base/button-variants'")
-    expect(source).toContain('<Button')
+    expect(source).not.toContain("from '@nl/ui/base/button'")
+    expect(source).toContain("from '../../base/button-variants'")
+    expect(source).toContain('<button')
+    expect(source).toContain("buttonVariants({ variant: 'outline' })")
     expect(source).toContain('type="button"')
     expect(source).toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(source).toContain('role="status"')


### PR DESCRIPTION
## Summary
- keep the shared below-fold retry control as a native semantic button
- reuse the existing shadcn button variant classes without importing the Radix-backed Button wrapper
- preserve the existing outline theme, keyboard behavior, retry state, and loading/error accessibility contract

## Why
`DeferredSection` is used by multiple web and Smashers deferred client boundaries. The retry action was the only reason it imported the full `@nl/ui/base/button` wrapper and its Radix Slot dependency. This keeps the shared loader graph smaller while retaining the same visual variant and native button semantics.

## Validation
- `bun --filter '@nl/ui' type-check`
- `bun --filter '@nl/ui' lint`
- `bun --filter '@nl/ui' test` — 145 passed
- `bun --filter web type-check`
- `bun --filter web lint`
- `bun --filter web test` — 14 passed
- `bun test test/contract/route-surface.test.ts` — 186 passed
- `bun --filter web build` — passed; 16 routes generated
- `git diff --check`

Hosted validation intentionally remains deferred while this PR is draft under the repository cost policy.
