### PR TITLE
promote: shared preloader transform fix

### DIFF
--- a/packages/ui/src/components/custom/preloader/base.tsx
+++ b/packages/ui/src/components/custom/preloader/base.tsx
@@ -36,11 +36,7 @@ export function PreloaderBase({ ready, percent, showWarning }: PreloaderProps) {
   return (
     <div
       className={styles.preloader_overlay}
-      style={
-        ready
-          ? { transform: 'translateY(100%)', display: 'none' }
-          : { transform: 'transform: translateY(0)' }
-      }
+      style={ready ? { transform: 'translateY(100%)', display: 'none' } : undefined}
     >
       <div id="js-preloader" className={styles.preloader}>
         <div className={cn(styles.preloader_inner, styles.fadeInUp)}>

--- a/packages/ui/src/components/custom/preloader/index.test.tsx
+++ b/packages/ui/src/components/custom/preloader/index.test.tsx
@@ -71,7 +71,7 @@ describe('Preloader', () => {
   it('keeps overlay visible when ready is false', () => {
     const { container } = render(<Preloader ready={false} progress={0.5} />)
     const root = container.firstChild as HTMLElement
-    expect(root.style.transform).toContain('translateY(0)')
+    expect(root.style.transform).toBe('')
   })
 
   it('calls start() when not ready', () => {

--- a/packages/ui/src/components/custom/preloader/preloader-base.test.tsx
+++ b/packages/ui/src/components/custom/preloader/preloader-base.test.tsx
@@ -47,10 +47,10 @@ describe('PreloaderBase', () => {
     expect(root.style.display).toBe('none')
   })
 
-  it('uses translateY(0) transform when not ready', () => {
+  it('uses default CSS transform when not ready', () => {
     const { container } = render(<PreloaderBase />)
     const root = container.firstChild as HTMLElement
-    expect(root.style.transform).toContain('translateY(0)')
+    expect(root.style.transform).toBe('')
   })
 
   it('renders the preloader inner with SVG via role="img"', () => {


### PR DESCRIPTION
Promote the exact staging tree through the canonical staging-to-main path.

Included: remove the malformed shared preloader transform inline style and update its regression expectations.

Validated in PR #692 on staging: format, lint, type-check, build, unit tests, and Validation/Gate.