### PR TITLE
perf(app): use turbopack for local development

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -12,8 +12,8 @@ const nextConfig: NextConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
   },
-  // TODO: Switch to turbopack once build issues are resolved
-  // turbopack: { resolveAlias: { '@wagmi/connectors': 'wagmi/connectors' } },
+  // Keep the Webpack compatibility path for explicit `next build --webpack`
+  // fallback runs; local development uses Turbopack for faster iteration.
   // serverExternalPackages: ['pino-pretty', 'lokijs', 'encoding', 'sodium-native', 'require-addon'],
   webpack: (config, { isServer }) => {
     // Map @wagmi/core connectors package to wagmi/connectors to avoid ESM issues

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NEXT_TYPESCRIPT_NO_AUTO_INSTALL=1 next build",
     "clean": "rm -rf node_modules && rm -rf .turbo && rm -rf .next",
-    "dev": "next dev --webpack --port 3001",
+    "dev": "next dev --turbopack --port 3001",
     "format": "prettier --write \"**/*.{js,ts,tsx,md,mdx,json}\" --ignore-path ../../.gitignore",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -51,6 +51,13 @@ describe('app performance contracts', () => {
     expect(source).toContain('strategy="lazyOnload"')
   })
 
+  it('uses Turbopack for local app development', () => {
+    const manifest = JSON.parse(readFileSync(appManifest, 'utf8'))
+
+    expect(manifest.scripts.dev).toBe('next dev --turbopack --port 3001')
+    expect(manifest.scripts.dev).not.toContain('--webpack')
+  })
+
   it('loads the bridge form only after its dialog opens', () => {
     const source = readFileSync(bridgeDialog, 'utf8')
 


### PR DESCRIPTION
## Summary
- use Next Turbopack for the app development server
- retain the Webpack compatibility callback for explicit fallback builds
- add a contract preventing the dev script from regressing to Webpack

## Validation
- app performance contract: 8 passed, 0 failed
- app type-check: passed
- app lint: passed
- formatter: passed
- Turbopack dev probe: served `/` successfully in 684ms with a 68KB response

The controlled production build rerun was blocked by an orphaned Next process from an earlier parallel invocation; the unchanged app production path already passed on this staging tip in the preceding dependency milestone.