### PR TITLE
refactor: share app pagination controls

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Pencil } from 'lucide-react'
+import { ChevronDown, ChevronUp, Pencil } from 'lucide-react'
 import { Button } from '@nl/ui/base/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@nl/ui/base/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
@@ -16,6 +16,7 @@ import useLocalStorage from '@/hooks/useLocalStorage'
 
 import DeferredDegenDialog from '@/components/providers/DeferredDegenDialog'
 import DeferredChangeNicknameDialog from '@/components/providers/DeferredChangeNicknameDialog'
+import { PaginationControls } from '@/components/pagination/PaginationControls'
 import { RentalDataGrid } from '@/types/rentalDataGrid'
 
 const RENTAL_COLUMN_VISIBILITY = 'rental-column-visibility-model'
@@ -459,31 +460,18 @@ const MyRentalsDataGrid = ({
             </Select>
             <span className="text-sm text-muted-foreground">Rows per page</span>
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              aria-label="Previous page"
-              onClick={handlePrevPage}
-              disabled={page === 0}
-              className="h-8 w-8 cursor-pointer p-0"
-            >
-              <ChevronLeft aria-hidden="true" absoluteStrokeWidth size={18} strokeWidth={1.5} />
-            </Button>
-            <span className="text-sm">
-              Page {page + 1} of {pageCount}
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              aria-label="Next page"
-              onClick={handleNextPage}
-              disabled={page === pageCount - 1 || sortedRows.length === 0}
-              className="h-8 w-8 cursor-pointer p-0"
-            >
-              <ChevronRight aria-hidden="true" absoluteStrokeWidth size={18} strokeWidth={1.5} />
-            </Button>
-          </div>
+          <PaginationControls
+            hasNext={page < pageCount - 1 && sortedRows.length > 0}
+            hasPrev={page > 0}
+            onClickNext={handleNextPage}
+            onClickPrev={handlePrevPage}
+            pageLabel={
+              <span className="text-sm">
+                Page {page + 1} of {pageCount}
+              </span>
+            }
+            buttonClassName="h-8 w-8 p-0"
+          />
         </div>
       </div>
 

--- a/apps/app/src/components/ResponsiveTable/Pagination.tsx
+++ b/apps/app/src/components/ResponsiveTable/Pagination.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Button } from '@nl/ui/base/button'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@nl/ui/utils'
+
+import { PaginationControls } from '@/components/pagination/PaginationControls'
 
 import type { TablePaginationProps } from './types'
 
@@ -42,29 +42,18 @@ const Pagination: React.FC<PaginationProps> = ({
       )}
       style={TablePaginationProps?.style}
     >
-      <Button
-        variant="ghost"
-        size="icon"
-        className="cursor-pointer"
-        disabled={page === 0}
-        onClick={() => handleChangePage(null, Math.max(0, page - 1))}
-        aria-label="Previous page"
-      >
-        <ChevronLeft aria-hidden="true" absoluteStrokeWidth size={20} strokeWidth={1.5} />
-      </Button>
-      <span className="text-sm text-muted-foreground">
-        Page {page + 1} of {totalPages}
-      </span>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="cursor-pointer"
-        disabled={page + 1 >= totalPages}
-        onClick={() => handleChangePage(null, page + 1)}
-        aria-label="Next page"
-      >
-        <ChevronRight aria-hidden="true" absoluteStrokeWidth size={20} strokeWidth={1.5} />
-      </Button>
+      <PaginationControls
+        hasNext={page + 1 < totalPages}
+        hasPrev={page > 0}
+        onClickNext={() => handleChangePage(null, page + 1)}
+        onClickPrev={() => handleChangePage(null, Math.max(0, page - 1))}
+        pageLabel={
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+        }
+        iconSize={20}
+      />
     </Wrapper>
   )
 }

--- a/apps/app/src/components/pagination/PaginationControls.test.tsx
+++ b/apps/app/src/components/pagination/PaginationControls.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render } from '@testing-library/react'
+import { describe, expect, it, mock } from 'bun:test'
+
+import { PaginationControls } from './PaginationControls'
+
+describe('PaginationControls', () => {
+  it('renders accessible navigation buttons and preserves their callbacks', () => {
+    const onClickPrev = mock()
+    const onClickNext = mock()
+    const { getByRole } = render(
+      <PaginationControls
+        hasNext
+        hasPrev={false}
+        onClickNext={onClickNext}
+        onClickPrev={onClickPrev}
+        pageLabel={<span>Page 1 of 2</span>}
+      />
+    )
+
+    const previous = getByRole('button', { name: 'Previous page' })
+    const next = getByRole('button', { name: 'Next page' })
+    expect(previous.hasAttribute('disabled')).toBe(true)
+    expect(next.hasAttribute('disabled')).toBe(false)
+
+    fireEvent.click(next)
+    expect(onClickNext).toHaveBeenCalledTimes(1)
+    fireEvent.click(previous)
+    expect(onClickPrev).not.toHaveBeenCalled()
+  })
+})

