### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@nl/typescript-config/nextjs.json",
   "compilerOptions": {
+    "incremental": true,
     "paths": { "@/*": ["./src/*"], "@nl/ui/*": ["../../packages/ui/src/*"] },
     "plugins": [{ "name": "next" }]
   },


### PR DESCRIPTION
## Promotion
Promote the validated `staging` content into `main` as a clean single commit based on the current main head.

## Why this branch exists
The direct staging-history promotion could not be rebase-merged because the two branches have divergent promotion histories. This branch preserves the exact `staging` tree while giving GitHub a normal one-commit promotion that can be rebase-merged.

## Validation
- `staging` Code Foundry passed: run `31771159590`
- Prior feature PR #667 fast gate passed
- Prior promotion run `31771220717` full release-tier checks passed; the only failure was the non-required Draft PR/Create workflow hardcoded to target staging
- Current branch tree equals `origin/staging` exactly

Use the canonical rebase merge strategy.