### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/components/providers/PublicNavLinks.tsx
+++ b/apps/app/src/components/providers/PublicNavLinks.tsx
@@ -1,6 +1,6 @@
-import type { LucideIcon } from 'lucide-react'
-import { Cat, Dot, Gamepad, ListOrdered, Sparkles } from 'lucide-react'
 import Link from 'next/link'
+
+import { NavIcon } from '@nl/ui/custom/nav-icon'
 
 import { PublicItems } from '@/constants/menu-items'
 
@@ -8,19 +8,13 @@ const publicLinks = PublicItems.items.flatMap((item) =>
   item.type === 'group' ? (item.children ?? []) : []
 )
 
-const publicIconMap = {
-  cat: Cat,
-  gamepad: Gamepad,
-  'list-ordered': ListOrdered,
-  sparkles: Sparkles,
-} satisfies Record<string, LucideIcon>
-
 function PublicNavIcon({ name }: { name?: string }) {
-  const Icon =
-    name && name in publicIconMap ? publicIconMap[name as keyof typeof publicIconMap] : undefined
-  const IconComponent = Icon ?? Dot
+  const iconName =
+    name === 'cat' || name === 'gamepad' || name === 'list-ordered' || name === 'sparkles'
+      ? name
+      : 'dot'
 
-  return <IconComponent aria-hidden="true" absoluteStrokeWidth size={24} strokeWidth={1.5} />
+  return <NavIcon name={iconName} />
 }
 
 export default function PublicNavLinks() {

--- a/packages/ui/src/components/custom/nav-icon/index.tsx
+++ b/packages/ui/src/components/custom/nav-icon/index.tsx
@@ -1,0 +1,72 @@
+import type { SVGProps } from 'react'
+
+const iconPaths = {
+  cat: (
+    <>
+      <path d="M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z" />
+      <path d="M8 14v.5" />
+      <path d="M16 14v.5" />
+      <path d="m11.25 16.25 1.5 0L12 17l-.75-.75Z" />
+    </>
+  ),
+  dot: <circle cx="12" cy="12" r="1" />,
+  gamepad: (
+    <>
+      <line x1="6" x2="10" y1="12" y2="12" />
+      <line x1="8" x2="8" y1="10" y2="14" />
+      <line x1="15" x2="15.01" y1="13" y2="13" />
+      <line x1="18" x2="18.01" y1="11" y2="11" />
+      <rect width="20" height="12" x="2" y="6" rx="2" />
+    </>
+  ),
+  'list-ordered': (
+    <>
+      <path d="M11 5h10" />
+      <path d="M11 12h10" />
+      <path d="M11 19h10" />
+      <path d="M4 4h1v5" />
+      <path d="M4 9h2" />
+      <path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02" />
+    </>
+  ),
+  sparkles: (
+    <>
+      <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+      <path d="M20 2v4" />
+      <path d="M22 4h-4" />
+      <circle cx="4" cy="20" r="2" />
+    </>
+  ),
+} as const
+
+type NavIconName = keyof typeof iconPaths
+
+interface NavIconProps extends Omit<SVGProps<SVGSVGElement>, 'color' | 'name'> {
+  name?: NavIconName
+  size?: number | string
+}
+
+function NavIcon({ name = 'dot', size = 24, ...props }: NavIconProps) {
+  const { ['aria-hidden']: ariaHidden, ['aria-label']: ariaLabel, ...svgProps } = props
+
+  return (
+    <svg
+      aria-hidden={ariaHidden ?? (ariaLabel ? undefined : true)}
+      aria-label={ariaLabel}
+      fill="none"
+      height={size}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      width={size}
+      {...svgProps}
+    >
+      {iconPaths[name]}
+    </svg>
+  )
+}
+
+export { NavIcon }
+export type { NavIconName, NavIconProps }

--- a/packages/ui/src/components/custom/nav-icon/nav-icon.test.tsx
+++ b/packages/ui/src/components/custom/nav-icon/nav-icon.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { NavIcon } from './index'
+
+describe('NavIcon', () => {
+  it('renders decorative themed glyphs without a client-only icon registry', () => {
+    const { container } = render(<NavIcon name="gamepad" className="text-sidebar-foreground" />)
+    const icon = container.querySelector('svg')
+
+    expect(icon).not.toBeNull()
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+    expect(icon?.getAttribute('stroke')).toBe('currentColor')
+    expect(icon?.getAttribute('class')).toBe('text-sidebar-foreground')
+    expect(icon?.querySelector('rect')).not.toBeNull()
+  })
+
+  it('supports an accessible label when the glyph carries meaning', () => {
+    const { container } = render(<NavIcon name="sparkles" aria-label="Mint-O-Matic" />)
+    const icon = container.querySelector('svg')
+
+    expect(icon?.getAttribute('aria-label')).toBe('Mint-O-Matic')
+    expect(icon?.getAttribute('aria-hidden')).toBeNull()
+  })
+})

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -873,7 +873,8 @@ describe('public app shell contract', () => {
     expect(contentContainerSource).toContain('container py-5 md:py-10')
     expect(linksSource).not.toContain("'use client'")
     expect(linksSource).not.toContain("from '@nl/ui/base/icon'")
-    expect(linksSource).toContain("from 'lucide-react'")
+    expect(linksSource).toContain("from '@nl/ui/custom/nav-icon'")
+    expect(linksSource).not.toContain("from 'lucide-react'")
     expect(linksSource).toContain("from 'next/link'")
     expect(linksSource).not.toContain("from './PublicActiveNavLink'")
     expect(


### PR DESCRIPTION
## Summary
Promotes the validated `staging` tree to the protected `main` release branch.

## Promotion invariant
This is a linear promotion commit whose tree exactly matches `origin/staging`, so it can use the repository-required rebase merge.

## Included milestone
- server-safe shared public navigation glyphs
- public shell client-graph reduction with preserved theme and accessibility behavior

## Validation
The feature PR was squash-merged into `staging` after all required staging checks passed. This promotion commit has the exact `staging` tree; release-tier validation will run on this PR.