### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/smashers/tsconfig.json
+++ b/apps/smashers/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@nl/typescript-config/nextjs.json",
   "compilerOptions": {
+    "incremental": true,
     "paths": { "@/*": ["./src/*"], "@nl/ui/*": ["../../packages/ui/src/*"] },
     "plugins": [{ "name": "next" }]
   },

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -261,12 +261,6 @@
   .section-title {
     max-width: 460px;
   }
-  .compete-to-earn-section-token-1 {
-    display: none;
-  }
-  .compete-to-earn-section-token-2 {
-    display: none;
-  }
 }
 
 @media (max-width: 920px) {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@nl/typescript-config/nextjs.json",
   "compilerOptions": {
+    "incremental": true,
     "paths": { "@/*": ["./src/*"], "@nl/ui/*": ["../../packages/ui/src/*"] },
     "plugins": [{ "name": "next" }]
   },


### PR DESCRIPTION
## Promotion
Promote the validated `staging` tree to `main` using the canonical rebase promotion path.

## Scope
- includes the merged performance batch from PR #689
- promotion branch was created from `origin/main` and cherry-picked the staging commit
- verified `git diff --quiet origin/staging HEAD` before publishing; the trees are identical

## Validation
- staging PR #689 required checks passed: build, format, lint, type-check, unit, and Validation / Gate
- affected local web, app, and Smashers production builds passed
- no feature-branch Vercel preview deployment was created