### PR TITLE
chore: promote staging sidebar fix to main

### DIFF
--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 
 import { cn } from '@nl/ui/utils'
 import { ScrollArea } from '@nl/ui/base/scroll-area'
+import AppBar from '@nl/ui/custom/app-bar'
 
 import Breadcrumbs from '@/components/extended/Breadcrumbs'
 import { NavigationProvider, useNavigation } from '@/contexts/NavigationContext'
@@ -52,7 +53,7 @@ function AppShellContent({ children, header, sidebar, networkWarning }: AppShell
       <div className="flex" data-sidebar-open={drawerOpen}>
         <header className="fixed top-0 right-0 left-0 z-50 border-0 bg-sidebar">
           {networkWarning}
-          <div className={styles.appBarInner}>{header}</div>
+          <AppBar>{header}</AppBar>
         </header>
 
         {sidebar}

--- a/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
+++ b/apps/app/src/app/_layout/_MainLayout/MainLayout.module.css
@@ -10,23 +10,6 @@
   height: calc(100dvh - 56px);
 }
 
-.appBarInner {
-  box-sizing: border-box;
-  display: flex;
-  width: 100%;
-  min-height: 56px;
-  align-items: center;
-  padding: 8px 16px;
-}
-
-@media (min-width: 1024px) {
-  .appBarInner {
-    height: 60px;
-    min-height: 0;
-    padding: 0 24px;
-  }
-}
-
 .mainClosed {
   transition: margin 200ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;
 }
@@ -53,11 +36,13 @@
     width 200ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;
 }
 
