### PR TITLE
fix(web): restore accumulated NFTL on GLTF routes

### DIFF
--- a/apps/web/src/hooks/useClaimableNFTL.ts
+++ b/apps/web/src/hooks/useClaimableNFTL.ts
@@ -17,21 +17,31 @@ export default function useClaimableNFTL(tokenId: number | string): NFTLClaimabl
   const [balance, setTotalBalance] = useState(0)
 
   useEffect(() => {
+    const tokenNumber = typeof tokenId === 'number' ? tokenId : Number(tokenId)
+    if (!Number.isSafeInteger(tokenNumber) || tokenNumber < 0) return
+
+    let cancelled = false
+
     const readContract = async () => {
       try {
         const data = await publicClient.readContract({
           address: NFTL_CONTRACT?.address as `0x${string}`,
           abi: NFTL_CONTRACT?.abi as Abi,
           functionName: 'accumulated',
-          args: [tokenId],
+          args: [BigInt(tokenNumber)],
         })
-        setTotalBalance(data ? parseFloat(formatEther(data as bigint)) : 0)
+        if (!cancelled) setTotalBalance(data ? parseFloat(formatEther(data as bigint)) : 0)
       } catch (e) {
         const error = e as GetBlockNumberErrorType
         console.error(error)
       }
     }
-    if (tokenId) readContract()
+
+    readContract()
+
+    return () => {
+      cancelled = true
+    }
   }, [tokenId])
 
   return { balance, loading: false }

--- a/apps/web/src/lib/viemClient.ts
+++ b/apps/web/src/lib/viemClient.ts
@@ -1,7 +1,17 @@
-import { type PublicClient, createPublicClient, http } from 'viem'
+import { type PublicClient, createPublicClient, fallback, http } from 'viem'
 import { mainnet } from 'viem/chains'
+
+const infuraProjectId =
+  process.env.NEXT_PUBLIC_INFURA_ID ?? process.env.NEXT_PUBLIC_INFURA_PROJECT_ID
+
+const rpcTransports = [
+  ...(infuraProjectId ? [http(`https://mainnet.infura.io/v3/${infuraProjectId}`)] : []),
+  // Keep public GLTF pages working when the optional Infura variable is missing,
+  // rotated, or temporarily rate-limited.
+  http('https://ethereum-rpc.publicnode.com'),
+]
 
 export const publicClient: PublicClient = createPublicClient({
   chain: mainnet,
-  transport: http(`https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_ID}`),
+  transport: fallback(rpcTransports),
 })

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -237,6 +237,8 @@ const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
 const gltfClient = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
 const gltfRouteBoundary =
   'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViewsRouteBoundary.tsx'
+const webViemClient = 'apps/web/src/lib/viemClient.ts'
+const webClaimableNFTL = 'apps/web/src/hooks/useClaimableNFTL.ts'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
@@ -406,6 +408,18 @@ describe('GLTF viewer loading contract', () => {
     expect(source).toContain('priority\n          src={imageSrc}')
     expect(source).not.toContain('className={styles.sprite}\n          fill\n          priority')
     expect(source).not.toContain('quality={100}')
+  })
+
+  it('keeps accumulated NFTL reads available when the optional Infura variable is unavailable', () => {
+    const clientSource = readFileSync(join(process.cwd(), webViemClient), 'utf8')
+    const hookSource = readFileSync(join(process.cwd(), webClaimableNFTL), 'utf8')
+
+    expect(clientSource).toContain('NEXT_PUBLIC_INFURA_ID')
+    expect(clientSource).toContain('NEXT_PUBLIC_INFURA_PROJECT_ID')
+    expect(clientSource).toContain('ethereum-rpc.publicnode.com')
+    expect(clientSource).toContain('fallback(rpcTransports)')
+    expect(hookSource).toContain('args: [BigInt(tokenNumber)]')
+    expect(hookSource).toContain('if (!cancelled)')
   })
 })
 


### PR DESCRIPTION
## Summary
- restore accumulated NFTL reads when the optional Infura environment variable is missing or unavailable
- accept both Infura variable names used across the monorepo
- normalize GLTF token IDs to `bigint` before the contract call
- prevent stale route responses from overwriting the current token balance
- add a GLTF NFTL regression contract

## Validation
- `bun test test/contract/route-surface.test.ts` — 188 pass
- `bunx prettier --check apps/web/src/lib/viemClient.ts apps/web/src/hooks/useClaimableNFTL.ts test/contract/route-surface.test.ts`
- `bun run type-check` in `apps/web`
- `bun run lint` in `apps/web`
- `NEXT_PUBLIC_INFURA_ID=invalid NEXT_PUBLIC_INFURA_PROJECT_ID=invalid bun run build` in `apps/web`
- fallback `eth_call` returned `76999999250000000000000` for token 10

Keep this PR draft until the hotfix is reviewed and the production Vercel environment is confirmed.