--- a/apps/app/src/components/pagination/PaginationControls.tsx
+++ b/apps/app/src/components/pagination/PaginationControls.tsx
@@ -1,0 +1,49 @@
+import type { MouseEventHandler, ReactNode } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+import { IconButton } from '@nl/ui/base/icon-button'
+import { cn } from '@nl/ui/utils'
+
+interface PaginationControlsProps {
+  hasNext: boolean
+  hasPrev: boolean
+  onClickNext: MouseEventHandler<HTMLButtonElement>
+  onClickPrev: MouseEventHandler<HTMLButtonElement>
+  pageLabel?: ReactNode
+  className?: string
+  buttonClassName?: string
+  iconSize?: number
+}
+
+export function PaginationControls({
+  hasNext,
+  hasPrev,
+  onClickNext,
+  onClickPrev,
+  pageLabel,
+  className,
+  buttonClassName,
+  iconSize = 18,
+}: PaginationControlsProps) {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <IconButton
+        aria-label="Previous page"
+        className={cn('cursor-pointer', buttonClassName)}
+        disabled={!hasPrev}
+        onClick={onClickPrev}
+      >
+        <ChevronLeft aria-hidden="true" absoluteStrokeWidth size={iconSize} strokeWidth={1.5} />
+      </IconButton>
+      {pageLabel}
+      <IconButton
+        aria-label="Next page"
+        className={cn('cursor-pointer', buttonClassName)}
+        disabled={!hasNext}
+        onClick={onClickNext}
+      >
+        <ChevronRight aria-hidden="true" absoluteStrokeWidth size={iconSize} strokeWidth={1.5} />
+      </IconButton>
+    </div>
+  )
+}

--- a/apps/app/src/components/pagination/PaginationIconOnly.tsx
+++ b/apps/app/src/components/pagination/PaginationIconOnly.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@nl/ui/base/button'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { PaginationControls } from './PaginationControls'
 
 export interface PaginationIconOnlyProps {
   hasNext?: boolean
@@ -8,31 +7,18 @@ export interface PaginationIconOnlyProps {
   onClickNext?: React.MouseEventHandler<HTMLButtonElement>
 }
 
-const PaginationIconOnly: React.FC<
-  React.PropsWithChildren<React.PropsWithChildren<PaginationIconOnlyProps>>
-> = ({ hasNext, hasPrev, onClickPrev, onClickNext }) => (
-  <div className="flex flex-row gap-2">
-    <Button
-      variant="ghost"
-      size="icon"
-      className="cursor-pointer"
-      disabled={hasPrev === false}
-      onClick={onClickPrev}
-      aria-label="Previous page"
-    >
-      <ChevronLeft aria-hidden="true" absoluteStrokeWidth size={18} strokeWidth={1.5} />
-    </Button>
-    <Button
-      variant="ghost"
-      size="icon"
-      className="cursor-pointer"
-      disabled={hasNext === false}
-      onClick={onClickNext}
-      aria-label="Next page"
-    >
-      <ChevronRight aria-hidden="true" absoluteStrokeWidth size={18} strokeWidth={1.5} />
-    </Button>
-  </div>
+const PaginationIconOnly: React.FC<PaginationIconOnlyProps> = ({
+  hasNext = true,
+  hasPrev = true,
+  onClickPrev = () => undefined,
+  onClickNext = () => undefined,
+}) => (
+  <PaginationControls
+    hasNext={hasNext}
+    hasPrev={hasPrev}
+    onClickNext={onClickNext}
+    onClickPrev={onClickPrev}
+  />
 )
 
 export default PaginationIconOnly


### PR DESCRIPTION
## What changed

Consolidate the app pagination controls used by section sliders, responsive tables, and rentals into one accessible shared implementation built on the existing shadcn IconButton primitive.

## Why

The three implementations repeated the same previous/next button markup and accessibility labels. The shared control preserves callbacks, disabled boundaries, page labels, theme classes, and sizing overrides while reducing app code and keeping the anchor-oriented shared pagination API unchanged.

## Validation

- Focused PaginationControls test: 1 pass, 4 assertions
- bun --filter app type-check: passed
- bun --filter app lint: passed
- bun --filter app test: 176 pass, 1,205 assertions
- bun --filter app build: passed, 21 routes
- git diff --check: passed