### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -43,7 +43,14 @@ function AppShellContent({ children, header, sidebar, networkWarning }: AppShell
 
   const content = (
     <>
-      <Breadcrumbs separator="chevron-right" navigation={navigation} icon title rightAlign />
+      <Breadcrumbs
+        pathname={pathname ?? ''}
+        separator="chevron-right"
+        navigation={navigation}
+        icon
+        title
+        rightAlign
+      />
       {children}
     </>
   )

--- a/apps/app/src/components/extended/Breadcrumbs.tsx
+++ b/apps/app/src/components/extended/Breadcrumbs.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
 import Link from 'next/link'
 
 import { AppNavIcon } from '@/components/AppNavIcon'
@@ -13,31 +12,42 @@ import type { NavItemType, NavItemTypeObject } from '@/types'
 
 const gridSpacing = 3 // 24px
 
-const linkSX = {
-  display: 'flex',
-  color: 'var(--color-background)',
-  textDecoration: 'none',
-  alignContent: 'center',
-  alignItems: 'center',
-}
-
-interface BreadCrumbSxProps extends React.CSSProperties {
-  mb?: string
-  bgcolor?: string
-}
-
 interface BreadCrumbsProps {
   card?: boolean
   divider?: boolean
   icon?: boolean
   icons?: boolean
-  maxItems?: number
   navigation?: NavItemTypeObject
+  pathname?: string
   rightAlign?: boolean
   separator?: AppNavIconName
   title?: boolean
   titleBottom?: boolean
-  sx?: BreadCrumbSxProps
+}
+
+const findBreadcrumb = (navigation: NavItemTypeObject | undefined, pathname: string) => {
+  let main: NavItemType | undefined
+  let item: NavItemType | undefined
+
+  const visit = (menu: NavItemType, parentMenu: NavItemType): boolean => {
+    for (const child of menu.children ?? []) {
+      if (child.type === 'collapse' && visit(child, child)) return true
+
+      if (child.type === 'item' && pathname === BASE_PATH + child.url) {
+        main = parentMenu
+        item = child
+        return true
+      }
+    }
+
+    return false
+  }
+
+  for (const menu of navigation?.items ?? []) {
+    if (menu.type === 'group' && visit(menu, menu)) break
+  }
+
+  return { main, item }
 }
 
 // ==============================|| BREADCRUMBS ||============================== //
