### PR TITLE
perf(smashers): defer hero animation after first paint

### DIFF
--- a/apps/smashers/src/components/Header/DeferredHeroBackground.tsx
+++ b/apps/smashers/src/components/Header/DeferredHeroBackground.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import styles from './index.module.css'
+
+const ANIMATED_BACKGROUND = '/img/games/smashers/background.webp'
+const FALLBACK_BACKGROUND = '/img/games/smashers/background.gif'
+const POSTER_BACKGROUND = '/img/games/smashers/smashers-poster.jpg'
+
+type IdleWindow = Window & {
+  cancelIdleCallback?: (handle: number) => void
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number
+}
+
+const scheduleAnimationLoad = (callback: () => void) => {
+  const idleWindow = window as IdleWindow
+
+  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(callback, { timeout: 2_000 })
+
+    return () => idleWindow.cancelIdleCallback?.(handle)
+  }
+
+  const handle = window.setTimeout(callback, 1_200)
+
+  return () => window.clearTimeout(handle)
+}
+
+const DeferredHeroBackground = () => {
+  const [animationReady, setAnimationReady] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    const cancelScheduledLoad = scheduleAnimationLoad(() => {
+      const preload = new window.Image()
+      preload.decoding = 'async'
+      preload.onload = () => {
+        if (mounted) setAnimationReady(true)
+      }
+      preload.onerror = () => {
+        if (mounted) setAnimationReady(true)
+      }
+      preload.src = ANIMATED_BACKGROUND
+    })
+
+    return () => {
+      mounted = false
+      cancelScheduledLoad()
+    }
+  }, [])
+
+  return (
+    <picture className={styles.heroBackground}>
+      {animationReady && <source type="image/webp" srcSet={ANIMATED_BACKGROUND} />}
+      <Image
+        src={animationReady ? FALLBACK_BACKGROUND : POSTER_BACKGROUND}
+        alt=""
+        fill
+        unoptimized
+        sizes="100vw"
+        priority
+        className={styles.heroBackgroundImage}
+        decoding="async"
+      />
+    </picture>
+  )
+}
+
+export default DeferredHeroBackground

--- a/apps/smashers/src/components/Header/index.module.css
+++ b/apps/smashers/src/components/Header/index.module.css
@@ -15,6 +15,9 @@
 }
 
 .heroBackgroundImage {
+  position: absolute;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   object-position: center;
 }

--- a/apps/smashers/src/components/Header/index.tsx
+++ b/apps/smashers/src/components/Header/index.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import ActionButtonsGroup from './ActionButtonsGroup'
+import DeferredHeroBackground from './DeferredHeroBackground'
 import Navbar from './Navbar'
 
 import styles from './index.module.css'
@@ -8,18 +9,7 @@ export type ActiveModal = 'credits' | 'play' | 'trailer' | 'unity' | null
 
 const Header = ({ activeModal }: { activeModal: ActiveModal }) => (
   <div className={styles.hero}>
-    <picture className={styles.heroBackground}>
-      <source type="image/webp" srcSet="/img/games/smashers/background.webp" />
-      <Image
-        src="/img/games/smashers/background.gif"
-        alt=""
-        fill
-        unoptimized
-        loading="eager"
-        sizes="100vw"
-        className={styles.heroBackgroundImage}
-      />
-    </picture>
+    <DeferredHeroBackground />
     <div className="dark-gradient-overlay !h-screen" />
     <div className={styles.heroContainer}>
       <Navbar />

--- a/test/contract/smashers-assets.test.ts
+++ b/test/contract/smashers-assets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { readFileSync, statSync } from 'node:fs'
 
 const headerSource = 'apps/smashers/src/components/Header/index.tsx'
+const deferredBackgroundSource = 'apps/smashers/src/components/Header/DeferredHeroBackground.tsx'
 const gameSectionSource = 'apps/smashers/src/components/GameSection/index.tsx'
 
 const assets = [
@@ -18,10 +19,14 @@ describe('Smashers asset delivery contracts', () => {
 
   it('keeps WebP sources paired with GIF fallbacks in the consuming components', () => {
     const header = readFileSync(headerSource, 'utf8')
+    const deferredBackground = readFileSync(deferredBackgroundSource, 'utf8')
     const gameSection = readFileSync(gameSectionSource, 'utf8')
 
-    expect(header).toContain('background.webp')
-    expect(header).toContain('background.gif')
+    expect(header).toContain('DeferredHeroBackground')
+    expect(deferredBackground).toContain('background.webp')
+    expect(deferredBackground).toContain('background.gif')
+    expect(deferredBackground).toContain('smashers-poster.jpg')
+    expect(deferredBackground).toContain('requestIdleCallback')
     expect(gameSection).toContain('party_modes.webp')
     expect(gameSection).toContain('party_modes.gif')
   })


### PR DESCRIPTION
## Summary
- render the existing small Smashers poster in the initial hero HTML
- defer loading the animated WebP until the browser is idle
- preserve the existing GIF fallback and hero styling

## Measured impact
- initial hero background request: 46,793 bytes instead of 3,890,728 bytes
- critical background payload reduction: approximately 98.8%
- the 3.89 MB animation remains available and is preloaded/swapped in after idle

## Validation
- `bun test test/contract/smashers-assets.test.ts`
- `bun --filter smashers test`
- `bun --filter smashers type-check`
- `bun --filter smashers lint`
- `NEXTAUTH_SECRET=... bun --filter smashers build`
- runtime smoke on port 3101: initial HTML contained `smashers-poster.jpg` and no animation URL
