### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/app/(private-routes)/dashboard/overview/_MyRentals/RentalsTableSimple.test.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/_MyRentals/RentalsTableSimple.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import type { RentalDataGrid } from '@/types/rentalDataGrid'
+import RentalsTableSimple from './RentalsTableSimple'
+
+const rental: RentalDataGrid = {
+  id: 'rental-1',
+  rentalId: 'rental-1',
+  degenId: '42',
+  multiplier: 1,
+  roi: 12.5,
+  earningCap: 100,
+  category: 'direct-rental',
+  totalEarnings: 40,
+}
+
+describe('RentalsTableSimple', () => {
+  it('renders shared table semantics and formatted rental values', () => {
+    render(
+      <RentalsTableSimple
+        rentals={[rental]}
+        columns={[
+          { id: 'degenId', label: 'Degen ID' },
+          { id: 'winRate', label: 'Win Rate' },
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('table', { name: 'simple table' })).not.toBeNull()
+    expect(screen.getByRole('columnheader', { name: 'Degen ID' })).not.toBeNull()
+    expect(screen.getByRole('cell', { name: '42' })).not.toBeNull()
+    expect(screen.getByRole('cell', { name: '0%' })).not.toBeNull()
+  })
+
+  it('uses the visible column count for the empty state', () => {
+    render(
+      <RentalsTableSimple
+        rentals={[]}
+        columns={[
+          { id: 'degenId', label: 'Degen ID' },
+          { id: 'earningCapProgress', label: 'Earnings Cap' },
+        ]}
+      />
+    )
+
+    const emptyState = screen.getByRole('cell', { name: /don't have any rentals yet/i })
+    expect(emptyState.getAttribute('colspan')).toBe('2')
+  })
+})

--- a/apps/app/src/app/(private-routes)/dashboard/overview/_MyRentals/RentalsTableSimple.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/overview/_MyRentals/RentalsTableSimple.tsx
@@ -1,6 +1,7 @@
 import type { RentalDataGrid } from '@/types/rentalDataGrid'
 import type { ColumnType } from '.'
 import { Countdown } from '@nl/ui/base/countdown'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@nl/ui/base/table'
 import { formatNumberToDisplay } from '@nl/ui/utils'
 import ProgressBar from '@/components/wrapper/ProgressBar'
 
@@ -9,104 +10,94 @@ interface RentalsTableSimpleProps {
   columns: ColumnType[]
 }
 
+const renderRentalCell = (rental: RentalDataGrid, column: ColumnType): React.ReactNode => {
+  const value = rental[column.id as keyof RentalDataGrid]
+
+  if (column.id === 'earningCap') {
+    return (
+      <span className="text-base">
+        {formatNumberToDisplay(rental.totalEarnings)} / {formatNumberToDisplay(value as number)}
+      </span>
+    )
+  }
+
+  if (column.id === 'rentalRenewsIn') {
+    return (
+      <span className="text-warning">
+        <Countdown date={new Date((value as number) * 1000)} />
+      </span>
+    )
+  }
+
+  if (column.id === 'winRate') {
+    return <>{formatNumberToDisplay(value as number)}%</>
+  }
+
+  if (column.id === 'profits' || column.id === 'netEarning') {
+    return formatNumberToDisplay(value as number)
+  }
+
+  if (column.id === 'earningCapProgress') {
+    const val = (100 / rental.earningCap) * (rental.totalEarnings ?? 0)
+
+    return (
+      <ProgressBar value={val}>
+        {rental.earningCap !== rental.totalEarnings ? (
+          `${rental.totalEarnings} / ${rental.earningCap}`
+        ) : (
+          <span className="text-[10px]">
+            LIMIT REACHED. RENEWS IN{' '}
+            <span className="text-[10px] text-warning">
+              <Countdown date={new Date((rental.rentalRenewsIn ?? 0) * 1000)} />
+            </span>
+          </span>
+        )}
+      </ProgressBar>
+    )
+  }
+
+  return value
+}
+
 const RentalsTableSimple = ({ rentals, columns }: RentalsTableSimpleProps): React.ReactNode => (
   <div className="h-full w-full overflow-hidden rounded-none bg-transparent">
     <div className="h-full max-h-[750px] overflow-auto rounded-lg border bg-background">
-      <table className="w-full border-collapse text-sm" aria-label="simple table">
-        <thead className="sticky top-0 z-10 bg-background">
-          <tr>
-            {columns.map((column: ColumnType) => (
-              <th
+      <Table aria-label="simple table" className="border-collapse">
+        <TableHeader className="sticky top-0 z-10 bg-background">
+          <TableRow className="border-0 hover:bg-transparent">
+            {columns.map((column) => (
+              <TableHead
                 key={column.id}
+                scope="col"
                 align={column.align}
                 style={{ minWidth: column.minWidth }}
                 className="px-4 py-3 font-medium text-muted-foreground"
               >
                 {column.label}
-              </th>
+              </TableHead>
             ))}
-          </tr>
-        </thead>
-        <tbody>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {rentals?.length > 0 ? (
-            rentals.map((rental: RentalDataGrid) => (
-              <tr key={rental.rentalId || rental.id} className="hover:bg-accent/50">
-                {columns.map((column: ColumnType) => {
-                  const value = rental[column.id as keyof RentalDataGrid]
-                  if (column.id === 'earningCap') {
-                    return (
-                      <td key={column.id} align={column.align} className="px-4 py-3">
-                        <span className="text-base">
-                          {formatNumberToDisplay(rental.totalEarnings)} /{' '}
-                          {formatNumberToDisplay(value as number)}
-                        </span>
-                      </td>
-                    )
-                  }
-
-                  if (column.id === 'rentalRenewsIn') {
-                    return (
-                      <td key={column.id} align={column.align} className="px-4 py-3">
-                        <span className="text-warning">
-                          <Countdown date={new Date((value as number) * 1000)} />
-                        </span>
-                      </td>
-                    )
-                  }
-
-                  if (column.id === 'winRate') {
-                    return (
-                      <td key={column.id} align={column.align} className="px-4 py-3">
-                        {formatNumberToDisplay(value as number)}%
-                      </td>
-                    )
-                  }
-
-                  if (column.id === 'profits' || column.id === 'netEarning') {
-                    return (
-                      <td key={column.id} align={column.align} className="px-4 py-3">
-                        {formatNumberToDisplay(value as number)}
-                      </td>
-                    )
-                  }
-
-                  if (column.id === 'earningCapProgress') {
-                    const val = (100 / rental.earningCap) * (rental.totalEarnings ?? 0)
-                    return (
-                      <td key={column.id} align={column.align} className="px-4 py-3">
-                        <ProgressBar value={val}>
-                          {rental.earningCap !== rental.totalEarnings ? (
-                            `${rental.totalEarnings} / ${rental.earningCap}`
-                          ) : (
-                            <span className="text-[10px]">
-                              LIMIT REACHED. RENEWS IN{' '}
-                              <span className="text-[10px] text-warning">
-                                <Countdown date={new Date((rental.rentalRenewsIn ?? 0) * 1000)} />
-                              </span>
-                            </span>
-                          )}
-                        </ProgressBar>
-                      </td>
-                    )
-                  }
-
-                  return (
-                    <td key={column.id} align={column.align} className="px-4 py-3">
-                      {value}
-                    </td>
-                  )
-                })}
-              </tr>
+            rentals.map((rental) => (
+              <TableRow key={rental.rentalId || rental.id} className="border-0 hover:bg-accent/50">
+                {columns.map((column) => (
+                  <TableCell key={column.id} align={column.align} className="px-4 py-3">
+                    {renderRentalCell(rental, column)}
+                  </TableCell>
+                ))}
+              </TableRow>
             ))
           ) : (
-            <tr>
-              <td colSpan={7} className="h-full px-4 py-3">
+            <TableRow className="border-0 hover:bg-transparent">
+              <TableCell colSpan={columns.length} className="h-full px-4 py-3">
                 <span className="text-muted-foreground">You don&apos;t have any rentals yet</span>
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   </div>
 )

--- a/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/rentals/MyRentalsDataGrid.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react'
 import { ChevronDown, ChevronUp, Pencil } from 'lucide-react'
 import { Button } from '@nl/ui/base/button'
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@nl/ui/base/dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@nl/ui/base/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@nl/ui/base/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@nl/ui/base/table'
 import { CircularProgress } from '@nl/ui/custom/circular-progress'


### PR DESCRIPTION
## Summary
Promote the validated staging snapshot to `main`.

This promotion commit was created from `origin/main` and its tree matches `origin/staging` exactly.

## Included milestone
- migrate the overview rentals table to shared accessible shadcn table primitives
- consolidate repeated rental cell rendering without changing displayed values or layout intent
- fix empty-state colspan sizing and add regression coverage
- remove an unused dialog import

## Validation
Feature PR #748 passed staging Format, Lint, Type-Check, Build, Unit, and Validation / Gate.

## Promotion
- target: `main`
- merge method: rebase per repository release workflow
- no dependency, environment, or deployment configuration changes