@@ -47,8 +57,8 @@ const Breadcrumbs = ({
   divider,
   icon,
   icons,
-  maxItems,
   navigation,
+  pathname = '',
   rightAlign,
   separator,
   title,
@@ -62,37 +72,7 @@ const Breadcrumbs = ({
     height: '16px',
   }
 
-  const [main, setMain] = useState<NavItemType | undefined>()
-  const [item, setItem] = useState<NavItemType>()
-
-  const getCollapse = useCallback(
-    (menu: NavItemType) => {
-      const recurse = (m: NavItemType, parentMenu: NavItemType) => {
-        if (m.children) {
-          m.children.forEach((collapse) => {
-            if (collapse.type === 'collapse') {
-              recurse(collapse, collapse)
-            } else if (collapse.type === 'item') {
-              if (document.location.pathname === BASE_PATH + collapse.url) {
-                setMain(parentMenu)
-                setItem(collapse)
-              }
-            }
-          })
-        }
-      }
-      recurse(menu, menu)
-    },
-    [setMain, setItem]
-  )
-
-  useEffect(() => {
-    navigation?.items?.forEach((menu: NavItemType) => {
-      if (menu.type && menu.type === 'group') {
-        getCollapse(menu as { children: NavItemType[]; type?: string })
-      }
-    })
-  }, [navigation, getCollapse])
+  const { main, item } = findBreadcrumb(navigation, pathname)
 
   // item separator
   const separatorIcon = <AppNavIcon name={separator || 'tally-1'} size="sm" />

--- a/apps/app/src/components/presentation.test.tsx
+++ b/apps/app/src/components/presentation.test.tsx
@@ -58,13 +58,11 @@ describe('Breadcrumbs', () => {
     ],
   }
 
-  it('resolves nested routes and renders the full title and icon variants', async () => {
-    const originalLoc = document.location
-    const loc = { pathname: '/profile' } as Location
-    Object.defineProperty(document, 'location', { value: loc, writable: true, configurable: true })
+  it('resolves nested routes and renders the full title and icon variants', () => {
     const { rerender } = render(
       <Breadcrumbs
         navigation={navigation as never}
+        pathname="/profile"
         card={false}
         icons
         rightAlign
@@ -73,7 +71,7 @@ describe('Breadcrumbs', () => {
       />
     )
 
-    expect(await screen.findAllByText('Profile')).toHaveLength(2)
+    expect(screen.getAllByText('Profile')).toHaveLength(2)
     expect(screen.getByText('Settings')).not.toBeNull()
     expect(screen.getByText('Dashboard')).not.toBeNull()
     expect(screen.getAllByText('chevron-right')).toHaveLength(2)
@@ -81,22 +79,16 @@ describe('Breadcrumbs', () => {
     rerender(
       <Breadcrumbs
         navigation={navigation as never}
+        pathname="/profile"
         card={false}
         divider={false}
         icon
         title
         titleBottom
-        maxItems={3}
       />
     )
     expect(screen.getByText('house')).not.toBeNull()
     expect(screen.getAllByText('Profile')).toHaveLength(2)
-
-    Object.defineProperty(document, 'location', {
-      value: originalLoc,
-      writable: true,
-      configurable: true,
-    })
   })
 
   it('omits the card when an item disables breadcrumbs or no route matches', async () => {
@@ -114,12 +106,12 @@ describe('Breadcrumbs', () => {
         },
       ],
     }
-    const { container, rerender } = render(<Breadcrumbs navigation={hiddenNavigation as never} />)
-    await Promise.resolve()
+    const { container, rerender } = render(
+      <Breadcrumbs navigation={hiddenNavigation as never} pathname="/hidden" />
+    )
     expect(container.querySelector('[aria-label="breadcrumb"]')).toBeNull()
 
-    window.history.replaceState({}, '', '/missing')
-    rerender(<Breadcrumbs navigation={navigation as never} />)
+    rerender(<Breadcrumbs navigation={navigation as never} pathname="/missing" />)
     expect(container.querySelector('[aria-label="breadcrumb"]')).toBeNull()
   })
 })

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -8,6 +8,7 @@ const webNextConfig = 'apps/web/next.config.ts'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
+const appBreadcrumbs = 'apps/app/src/components/extended/Breadcrumbs.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
 const appNavigationContext = 'apps/app/src/contexts/NavigationContext.tsx'
 const appNavigationBreakpoints = 'apps/app/src/app/_layout/navigation-breakpoints.ts'
@@ -96,6 +97,16 @@ describe('app performance contracts', () => {
     expect(appBarSource).toContain('px-4 py-2')
     expect(appBarSource).toContain('lg:h-[60px]')
     expect(appBarSource).toContain('lg:px-6 lg:py-0')
+  })
+
+  it('resolves breadcrumbs from the current pathname without a post-mount scan', () => {
+    const source = readFileSync(appBreadcrumbs, 'utf8')
+
+    expect(source).toContain('pathname?: string')
+    expect(source).toContain('findBreadcrumb')
+    expect(source).not.toContain('useEffect')
+    expect(source).not.toContain('document.location')
+    expect(source).not.toContain('maxItems')
   })
 
   it('shares the accessible native carousel and keeps the app free of slider runtimes', () => {


### PR DESCRIPTION
## Summary
- promote the validated staging tree to main
- includes the private app breadcrumb render-time resolver from #758

## Validation
- feature PR #758 required gate passed
- apps/app full unit suite, lint, type-check, and production build passed locally
- promotion branch tree matches origin/staging exactly

This is the canonical staging-to-main promotion PR.