### PR TITLE
chore: promote validated staging to main

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx
@@ -77,7 +77,8 @@ const DashboardDegensPageContent = (): React.ReactNode => {
   }, [favsData, setFavDegens])
 
   const { loading: loadingAllRentals, data } = useFetch<Degen[]>(
-    `${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`
+    `${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`,
+    { sharedCache: true }
   )
 
   const { degensBalances, loadingDegens } = useNFTsBalances()

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx
@@ -26,7 +26,9 @@ const GamerProfileContent = (): React.ReactNode => {
   const { address } = useAccount()
   const { avatarsAndFee } = useProfileAvatarFee()
   const profileAvatars = avatarsAndFee?.avatars
-  const { data } = useFetch<Degen[]>(`${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`)
+  const { data } = useFetch<Degen[]>(`${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`, {
+    sharedCache: true,
+  })
 
   const { comicsBalances, degenCount, degensBalances, itemsBalances } = useNFTsBalances()
 

--- a/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx
@@ -52,7 +52,8 @@ const MyDegens = (): React.ReactNode => {
   const { loadingDegens, degensBalances } = useNFTsBalances()
 
   const { data: degensData } = useFetch<Degen[]>(
-    `${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`
+    `${DEGEN_BASE_API_URL}/cache/rentals/rentables.json`,
+    { sharedCache: true }
   )
 
   const filteredDegens = useMemo(() => {

--- a/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
+++ b/apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx
@@ -44,7 +44,7 @@ const AllDegensPage = (): React.ReactNode => {
   const [searchParams, setSearchParams] = useState<Record<string, string>>({})
   const [layoutMode, setLayoutMode] = useState<string>('gridView')
 
-  const { data } = useFetch<PublicDegen[]>(PUBLIC_DEGENS_API_URL)
+  const { data } = useFetch<PublicDegen[]>(PUBLIC_DEGENS_API_URL, { sharedCache: true })
 
   const originalDegens = useMemo(() => {
     if (!data?.length) return []

--- a/apps/app/src/hooks/hooks.test.tsx
+++ b/apps/app/src/hooks/hooks.test.tsx
@@ -71,6 +71,46 @@ describe('useFetch', () => {
     )
   })
 
+  it('shares in-flight and completed public catalog requests across hook instances', async () => {
+    let resolveRequest: (response: Response) => void = () => undefined
+    const fetchMock = spyOn(globalThis, 'fetch').mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      })
+    )
+    const options = { sharedCache: true }
+    const first = renderHook(() => useFetch<{ id: number }>('/shared-catalog', options))
+    const second = renderHook(() => useFetch<{ id: number }>('/shared-catalog', options))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveRequest(new Response(JSON.stringify({ id: 7 }), { status: 200 }))
+    await waitFor(() => expect(first.result.current.data).toEqual({ id: 7 }))
+    await waitFor(() => expect(second.result.current.data).toEqual({ id: 7 }))
+
+    first.unmount()
+    second.unmount()
+    const cached = renderHook(() => useFetch<{ id: number }>('/shared-catalog', options))
+    await waitFor(() => expect(cached.result.current.data).toEqual({ id: 7 }))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not update an unmounted hook when its request resolves', async () => {
+    let resolveRequest: (response: Response) => void = () => undefined
+    spyOn(globalThis, 'fetch').mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      })
+    )
+    const { result, unmount } = renderHook(() => useFetch<{ id: number }>('/cancelled'))
+
+    unmount()
+    resolveRequest(new Response(JSON.stringify({ id: 8 }), { status: 200 }))
+    await Promise.resolve()
+
+    expect(result.current.data).toBeUndefined()
+  })
+
   it('skips requests without a URL or when disabled', () => {
     const fetchMock = spyOn(globalThis, 'fetch')
     const { result } = renderHook(() => useFetch('/skip', { enabled: false }))

--- a/apps/app/src/hooks/useFetch.ts
+++ b/apps/app/src/hooks/useFetch.ts
@@ -1,6 +1,7 @@
 'use client'
 
-import { useMemo, useEffect, useReducer, useRef } from 'react'
+import { useEffect, useMemo, useReducer, useRef } from 'react'
+
 import { getAuditFixtureData, isAuditFixtureEnabled } from '@/audit/fixture'
 
 interface State<T> {
@@ -10,9 +11,17 @@ interface State<T> {
   reset?: boolean
 }
 
-type Cache<T> = { [url: string]: T }
+type Cache<T> = Record<string, T>
 
-// discriminated union type
+type SharedCacheEntry = {
+  value: unknown
+  expiresAt: number
+}
+
+const SHARED_CACHE_TTL_MS = 5 * 60 * 1000
+const sharedCache = new Map<string, SharedCacheEntry>()
+const pendingRequests = new Map<string, Promise<unknown>>()
+
 type Action<T> =
   | { type: 'loading' }
   | { type: 'reset' }
@@ -26,7 +35,6 @@ const initialState: State<unknown> = {
   reset: undefined,
 }
 
-// Keep state logic separated
 function fetchReducer<T>(state: State<T>, action: Action<T>): State<T> {
   switch (action.type) {
     case 'loading':
@@ -42,24 +50,70 @@ function fetchReducer<T>(state: State<T>, action: Action<T>): State<T> {
   }
 }
 
-type Options = RequestInit & { enabled?: boolean; stale?: boolean }
+type Options = RequestInit & { enabled?: boolean; sharedCache?: boolean }
+
+const getRequestKey = (url: string, requestInit: RequestInit, textOnly: boolean): string => {
+  const normalizedHeaders = new Headers(requestInit.headers)
+  const headers = Array.from(normalizedHeaders.entries()).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )
+
+  return JSON.stringify({
+    url,
+    method: requestInit.method ?? 'GET',
+    headers,
+    body: typeof requestInit.body === 'string' ? requestInit.body : undefined,
+    cache: requestInit.cache,
+    credentials: requestInit.credentials,
+    mode: requestInit.mode,
+    redirect: requestInit.redirect,
+    textOnly,
+  })
+}
+
+async function fetchOnce<T>(
+  url: string,
+  requestInit: RequestInit,
+  textOnly: boolean,
+  requestKey: string,
+  shareRequest: boolean
+): Promise<T> {
+  if (shareRequest) {
+    const pending = pendingRequests.get(requestKey)
+    if (pending) return pending as Promise<T>
+  }
+
+  const request = fetch(url, { ...requestInit, headers: requestInit.headers })
+    .then(async (response) => {
+      if (!response.ok) throw new Error(response.statusText)
+      return (textOnly ? await response.text() : await response.json()) as T
+    })
+    .finally(() => shareRequest && pendingRequests.delete(requestKey))
+
+  if (shareRequest) pendingRequests.set(requestKey, request)
+  return request
+}
 
 function useFetch<T = unknown>(url?: string, options?: Options, textOnly = false): State<T> {
   const cache = useRef<Cache<T>>({})
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const headers = useMemo(() => options?.headers, [JSON.stringify(options?.headers)])
   const enabled = useMemo(() => options?.enabled ?? true, [options?.enabled])
-
-  // Used to prevent state update if the component is unmounted
-  const cancelRequest = useRef<boolean>(false)
-
-  // Used to mark that state has been reset to prevent re-dispatching
+  const shouldShareCache = useMemo(() => options?.sharedCache ?? false, [options?.sharedCache])
+  const optionsKey = JSON.stringify(options)
+  // The serialized key keeps inline request option objects from restarting the
+  // request when a consuming component re-renders.
+  const requestInit = useMemo(() => {
+    const { enabled: _enabled, sharedCache: _sharedCache, ...init } = options ?? {}
+    return init
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optionsKey])
+  const requestKey = useMemo(
+    () => (url ? getRequestKey(url, requestInit, textOnly) : undefined),
+    [requestInit, textOnly, url]
+  )
   const hasReset = useRef(false)
-
   const [state, dispatch] = useReducer(fetchReducer, initialState)
 
   useEffect(() => {
-    // Do nothing if the url is not given
     if (!url) return
     if (enabled === false) {
       if (!hasReset.current) {
@@ -70,47 +124,52 @@ function useFetch<T = unknown>(url?: string, options?: Options, textOnly = false
     }
 
     hasReset.current = false
+    let active = true
+    dispatch({ type: 'loading' })
 
     const fetchData = async () => {
-      dispatch({ type: 'loading' })
-
       if (isAuditFixtureEnabled) {
-        dispatch({ type: 'fetched', payload: getAuditFixtureData(url) as T })
+        if (active) dispatch({ type: 'fetched', payload: getAuditFixtureData(url) as T })
         return
       }
 
-      // If a cache exists for this url, return it
-      if (cache.current[url]) {
-        dispatch({ type: 'fetched', payload: cache.current[url] })
+      const cacheKey = requestKey ?? url
+      if (Object.prototype.hasOwnProperty.call(cache.current, cacheKey)) {
+        if (active) dispatch({ type: 'fetched', payload: cache.current[cacheKey] })
         return
+      }
+
+      if (shouldShareCache && requestKey) {
+        const cached = sharedCache.get(requestKey)
+        if (cached?.expiresAt && cached.expiresAt > Date.now()) {
+          cache.current[cacheKey] = cached.value as T
+          if (active) dispatch({ type: 'fetched', payload: cached.value as T })
+          return
+        }
+        if (cached) sharedCache.delete(requestKey)
       }
 
       try {
-        const response = await fetch(url, { headers })
-        if (!response.ok) {
-          throw new Error(response.statusText)
+        const data = await fetchOnce<T>(url, requestInit, textOnly, cacheKey, shouldShareCache)
+        cache.current[cacheKey] = data
+        if (shouldShareCache && requestKey) {
+          sharedCache.set(requestKey, {
+            value: data,
+            expiresAt: Date.now() + SHARED_CACHE_TTL_MS,
+          })
         }
-
-        const data = (textOnly ? await response.text() : await response.json()) as T
-        cache.current[url] = data
-
-        dispatch({ type: 'fetched', payload: data })
+        if (active) dispatch({ type: 'fetched', payload: data })
       } catch (error) {
-        if (cancelRequest.current) return
-
-        dispatch({ type: 'error', payload: error as Error })
+        if (active) dispatch({ type: 'error', payload: error as Error })
       }
     }
 
-    fetchData()
+    void fetchData()
 
-    // Use the cleanup function for avoiding a possibly...
-    // ...state update after the component was unmounted
-    // eslint-disable-next-line consistent-return
     return () => {
-      cancelRequest.current = true
+      active = false
     }
-  }, [enabled, headers, textOnly, url])
+  }, [enabled, requestInit, requestKey, shouldShareCache, textOnly, url])
 
   return state as State<T>
 }

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -24,6 +24,13 @@ const sharedResponsiveCarousel = 'packages/ui/src/components/custom/responsive-c
 const sharedResponsiveCarouselStyles =
   'packages/ui/src/components/custom/responsive-carousel/responsive-carousel.module.css'
 const degenFilterUtils = 'apps/app/src/components/extended/DegensFilter/utils.ts'
+const useFetch = 'apps/app/src/hooks/useFetch.ts'
+const sharedCatalogConsumers = [
+  'apps/app/src/app/(public-routes)/degens/AllDegensPage.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/degens/DashboardDegensContent.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/gamer-profile/GamerProfileContent.tsx',
+  'apps/app/src/app/(private-routes)/dashboard/overview/MyDegens.tsx',
+]
 const privateShellIconSources = [
   'apps/app/src/app/_layout/_CollapsibleSidebarLayout/index.tsx',
   'apps/app/src/app/_layout/_MainLayout/_Header/index.tsx',
@@ -201,5 +208,17 @@ describe('app performance contracts', () => {
 
     expect(source).toContain("from '@/constants/hydra-rarities'")
     expect(source).not.toContain("from '@/constants/hydras'")
+  })
+
+  it('deduplicates the repeated degen catalog request across app surfaces', () => {
+    const fetchSource = readFileSync(useFetch, 'utf8')
+
+    expect(fetchSource).toContain('sharedCache?: boolean')
+    expect(fetchSource).toContain('pendingRequests')
+    expect(fetchSource).toContain('SHARED_CACHE_TTL_MS')
+
+    for (const file of sharedCatalogConsumers) {
+      expect(readFileSync(file, 'utf8')).toContain('sharedCache: true')
+    }
   })
 })


### PR DESCRIPTION
## Promotion
Promotes the validated staging tree after PR #634.

## Source
- staging: `b145f065`
- exact source tree: `734373f2fe33c1de0b506fcc7ae911de1cbfe017`
- promotion parent: current `main`

## Validation already completed
- staging PR #634 hosted gate passed: format, lint, type-check, unit, build, and aggregate gate
- staging push release workflow passed with no release changes
- local app tests/build/contracts passed before staging promotion

This is a clean exact-tree promotion; merge with the repository-required rebase strategy.