### PR TITLE
chore: promote build cache reproducibility to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "license": "Apache-2.0",
   "private": true,
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "act-ci": "act --container-architecture linux/amd64 -P ubuntu-latest=-self-hosted -s GITHUB_TOKEN --var-file .env.act --secret-file .env.act -W '.github/workflows/ci.yml'",
     "add-ui": "bun --filter ui add-component $@",

--- a/test/contract/turbo-cache-scope.test.ts
+++ b/test/contract/turbo-cache-scope.test.ts
@@ -17,6 +17,7 @@ const turbo = JSON.parse(readFileSync('turbo.json', 'utf8')) as {
 }
 const rootPackage = JSON.parse(readFileSync('package.json', 'utf8')) as {
   scripts?: Record<string, string>
+  packageManager?: string
 }
 
 const envFor = (task: string) => new Set(turbo.tasks[task]?.env ?? [])
@@ -34,6 +35,10 @@ describe('Turbo cache environment scope', () => {
     )
   })
 
+  it('pins the package manager used by Vercel and local builds', () => {
+    expect(rootPackage.packageManager).toBe('bun@1.3.14')
+  })
+
   it('does not invalidate every workspace for app-specific credentials', () => {
     expect(turbo.globalEnv ?? []).toEqual(['CI', 'VERCEL_ENV'])
   })
@@ -48,15 +53,27 @@ describe('Turbo cache environment scope', () => {
 
   it('keeps environment inputs on the builds that read them', () => {
     expect(envFor('app#build')).toEqual(
-      new Set(['CI', 'NEXT_RUNTIME', 'NEXT_PUBLIC_*', 'SENTRY_AUTH_TOKEN', 'VERCEL_ENV'])
+      new Set([
+        'CI',
+        'ENABLE_EXPERIMENTAL_COREPACK',
+        'NEXT_RUNTIME',
+        'NEXT_PUBLIC_*',
+        'SENTRY_AUTH_TOKEN',
+        'SENTRY_ORG',
+        'SENTRY_PROJECT',
+        'VERCEL_ENV',
+      ])
     )
     expect(envFor('web#build')).toEqual(
       new Set([
         'CI',
         'EDGE_CONFIG',
+        'ENABLE_EXPERIMENTAL_COREPACK',
         'NEXT_RUNTIME',
         'NEXT_PUBLIC_*',
         'SENTRY_AUTH_TOKEN',
+        'SENTRY_ORG',
+        'SENTRY_PROJECT',
         'VERCEL_ENV',
       ])
     )
@@ -65,6 +82,7 @@ describe('Turbo cache environment scope', () => {
         'APPLE_CLIENT_ID',
         'APPLE_CLIENT_SECRET',
         'CI',
+        'ENABLE_EXPERIMENTAL_COREPACK',
         'FACEBOOK_CLIENT_ID',
         'FACEBOOK_CLIENT_SECRET',
         'GITHUB_ACTIONS',
@@ -76,6 +94,8 @@ describe('Turbo cache environment scope', () => {
         'NEXTAUTH_SECRET',
         'PLAYFAB_API_KEY',
         'SENTRY_AUTH_TOKEN',
+        'SENTRY_ORG',
+        'SENTRY_PROJECT',
         'TWITCH_CLIENT_ID',
         'TWITCH_CLIENT_SECRET',
         'VERCEL_ENV',

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,16 @@
     },
     "app#build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
-      "env": ["CI", "NEXT_RUNTIME", "NEXT_PUBLIC_*", "SENTRY_AUTH_TOKEN", "VERCEL_ENV"],
+      "env": [
+        "CI",
+        "ENABLE_EXPERIMENTAL_COREPACK",
+        "NEXT_RUNTIME",
+        "NEXT_PUBLIC_*",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
+        "VERCEL_ENV"
+      ],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "api#build": {
@@ -56,6 +65,7 @@
         "APPLE_CLIENT_ID",
         "APPLE_CLIENT_SECRET",
         "CI",
+        "ENABLE_EXPERIMENTAL_COREPACK",
         "FACEBOOK_CLIENT_ID",
         "FACEBOOK_CLIENT_SECRET",
         "GITHUB_ACTIONS",
@@ -67,6 +77,8 @@
         "NEXTAUTH_SECRET",
         "PLAYFAB_API_KEY",
         "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
         "TWITCH_CLIENT_ID",
         "TWITCH_CLIENT_SECRET",
         "VERCEL_ENV"
@@ -77,10 +89,13 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "CI",
+        "ENABLE_EXPERIMENTAL_COREPACK",
         "EDGE_CONFIG",
         "NEXT_RUNTIME",
         "NEXT_PUBLIC_*",
         "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
         "VERCEL_ENV"
       ],
       "outputs": [".next/**", "!.next/cache/**"]


### PR DESCRIPTION
Promotes the validated staging tree from PR #734.\n\nStaging validation passed the required format, lint, type-check, unit, build, and aggregate gate checks. The promotion uses the repository's canonical rebase path.