+.publicNavigationShell[data-public-sidebar-state='open'] .publicMain,
 .publicNavigationShell:has(:global(#public-desktop-navigation-toggle[open])) .publicMain {
   margin-left: 0;
   width: calc(100% - 260px);
 }
 
+.publicNavigationShell[data-public-sidebar-state='closed'] .publicMain,
 .publicNavigationShell:not(:has(:global(#public-desktop-navigation-toggle[open]))) .publicMain {
   margin-left: -260px;
   width: calc(100% - 260px);
@@ -68,11 +53,13 @@
   transition: width 200ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;
 }
 
+.publicNavigationShell[data-public-sidebar-state='closed'] .publicHeaderControls,
 .publicNavigationShell:not(:has(:global(#public-desktop-navigation-toggle[open])))
   .publicHeaderControls {
   width: 80px;
 }
 
+.publicNavigationShell[data-public-sidebar-state='closed'] .publicDesktopSidebar,
 .publicNavigationShell:not(:has(:global(#public-desktop-navigation-toggle[open])))
   .publicDesktopSidebar {
   transform: translateX(-100%);
@@ -101,7 +88,9 @@
 }
 
 @media (max-width: 1023.95px) {
+  .publicNavigationShell[data-public-sidebar-state='open'] .publicMain,
   .publicNavigationShell:has(:global(#public-desktop-navigation-toggle[open])) .publicMain,
+  .publicNavigationShell[data-public-sidebar-state='closed'] .publicMain,
   .publicNavigationShell:not(:has(:global(#public-desktop-navigation-toggle[open]))) .publicMain {
     margin-left: 0;
     width: 100%;

--- a/apps/app/src/components/providers/PublicDesktopNavigationToggle.tsx
+++ b/apps/app/src/components/providers/PublicDesktopNavigationToggle.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+function syncSidebarState(details: HTMLDetailsElement) {
+  const shell = details.closest<HTMLElement>('[data-public-navigation]')
+  if (shell) shell.dataset.publicSidebarState = details.open ? 'open' : 'closed'
+}
+
+export default function PublicDesktopNavigationToggle() {
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+
+  useEffect(() => {
+    if (detailsRef.current) syncSidebarState(detailsRef.current)
+  }, [])
+
+  return (
+    <details
+      ref={detailsRef}
+      id="public-desktop-navigation-toggle"
+      open
+      className="hidden lg:block"
+      onToggle={(event) => syncSidebarState(event.currentTarget)}
+    >
+      <summary
+        role="button"
+        aria-controls="public-desktop-navigation"
+        aria-label="Toggle sidebar"
+        className="flex h-[34px] w-[34px] cursor-pointer list-none items-center justify-center overflow-hidden rounded-md bg-muted text-blue outline-none transition-colors duration-200 hover:bg-purple hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden"
+      >
+        <span aria-hidden="true" className="flex size-6 flex-col justify-center gap-1.5">
+          <span className="h-0.5 w-full rounded-full bg-current" />
+          <span className="h-0.5 w-full rounded-full bg-current" />
+          <span className="h-0.5 w-full rounded-full bg-current" />
+        </span>
+        <span className="sr-only">Toggle sidebar</span>
+      </summary>
+    </details>
+  )
+}

--- a/apps/app/src/components/providers/PublicNavigation.test.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.test.tsx
@@ -26,15 +26,19 @@ describe('PublicNavigation', () => {
 
     const toggle = screen.getByRole('button', { name: 'Toggle sidebar' })
     const disclosure = toggle.closest('details')
+    const shell = document.querySelector('[data-public-navigation]')
 
     expect(disclosure?.open).toBe(true)
+    expect(shell?.getAttribute('data-public-sidebar-state')).toBe('open')
     expect(toggle.getAttribute('aria-controls')).toBe('public-desktop-navigation')
 
     fireEvent.click(toggle)
     expect(disclosure?.open).toBe(false)
+    expect(shell?.getAttribute('data-public-sidebar-state')).toBe('closed')
 
     fireEvent.click(toggle)
     expect(disclosure?.open).toBe(true)
+    expect(shell?.getAttribute('data-public-sidebar-state')).toBe('open')
 
     const mobileToggle = screen.getByRole('button', { name: 'Toggle navigation' })
     const mobileDisclosure = mobileToggle.closest('details')

--- a/apps/app/src/components/providers/PublicNavigation.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.tsx
@@ -1,11 +1,13 @@
 import type { PropsWithChildren } from 'react'
 
+import AppBar from '@nl/ui/custom/app-bar'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import MobileNavigationDisclosure from '@nl/ui/custom/mobile-navigation'
 import { cn } from '@nl/ui/utils'
 
 import LogoSection from '@/app/_layout/_MainLayout/_LogoSection'
 import styles from '@/app/_layout/_MainLayout/MainLayout.module.css'
+import PublicDesktopNavigationToggle from './PublicDesktopNavigationToggle'
 import PublicNavLinks from './PublicNavLinks'
 
 const pages = [
@@ -16,29 +18,19 @@ const pages = [
 
 export default function PublicNavigation({ children }: PropsWithChildren) {
   return (
-    <div className={cn('flex', styles.publicNavigationShell)} data-public-navigation>
+    <div
+      className={cn('flex', styles.publicNavigationShell)}
+      data-public-navigation
+      data-public-sidebar-state="open"
+    >
       <header className="fixed top-0 right-0 left-0 z-50 border-0 bg-sidebar">
-        <div className={styles.appBarInner}>
+        <AppBar>
           <div className="flex w-full flex-row items-center justify-between">
             <div className={cn('flex items-center', styles.publicHeaderControls)}>
               <div className="hidden flex-grow lg:block">
                 <LogoSection />
               </div>
-              <details id="public-desktop-navigation-toggle" open className="hidden lg:block">
-                <summary
-                  role="button"
-                  aria-controls="public-desktop-navigation"
-                  aria-label="Toggle sidebar"
-                  className="flex h-[34px] w-[34px] cursor-pointer list-none items-center justify-center overflow-hidden rounded-md bg-muted text-blue outline-none transition-colors duration-200 hover:bg-purple hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden"
-                >
-                  <span aria-hidden="true" className="flex size-6 flex-col justify-center gap-1.5">
-                    <span className="h-0.5 w-full rounded-full bg-current" />
-                    <span className="h-0.5 w-full rounded-full bg-current" />
-                    <span className="h-0.5 w-full rounded-full bg-current" />
-                  </span>
-                  <span className="sr-only">Toggle sidebar</span>
-                </summary>
-              </details>
+              <PublicDesktopNavigationToggle />
               <MobileNavigationDisclosure
                 id="public-mobile-navigation"
                 label="Toggle navigation"
@@ -71,7 +63,7 @@ export default function PublicNavigation({ children }: PropsWithChildren) {
               ))}
             </div>
           </div>
-        </div>
+        </AppBar>
       </header>
 
       <nav

--- a/packages/ui/src/components/custom/app-bar/app-bar.test.tsx
+++ b/packages/ui/src/components/custom/app-bar/app-bar.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import AppBar from './index'
+
+describe('AppBar', () => {
+  it('keeps the shared responsive spacing contract', () => {
+    const { container } = render(<AppBar>Shell controls</AppBar>)
+
+    const appBar = container.firstElementChild
+
+    expect(appBar?.className).toContain('box-border')
+    expect(appBar?.className).toContain('min-h-14')
+    expect(appBar?.className).toContain('px-4')
+    expect(appBar?.className).toContain('py-2')
+    expect(appBar?.className).toContain('lg:h-[60px]')
+    expect(appBar?.className).toContain('lg:px-6')
+    expect(appBar?.className).toContain('lg:py-0')
+  })
+})

--- a/packages/ui/src/components/custom/app-bar/index.tsx
+++ b/packages/ui/src/components/custom/app-bar/index.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react'
+
+import { cn } from '@nl/ui/utils'
+
+export type AppBarProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
+
+export function AppBar({ children, className, ...props }: AppBarProps) {
+  return (
+    <div
+      className={cn(
+        'box-border flex min-h-14 w-full items-center px-4 py-2 lg:h-[60px] lg:min-h-0 lg:px-6 lg:py-0',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default AppBar

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -7,7 +7,7 @@ const webManifest = 'apps/web/package.json'
 const webNextConfig = 'apps/web/next.config.ts'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
-const appShellStyles = 'apps/app/src/app/_layout/_MainLayout/MainLayout.module.css'
+const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
 const appNavigationContext = 'apps/app/src/contexts/NavigationContext.tsx'
 const appNavigationBreakpoints = 'apps/app/src/app/_layout/navigation-breakpoints.ts'
@@ -88,12 +88,14 @@ describe('app performance contracts', () => {
 
   it('keeps the private app bar padded and vertically centered', () => {
     const shellSource = readFileSync(appShell, 'utf8')
-    const shellStyles = readFileSync(appShellStyles, 'utf8')
+    const appBarSource = readFileSync(sharedAppBar, 'utf8')
 
-    expect(shellSource).toContain('<div className={styles.appBarInner}>{header}</div>')
-    expect(shellStyles).toContain('.appBarInner')
-    expect(shellStyles).toContain('padding: 8px 16px;')
-    expect(shellStyles).toContain('padding: 0 24px;')
+    expect(shellSource).toContain("from '@nl/ui/custom/app-bar'")
+    expect(shellSource).toContain('<AppBar>{header}</AppBar>')
+    expect(appBarSource).toContain('min-h-14')
+    expect(appBarSource).toContain('px-4 py-2')
+    expect(appBarSource).toContain('lg:h-[60px]')
+    expect(appBarSource).toContain('lg:px-6 lg:py-0')
   })
 
   it('shares the accessible native carousel and keeps the app free of slider runtimes', () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -309,6 +309,9 @@ const degensSearchParamsBoundary =
 const degensTopNav = 'apps/app/src/components/extended/DegensTopNav/index.tsx'
 const publicMainLayout = 'apps/app/src/app/_layout/_PublicMainLayout/index.tsx'
 const publicNavigation = 'apps/app/src/components/providers/PublicNavigation.tsx'
+const publicDesktopNavigationToggle =
+  'apps/app/src/components/providers/PublicDesktopNavigationToggle.tsx'
+const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
 const publicContentContainer = 'apps/app/src/components/wrapper/PublicContentContainer.tsx'
 const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
 const sharedMobileNavigation = 'packages/ui/src/components/custom/mobile-navigation/index.tsx'
@@ -848,12 +851,19 @@ describe('public app shell contract', () => {
 
   it('keeps the public app bar padded and vertically centered', () => {
     const navigationSource = readFileSync(join(process.cwd(), publicNavigation), 'utf8')
+    const appBarSource = readFileSync(join(process.cwd(), sharedAppBar), 'utf8')
 
-    expect(navigationSource).toContain('<div className={styles.appBarInner}>')
+    expect(navigationSource).toContain("from '@nl/ui/custom/app-bar'")
+    expect(navigationSource).toContain('<AppBar>')
+    expect(appBarSource).toContain('min-h-14')
+    expect(appBarSource).toContain('px-4 py-2')
+    expect(appBarSource).toContain('lg:h-[60px]')
+    expect(appBarSource).toContain('lg:px-6 lg:py-0')
   })
 
   it('keeps mobile navigation server-rendered and avoids heavy shell primitives', () => {
     const navigationSource = readFileSync(join(process.cwd(), publicNavigation), 'utf8')
+    const toggleSource = readFileSync(join(process.cwd(), publicDesktopNavigationToggle), 'utf8')
     const navigationStyles = readFileSync(
       join(process.cwd(), 'apps/app/src/app/_layout/_MainLayout/MainLayout.module.css'),
       'utf8'
@@ -867,14 +877,20 @@ describe('public app shell contract', () => {
     expect(navigationSource).not.toContain("from '@nl/ui/base/scroll-area'")
     expect(navigationSource).not.toContain("from '@nl/ui/base/icon'")
     expect(navigationSource).not.toContain("from '@/components/extended/Breadcrumbs'")
-    expect(navigationSource).toContain('<details id="public-desktop-navigation-toggle"')
-    expect(navigationSource).toContain('aria-controls="public-desktop-navigation"')
-    expect(navigationSource).not.toContain('PublicDesktopSidebarToggle')
+    expect(navigationSource).toContain("from './PublicDesktopNavigationToggle'")
+    expect(toggleSource).toContain("'use client'")
+    expect(toggleSource).toContain('<details')
+    expect(toggleSource).toContain('onToggle=')
+    expect(toggleSource).toContain('aria-controls="public-desktop-navigation"')
+    expect(toggleSource).not.toContain("from '@nl/ui/base/sheet'")
+    expect(toggleSource).not.toContain("from 'lucide-react'")
     expect(navigationSource).toContain('{children}')
     expect(navigationSource).not.toContain('PublicMainContent')
     expect(
       existsSync(join(process.cwd(), 'apps/app/src/components/providers/PublicMainContent.tsx'))
     ).toBe(false)
+    expect(navigationStyles).toContain("data-public-sidebar-state='open'")
+    expect(navigationStyles).toContain("data-public-sidebar-state='closed'")
     expect(navigationStyles).toContain(':has(:global(#public-desktop-navigation-toggle[open]))')
     expect(navigationStyles).toContain(
       ':not(:has(:global(#public-desktop-navigation-toggle[open])))'
@@ -1274,8 +1290,14 @@ describe('dashboard burner loading contract', () => {
 describe('private app bar contract', () => {
   it('keeps the shared app bar padded and vertically centered', () => {
     const source = readFileSync(join(process.cwd(), appShell), 'utf8')
+    const appBarSource = readFileSync(join(process.cwd(), sharedAppBar), 'utf8')
 
-    expect(source).toContain('<div className={styles.appBarInner}>{header}</div>')
+    expect(source).toContain("from '@nl/ui/custom/app-bar'")
+    expect(source).toContain('<AppBar>{header}</AppBar>')
+    expect(appBarSource).toContain('min-h-14')
+    expect(appBarSource).toContain('px-4 py-2')
+    expect(appBarSource).toContain('lg:h-[60px]')
+    expect(appBarSource).toContain('lg:px-6 lg:py-0')
   })
 })
 


### PR DESCRIPTION
## Promotion

Promote the validated staging tree from PR #740 to `main`.

The tree is exact: `HEAD^{tree}` matches `origin/staging^{tree}`. The feature PR passed hosted format, lint, type-check, build, unit, and validation-gate checks before merging into staging.

## Included fix

- restore reliable public sidebar open/close layout state
- centralize responsive app-bar padding for public and private shells
- keep the navigation shell lightweight and accessible
