### PR TITLE
fix(app): restore sidebar and app bar geometry

### DIFF
--- a/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
+++ b/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
@@ -14,7 +14,7 @@
   box-sizing: border-box;
   display: flex;
   width: 100%;
-  min-height: 56px;
+  min-height: 60px;
   align-items: center;
   padding: 8px 16px;
 }
@@ -90,14 +90,6 @@
   .mainOpen {
     margin-left: 0;
     width: 100%;
-  }
-}
-
-@media (max-width: 767.95px) {
-  .mainClosed,
-  .mainOpen {
-    margin-top: 60px;
-    margin-left: 10px;
   }
 }
 

--- a/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Header/index.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@nl/ui/base/button'
-import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 import { Menu } from 'lucide-react'
+import { useMediaQuery } from '@nl/ui/hooks/useMediaQuery'
 
 import { useNavigation } from '@/contexts/NavigationContext'
+import { desktopNavigationMediaQuery } from '@/app/_layout/navigation-breakpoints'
 
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import LogoSection from '../_LogoSection'
@@ -17,7 +18,8 @@ const pages = [
 
 const Header = () => {
   const { drawerOpen, toggleDrawer } = useNavigation()
-  const isCompactScreen = useMediaQuery('(max-width:1023.95px)')
+  const isDesktopNavigation = useMediaQuery(desktopNavigationMediaQuery)
+  const isCompactScreen = !isDesktopNavigation
 
   return (
     <div className="flex w-full flex-row items-center justify-between">

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
@@ -61,8 +61,10 @@ describe('private sidebar frame', () => {
 
     const navigation = screen.getByRole('navigation', { name: 'Primary navigation' })
     const overlay = navigation.querySelector('[aria-hidden="false"]')
+    const scrollArea = navigation.querySelector('[style*="height"]')
 
     expect((overlay as HTMLElement | null)?.style.top).toBe('60px')
+    expect((scrollArea as HTMLElement | null)?.style.height).toBe('calc(100vh - 60px)')
   })
 
   it('keeps the desktop drawer interactive only while open', () => {

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
@@ -38,19 +38,14 @@ function SidebarFrame({ children, footer }: SidebarFrameProps) {
 
   const drawer = useMemo(
     () => (
-      <ScrollArea
-        style={{
-          height: isCompactScreen ? 'calc(100vh - 56px)' : 'calc(100vh - 60px)',
-        }}
-        viewportClassName="px-4"
-      >
+      <ScrollArea style={{ height: `calc(100vh - ${appHeaderHeight}px)` }} viewportClassName="px-4">
         <div className="flex h-full flex-col justify-between">
           <div>{children}</div>
           {footer && <div className="flex flex-col items-center">{footer}</div>}
         </div>
       </ScrollArea>
     ),
-    [children, footer, isCompactScreen]
+    [children, footer]
   )
 
   return (

--- a/apps/app/src/components/providers/PublicNavigation.test.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.test.tsx
@@ -30,5 +30,8 @@ describe('PublicNavigation', () => {
     expect(disclosure?.open).toBe(true)
     expect(toggle.getAttribute('aria-controls')).toBe('public-desktop-navigation')
     expect(document.getElementById('public-desktop-navigation')).toBeTruthy()
+
+    const mobilePanel = document.getElementById('public-mobile-navigation')
+    expect(mobilePanel?.className).toContain('top-[60px]')
   })
 })

--- a/apps/app/src/components/providers/PublicNavigation.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.tsx
@@ -43,7 +43,7 @@ export default function PublicNavigation({ children }: PropsWithChildren) {
                 label="Toggle navigation"
                 className="lg:hidden"
                 summaryClassName="h-[34px] w-[34px] overflow-hidden rounded-md bg-muted text-blue transition-all duration-200 hover:bg-purple hover:text-foreground"
-                panelClassName="fixed top-14 bottom-0 left-0 z-40 w-full max-w-xs overflow-y-auto bg-sidebar text-sidebar-foreground shadow-lg"
+                panelClassName="fixed top-[60px] bottom-0 left-0 z-40 w-full max-w-xs overflow-y-auto bg-sidebar text-sidebar-foreground shadow-lg"
               >
                 <div className="border-b border-sidebar-border px-4 py-3">
                   <div className="flex items-center gap-3 text-sidebar-foreground">


### PR DESCRIPTION
## Summary
- keep the app bar, main content, and sidebar aligned to one 60px shell height
- remove the stale mobile 10px main offset
- keep compact sidebar content below the bar and reuse the canonical navigation breakpoint
- align public mobile navigation with the same app bar height

## Validation
- `bun --filter app test -- src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx src/app/_layout/_MainLayout/_Header/index.test.tsx src/components/providers/PublicNavigation.test.tsx`
- `bun --filter app lint`
- `bun --filter app type-check`
- `bun --filter app build`
- `git diff --check`
- `bunx prettier --check`

Draft milestone: promote after final local visual review.