### PR TITLE
promote: restore app sidebar and app-bar shell

### DIFF
--- a/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
+++ b/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
@@ -81,7 +81,7 @@
 @media (min-width: 1024px) {
   .mainClosed {
     margin-left: -260px;
-    width: calc(100% - 260px);
+    width: 100%;
   }
 }
 

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
@@ -55,6 +55,16 @@ describe('private sidebar frame', () => {
     expect(navigationState.toggleDrawer).toHaveBeenCalledOnce()
   })
 
+  it('keeps the compact drawer below the app bar', () => {
+    navigationState.drawerOpen = true
+    render(<SidebarFrame>Navigation</SidebarFrame>)
+
+    const navigation = screen.getByRole('navigation', { name: 'Primary navigation' })
+    const overlay = navigation.querySelector('[aria-hidden="false"]')
+
+    expect((overlay as HTMLElement | null)?.style.top).toBe('60px')
+  })
+
   it('keeps the desktop drawer interactive only while open', () => {
     isDesktopNavigation = true
     navigationState.drawerOpen = true

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
@@ -63,10 +63,11 @@ function SidebarFrame({ children, footer }: SidebarFrameProps) {
       {isCompactScreen && (
         <div
           className={cn(
-            'fixed top-14 right-0 bottom-0 left-0 z-40 transition-opacity',
+            'fixed right-0 bottom-0 left-0 z-40 transition-opacity',
             drawerOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
           )}
           aria-hidden={!drawerOpen}
+          style={{ top: appHeaderHeight }}
         >
           {drawerOpen && (
             <button

--- a/apps/app/src/components/cards/ImageCard.tsx
+++ b/apps/app/src/components/cards/ImageCard.tsx
@@ -17,7 +17,10 @@ const styleImage: { imageWrapper: React.CSSProperties; imageCommon: React.CSSPro
 const ImageCard = ({ image, imageWebp, thumbnail, title, ratio }: ImageCardProps) => {
   const { handleImageOnLoad, css } = useImageOnLoad()
   return (
-    <div style={{ ...styleImage.imageWrapper, paddingBottom: `${ratio * 100}%` }}>
+    <div
+      className="relative"
+      style={{ ...styleImage.imageWrapper, paddingBottom: `${ratio * 100}%` }}
+    >
       {thumbnail && (
         // Marketplace media can be API-provided from arbitrary hosts, so it cannot use
         // next/image until those hosts are explicitly configured.
@@ -38,9 +41,11 @@ const ImageCard = ({ image, imageWebp, thumbnail, title, ratio }: ImageCardProps
             src={image}
             webpSrc={imageWebp}
             alt={title}
+            fill
+            sizes="(max-width: 1023px) 100vw, 345px"
             loading="lazy"
             decoding="async"
-            style={{ height: '100%', ...styleImage.imageCommon, ...css.fullSize }}
+            style={{ ...styleImage.imageCommon, ...css.fullSize }}
           />
         ) : (
           // Marketplace media can be API-provided from arbitrary hosts, so it cannot use


### PR DESCRIPTION
Promote the exact staging tree through the canonical staging-to-main path.

Included:
- restore full-width desktop content when the app sidebar is closed
- align the compact drawer below the 60px app bar
- fix shared dashboard image sizing so the app shell renders without a Next image runtime exception

Validated in PR #695 with app tests, format, lint, type-check, build, and Validation/Gate.