### PR TITLE
promote: make mobile sidebar control accessible

### DIFF
--- a/apps/app/src/components/providers/PublicNavigation.test.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.test.tsx
@@ -36,6 +36,15 @@ describe('PublicNavigation', () => {
     fireEvent.click(toggle)
     expect(disclosure?.open).toBe(true)
 
+    const mobileToggle = screen.getByRole('button', { name: 'Toggle navigation' })
+    const mobileDisclosure = mobileToggle.closest('details')
+
+    expect(mobileToggle.getAttribute('aria-controls')).toBe('public-mobile-navigation')
+    expect(mobileDisclosure?.open).toBe(false)
+
+    fireEvent.click(mobileToggle)
+    expect(mobileDisclosure?.open).toBe(true)
+
     const mobilePanel = document.getElementById('public-mobile-navigation')
     expect(mobilePanel?.className).toContain('top-[60px]')
   })

--- a/packages/ui/src/components/custom/mobile-navigation/index.tsx
+++ b/packages/ui/src/components/custom/mobile-navigation/index.tsx
@@ -22,6 +22,7 @@ export function MobileNavigationDisclosure({
   return (
     <details className={cn('group relative', className)}>
       <summary
+        role="button"
         aria-controls={id}
         aria-label={label}
         className={cn(

--- a/packages/ui/src/components/custom/mobile-navigation/mobile-navigation.test.tsx
+++ b/packages/ui/src/components/custom/mobile-navigation/mobile-navigation.test.tsx
@@ -13,13 +13,12 @@ describe('MobileNavigationDisclosure', () => {
       </MobileNavigationDisclosure>
     )
 
-    const label = screen.getByText('Toggle navigation')
-    const summary = label.closest('summary')
+    const summary = screen.getByRole('button', { name: 'Toggle navigation' })
 
     expect(summary?.getAttribute('aria-controls')).toBe('public-mobile-navigation')
     expect(screen.getByRole('navigation', { name: 'Primary navigation' })).not.toBeNull()
 
-    fireEvent.click(label)
+    fireEvent.click(summary)
 
     expect(summary?.closest('details')?.hasAttribute('open')).toBe(true)
   })


### PR DESCRIPTION
## Summary
Promote the validated staging tree to main. This restores an accessible mobile sidebar control while preserving the native server-rendered navigation and existing app-bar spacing.

This is a clean exact-tree promotion: the proposed tree is identical to origin/staging and has origin/main as its parent.

## Validation
- Staging PR #716 merged via squash after all required staging checks passed.
- `bun --filter app lint`
- `bun --filter app type-check`
- `bun --filter app test` (189 passed)
- `bun --filter app build`
- `bun --filter '@nl/ui' lint`
- `bun --filter '@nl/ui' type-check`
- `bun --filter '@nl/ui' test` (161 passed)
- local browser verification at 390px and 1280px
