### PR TITLE
perf(web): avoid preloading hidden degen artwork

### DIFF
--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
@@ -24,20 +24,12 @@ export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
           width={584}
           height={640}
           priority
-          quality={100}
           src={imageSrc}
           unoptimized={imageSrc.includes('.gif')}
         />
       }
       spriteImage={
-        <Image
-          alt="Degen Sprite"
-          className={styles.sprite}
-          fill
-          priority
-          unoptimized
-          src={spriteSrc}
-        />
+        <Image alt="Degen Sprite" className={styles.sprite} fill unoptimized src={spriteSrc} />
       }
       logo={
         <Image
@@ -45,7 +37,6 @@ export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
           width={200}
           height={70}
           style={{ maxWidth: '24vw', height: 'auto' }}
-          quality={100}
           src="/img/logos/NL/wordmark.webp"
         />
       }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -399,6 +399,14 @@ describe('GLTF viewer loading contract', () => {
     expect(clientSource).toContain("dynamic(() => import('./ModelView')")
     expect(clientSource).toContain('ssr: false')
   })
+
+  it('preloads only the visible NFT artwork', () => {
+    const source = readFileSync(join(process.cwd(), gltfPage), 'utf8')
+
+    expect(source).toContain('priority\n          src={imageSrc}')
+    expect(source).not.toContain('className={styles.sprite}\n          fill\n          priority')
+    expect(source).not.toContain('quality={100}')
+  })
 })
 
 describe('shared notification loading contract', () => {


### PR DESCRIPTION
## Summary
- keep only the visible 2D NFT artwork as a priority image
- stop preloading the hidden sprite GIF on every GLTF viewer route
- remove explicit quality-100 overrides and rely on the shared image defaults
- add a loading contract to prevent the eager preload from returning

## Validation
- route-surface contract: 187 passed, 0 failed
- web type-check: passed
- web lint: passed
- web production build: passed

Draft milestone; ready-only CI will run after promotion.