### PR TITLE
chore: promote Vercel Corepack hotfix to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.2.1",
   "license": "Apache-2.0",
   "private": true,
-  "packageManager": "bun@1.3.14",
   "scripts": {
     "act-ci": "act --container-architecture linux/amd64 -P ubuntu-latest=-self-hosted -s GITHUB_TOKEN --var-file .env.act --secret-file .env.act -W '.github/workflows/ci.yml'",
     "add-ui": "bun --filter ui add-component $@",

--- a/test/contract/turbo-cache-scope.test.ts
+++ b/test/contract/turbo-cache-scope.test.ts
@@ -17,7 +17,6 @@ const turbo = JSON.parse(readFileSync('turbo.json', 'utf8')) as {
 }
 const rootPackage = JSON.parse(readFileSync('package.json', 'utf8')) as {
   scripts?: Record<string, string>
-  packageManager?: string
 }
 
 const envFor = (task: string) => new Set(turbo.tasks[task]?.env ?? [])
@@ -33,10 +32,6 @@ describe('Turbo cache environment scope', () => {
     expect(rootPackage.scripts?.build).toBe(
       'turbo run api#build app#build docs#build smashers#build web#build'
     )
-  })
-
-  it('pins the package manager used by Vercel and local builds', () => {
-    expect(rootPackage.packageManager).toBe('bun@1.3.14')
   })
 
   it('does not invalidate every workspace for app-specific credentials', () => {
@@ -55,7 +50,6 @@ describe('Turbo cache environment scope', () => {
     expect(envFor('app#build')).toEqual(
       new Set([
         'CI',
-        'ENABLE_EXPERIMENTAL_COREPACK',
         'NEXT_RUNTIME',
         'NEXT_PUBLIC_*',
         'SENTRY_AUTH_TOKEN',
@@ -68,7 +62,6 @@ describe('Turbo cache environment scope', () => {
       new Set([
         'CI',
         'EDGE_CONFIG',
-        'ENABLE_EXPERIMENTAL_COREPACK',
         'NEXT_RUNTIME',
         'NEXT_PUBLIC_*',
         'SENTRY_AUTH_TOKEN',
@@ -82,7 +75,6 @@ describe('Turbo cache environment scope', () => {
         'APPLE_CLIENT_ID',
         'APPLE_CLIENT_SECRET',
         'CI',
-        'ENABLE_EXPERIMENTAL_COREPACK',
         'FACEBOOK_CLIENT_ID',
         'FACEBOOK_CLIENT_SECRET',
         'GITHUB_ACTIONS',

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,6 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "CI",
-        "ENABLE_EXPERIMENTAL_COREPACK",
         "NEXT_RUNTIME",
         "NEXT_PUBLIC_*",
         "SENTRY_AUTH_TOKEN",
@@ -65,7 +64,6 @@
         "APPLE_CLIENT_ID",
         "APPLE_CLIENT_SECRET",
         "CI",
-        "ENABLE_EXPERIMENTAL_COREPACK",
         "FACEBOOK_CLIENT_ID",
         "FACEBOOK_CLIENT_SECRET",
         "GITHUB_ACTIONS",
@@ -89,7 +87,6 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
       "env": [
         "CI",
-        "ENABLE_EXPERIMENTAL_COREPACK",
         "EDGE_CONFIG",
         "NEXT_RUNTIME",
         "NEXT_PUBLIC_*",


### PR DESCRIPTION
## Summary
Promote the validated Corepack hotfix from staging to main.

The staging hotfix removes the invalid root `packageManager` declaration and `ENABLE_EXPERIMENTAL_COREPACK` Turbo inputs that caused Vercel to run `corepack enable bun` and fail before build.

## Validation
- staging PR #737 passed the required Validation / Gate
- local grouped app, web, and smashers builds passed
- main and staging will be tree-aligned after rebase promotion

## Merge method
Rebase into main per the repository release workflow.