### PR TITLE
fix(ci): enforce ready-only validation cost controls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,11 +42,11 @@ docs/*  test/*  refactor/*         │              │
                                    └── integration branch
 ```
 
-| Branch                                                         | Purpose                  | Contribution rule                                                         |
-| -------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------- |
-| `main`                                                         | Protected release branch | Merge through the `staging` → `main` release PR. No direct pushes.        |
-| `staging`                                                      | Integration branch       | Target normal pull requests here. Required checks must pass before merge. |
-| `feat/*`, `fix/*`, `chore/*`, `refactor/*`, `docs/*`, `test/*` | Focused work             | Branch from `staging`; keep changes small and reviewable.                 |
+| Branch                                                                    | Purpose                  | Contribution rule                                                         |
+| ------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| `main`                                                                    | Protected release branch | Merge through the `staging` → `main` release PR. No direct pushes.        |
+| `staging`                                                                 | Integration branch       | Target normal pull requests here. Required checks must pass before merge. |
+| `feat/*`, `fix/*`, `chore/*`, `refactor/*`, `docs/*`, `test/*`, `codex/*` | Focused work             | Branch from `staging`; keep changes small and reviewable.                 |
 
 The Git workflow is `staging-release`: topic branches **squash** into `staging`, a promotion PR **rebases** validated changes into `main` (`merge_strategy: rebase`), and the Release Please version PR **rebases** into `main` (`release_merge_strategy: rebase`). Release automation never defaults to a merge method and never merges with `--admin`; `code-foundry doctor` and `code-foundry sync` fail closed on any other merge strategy. Re-align `staging` with `main` after a release when needed.
 
@@ -164,7 +164,7 @@ Keep pull requests focused and reviewable. Include screenshots or recordings for
 | Push to `staging`                                  | Promotion PR workflow; canonical validation waits for the PR event                     |
 | Push to `main`                                     | Release workflow; canonical validation already ran on the merged PR                    |
 
-The single validation caller keys concurrency by event and pull-request head. A newer update to the same pull request cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
+The single validation caller keys concurrency by pull request. A newer update to the same pull request—including conversion back to draft—cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
 
 Draft feature work is intentionally cost-aware: local validation is the feedback loop while a pull request is draft. Marking the pull request ready for review starts hosted validation. Vercel projects disable Git-triggered deployments and ignore builds for every feature branch through the versioned `git.deploymentEnabled` and `ignoreCommand` policies in `apps/*/vercel.json`; Vercel builds run on `staging` and `main`, while manual deployments remain available.
 If a ready pull request is returned to draft, its in-flight hosted validation is cancelled and no replacement validation starts until it is ready again.

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/*'
       - 'style/*'
       - 'test/*'
+      - 'codex/*'
 
 permissions:
   contents: read

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,11 +18,11 @@ on:
 permissions: {}
 
 # Superseded PR updates cancel the previous run; converting a PR back to draft
-# also cancels any hosted validation that was already in progress. Schedule
-# and dispatch runs are keyed by event so periodic audits and manual runs stay
-# independent.
+# also cancels any hosted validation that was already in progress. All events
+# for the same pull request share one group, while scheduled and manual runs
+# stay independent.
 concurrency:
-  group: code-foundry-validation-${{ github.event_name }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: code-foundry-validation-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/test/contract/ci-cost-policy.test.ts
+++ b/test/contract/ci-cost-policy.test.ts
@@ -14,7 +14,19 @@ describe('hosted validation cost policy', () => {
     expect(source).toContain(
       "if: github.event_name != 'pull_request' || github.event.pull_request.draft != true"
     )
+    expect(source).toContain('github.event.pull_request.number')
+    expect(source).toContain('github.run_id')
+    expect(source).not.toContain(
+      'code-foundry-validation-${{ github.event_name }}-${{ github.event.pull_request.head.repo.full_name'
+    )
     expect(source).toContain('cancel-in-progress: true')
+  })
+
+  it('creates draft PRs for the repository codex branch convention', () => {
+    const source = readWorkflow('draft-pr.yml')
+
+    expect(source).toContain("      - 'codex/*'")
+    expect(source).toContain('base: staging')
   })
 
   it('keeps optional security scans off for drafts while supporting ready release PRs', () => {


### PR DESCRIPTION
## Summary
- include the repository's `codex/*` branches in the draft PR workflow
- key validation concurrency by pull request so converting a ready PR back to draft cancels its active run
- document the branch convention and add regression contracts

The live `code-foundry-staging` ruleset was also repaired separately to require `Validation / Gate`, while preserving its existing deletion and linear-history protections.

## Local validation
- `bun test test/contract/ci-cost-policy.test.ts`
- `bunx prettier --check .github/workflows/draft-pr.yml .github/workflows/validation.yml .github/CONTRIBUTING.md test/contract/ci-cost-policy.test.ts`
- `git diff --check`

All passed. This PR intentionally remains draft until the cost-control behavior is ready for hosted verification.
