### PR TITLE
promote: remove unused openzeppelin app dependency

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -24,7 +24,6 @@
     "@nl/imx-passport": "workspace:*",
     "@nl/sentry-client": "workspace:*",
     "@nl/ui": "workspace:*",
-    "@openzeppelin/contracts": "^5.6.1",
     "@reown/appkit": "^1.8.23",
     "@reown/appkit-adapter-wagmi": "^1.8.23",
     "@sentry/nextjs": "^10.69.0",

--- a/bun.lock
+++ b/bun.lock
@@ -77,7 +77,6 @@
         "@nl/imx-passport": "workspace:*",
         "@nl/sentry-client": "workspace:*",
         "@nl/ui": "workspace:*",
-        "@openzeppelin/contracts": "^5.6.1",
         "@reown/appkit": "^1.8.23",
         "@reown/appkit-adapter-wagmi": "^1.8.23",
         "@sentry/nextjs": "^10.69.0",
@@ -1386,7 +1385,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
-    "@openzeppelin/contracts": ["@openzeppelin/contracts@5.6.1", "", {}, "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w=="],
+    "@openzeppelin/contracts": ["@openzeppelin/contracts@3.4.2-solc-0.7", "", {}, "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
 
@@ -6038,11 +6037,7 @@
 
     "@uniswap/sdk-core/big.js": ["big.js@5.2.2", "", {}, "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="],
 
-    "@uniswap/swap-router-contracts/@openzeppelin/contracts": ["@openzeppelin/contracts@3.4.2-solc-0.7", "", {}, "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="],
-
     "@uniswap/swap-router-contracts/dotenv": ["dotenv@14.3.2", "", {}, "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="],
-
-    "@uniswap/v3-periphery/@openzeppelin/contracts": ["@openzeppelin/contracts@3.4.2-solc-0.7", "", {}, "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="],
 
     "@uniswap/v3-sdk/@uniswap/sdk-core": ["@uniswap/sdk-core@4.2.1", "", { "dependencies": { "@ethersproject/address": "^5.0.2", "big.js": "^5.2.2", "decimal.js-light": "^2.5.0", "jsbi": "^3.1.4", "tiny-invariant": "^1.1.0", "toformat": "^2.0.0" } }, "sha512-hr7vwYrXScg+V8/rRc2UL/Ixc/p0P7yqe4D/OxzUdMRYr8RZd+8z5Iu9+WembjZT/DCdbTjde6lsph4Og0n1BQ=="],
 

--- a/test/contract/dependencies.test.ts
+++ b/test/contract/dependencies.test.ts
@@ -219,7 +219,6 @@ const ALLOWED_UNUSED: Record<string, Record<string, string>> = {
   'apps/app': {
     sharp: 'Next.js image optimization runtime dep',
     graphql: 'peer dep of graphql-request',
-    '@openzeppelin/contracts': 'typechain generated contracts/types import it',
   },
   'apps/smashers': {
     sharp: 'Next.js image optimization runtime dep',


### PR DESCRIPTION
## Promotion
Promote the validated `staging` tree to `main`.

## Included change
- remove unused direct `@openzeppelin/contracts` from `apps/app`
- prune its lockfile and dependency-contract exception
- preserve exact `main`/`staging` tree alignment

## Source validation
PR #712 passed the required staging gate: format, lint, type-check, build, and unit checks.