### PR TITLE
promote: stabilize shared animated image fill sizing

### DIFF
--- a/packages/ui/src/components/custom/animated-image/animated-image.test.tsx
+++ b/packages/ui/src/components/custom/animated-image/animated-image.test.tsx
@@ -2,9 +2,12 @@ import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 mock.module('next/image', () => ({
-  default: ({ alt, unoptimized: _unoptimized, ...props }: React.ComponentProps<'img'>) => (
-    <img alt={alt} {...props} />
-  ),
+  default: ({
+    alt,
+    fill: _fill,
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ComponentProps<'img'>) => <img alt={alt} {...props} />,
 }))
 
 describe('AnimatedImage', () => {
@@ -32,5 +35,16 @@ describe('AnimatedImage', () => {
     expect(picture?.querySelector('source')?.getAttribute('srcset')).toBe('/img/items/full/1.webp')
     expect(picture?.querySelector('img')?.getAttribute('src')).toBe('/img/items/full/1.gif')
     expect(picture?.querySelector('img')?.getAttribute('alt')).toBe('Cape')
+  })
+
+  it('positions the picture wrapper when using fill sizing', () => {
+    const { container } = render(
+      <AnimatedImage src="/img/items/full/1.gif" alt="Cape" fill sizes="100vw" unoptimized />
+    )
+    const picture = container.querySelector('picture')
+
+    expect(picture?.style.position).toBe('absolute')
+    expect(picture?.style.inset).toBe('0')
+    expect(picture?.style.display).toBe('block')
   })
 })

--- a/packages/ui/src/components/custom/animated-image/index.tsx
+++ b/packages/ui/src/components/custom/animated-image/index.tsx
@@ -1,4 +1,5 @@
 import Image, { type ImageProps } from 'next/image'
+import type { CSSProperties } from 'react'
 
 type AnimatedImageProps = ImageProps & { webpSrc?: string }
 
@@ -8,8 +9,12 @@ type AnimatedImageProps = ImageProps & { webpSrc?: string }
  * sizing and loading behavior.
  */
 export function AnimatedImage({ webpSrc, ...props }: AnimatedImageProps) {
+  const pictureStyle: CSSProperties | undefined = props.fill
+    ? { position: 'absolute', inset: 0, display: 'block' }
+    : undefined
+
   return (
-    <picture>
+    <picture style={pictureStyle}>
       {webpSrc ? <source type="image/webp" srcSet={webpSrc} /> : null}
       <Image {...props} />
     </picture>


### PR DESCRIPTION
Promote the exact staging tree through the canonical staging-to-main path.

Included: position the shared AnimatedImage picture wrapper when using Next Image fill sizing, completing the dashboard image/runtime fix from PR #696.

Validated in PR #698 with UI and app type-check, lint, build, unit tests, and Validation/Gate.