### PR TITLE
promote: restore reliable public sidebar toggle

### DIFF
--- a/apps/app/src/components/providers/PublicNavigation.test.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import PublicNavigation from './PublicNavigation'
@@ -17,19 +17,24 @@ beforeEach(() => {
 })
 
 describe('PublicNavigation', () => {
-  it('keeps the desktop sidebar open by default with a native disclosure control', () => {
+  it('keeps the desktop sidebar open with an accessible native disclosure control', () => {
     render(
       <PublicNavigation>
         <p>Public content</p>
       </PublicNavigation>
     )
 
-    const toggle = screen.getByLabelText('Toggle sidebar')
+    const toggle = screen.getByRole('button', { name: 'Toggle sidebar' })
     const disclosure = toggle.closest('details')
 
     expect(disclosure?.open).toBe(true)
     expect(toggle.getAttribute('aria-controls')).toBe('public-desktop-navigation')
-    expect(document.getElementById('public-desktop-navigation')).toBeTruthy()
+
+    fireEvent.click(toggle)
+    expect(disclosure?.open).toBe(false)
+
+    fireEvent.click(toggle)
+    expect(disclosure?.open).toBe(true)
 
     const mobilePanel = document.getElementById('public-mobile-navigation')
     expect(mobilePanel?.className).toContain('top-[60px]')

--- a/apps/app/src/components/providers/PublicNavigation.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.tsx
@@ -26,6 +26,7 @@ export default function PublicNavigation({ children }: PropsWithChildren) {
               </div>
               <details id="public-desktop-navigation-toggle" open className="hidden lg:block">
                 <summary
+                  role="button"
                   aria-controls="public-desktop-navigation"
                   aria-label="Toggle sidebar"
                   className="flex h-[34px] w-[34px] cursor-pointer list-none items-center justify-center overflow-hidden rounded-md bg-muted text-blue outline-none transition-colors duration-200 hover:bg-purple hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden"


### PR DESCRIPTION
## Summary
Promote the validated staging fix for the app public sidebar into main.

## Included change
- keep the public app shell server-rendered and lightweight
- expose the desktop native sidebar disclosure as an explicit accessible button
- add a close/reopen regression test

## Validation
Staging PR #704 passed format, lint, type-check, build, unit, and validation gate checks. Local app tests passed 189/189; contract tests passed 220/220; local browser smoke verified app-bar padding and sidebar close/reopen geometry.

This promotion contains the exact staging tree.