### PR TITLE
chore: promote staging to main

### DIFF
--- a/test/contract/turbo-cache-scope.test.ts
+++ b/test/contract/turbo-cache-scope.test.ts
@@ -3,9 +3,16 @@ import { readFileSync } from 'node:fs'
 
 const turbo = JSON.parse(readFileSync('turbo.json', 'utf8')) as {
   globalEnv?: string[]
+  globalDependencies?: string[]
   tasks: Record<
     string,
-    { cache?: boolean; env?: string[]; dependsOn?: string[]; outputs?: string[] }
+    {
+      cache?: boolean
+      env?: string[]
+      dependsOn?: string[]
+      inputs?: string[]
+      outputs?: string[]
+    }
   >
 }
 const rootPackage = JSON.parse(readFileSync('package.json', 'utf8')) as {
@@ -14,6 +21,7 @@ const rootPackage = JSON.parse(readFileSync('package.json', 'utf8')) as {
 
 const envFor = (task: string) => new Set(turbo.tasks[task]?.env ?? [])
 const dependenciesFor = (task: string) => turbo.tasks[task]?.dependsOn ?? []
+const inputsFor = (task: string) => turbo.tasks[task]?.inputs ?? []
 const packageJson = (path: string) =>
   JSON.parse(readFileSync(path, 'utf8')) as {
     scripts?: Record<string, string>
@@ -28,6 +36,14 @@ describe('Turbo cache environment scope', () => {
 
   it('does not invalidate every workspace for app-specific credentials', () => {
     expect(turbo.globalEnv ?? []).toEqual(['CI', 'VERCEL_ENV'])
+  })
+
+  it('keeps local environment files scoped to the builds that consume them', () => {
+    expect(turbo.globalDependencies ?? []).toEqual(['.env'])
+
+    for (const task of ['api#build', 'app#build', 'docs#build', 'smashers#build', 'web#build']) {
+      expect(inputsFor(task)).toEqual(['$TURBO_DEFAULT$', '.env*', '!.env.example'])
+    }
   })
 
   it('keeps environment inputs on the builds that read them', () => {

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://v2-10-9.turborepo.dev/schema.json",
   "ui": "tui",
-  "globalDependencies": ["apps/**/.env.*local", ".env"],
+  "globalDependencies": [".env"],
   "globalEnv": ["CI", "VERCEL_ENV"],
   "tasks": {
     "build": {
@@ -9,10 +9,12 @@
       "outputs": ["dist/**"]
     },
     "app#build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": ["CI", "NEXT_RUNTIME", "NEXT_PUBLIC_*", "SENTRY_AUTH_TOKEN", "VERCEL_ENV"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "api#build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "NODE_CONFIG_TS_DIR",
         "PORT",
@@ -44,10 +46,12 @@
       "outputs": ["dist/**", "api/.app/**", "api/config/**"]
     },
     "docs#build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": ["ALGOLIA_API_KEY", "ALGOLIA_APP_ID"],
       "outputs": ["build/**", ".docusaurus/**"]
     },
     "smashers#build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "APPLE_CLIENT_ID",
         "APPLE_CLIENT_SECRET",
@@ -70,6 +74,7 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "web#build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "CI",
         "EDGE_CONFIG",


### PR DESCRIPTION
## Summary
Promotes the validated staging snapshot to main.

## Promotion source
- staging: `ae2a6206c2d6a782551f28cf7fe61977f588a72a`
- promotion tree matches staging exactly
- feature PR: #637 (squash merged)

## Validation
The feature PR passed hosted build, format, lint, type-check, unit, and validation gate checks. The staging post-merge Code Foundry workflow also passed with no release changes.

Per repository policy, this promotion uses rebase merge.