### PR TITLE
perf(web): defer viewport video preparation

### DIFF
--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -8,7 +8,7 @@ import type { ViewportVideoProps } from './index'
 const ViewportVideoEnhancer = dynamic(() => import('./ViewportVideoEnhancer'), { ssr: false })
 
 export default function ViewportVideoBoundary({
-  rootMargin = '300px',
+  rootMargin = '0px',
   src,
   ...props
 }: ViewportVideoProps): React.ReactNode {

--- a/packages/ui/src/components/custom/viewport-video/index.tsx
+++ b/packages/ui/src/components/custom/viewport-video/index.tsx
@@ -11,7 +11,7 @@ export type ViewportVideoProps = Omit<
 }
 
 export const ViewportVideo = memo(function ViewportVideo({
-  rootMargin = '300px',
+  rootMargin = '0px',
   src,
   ...props
 }: ViewportVideoProps) {

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -2,15 +2,28 @@ import { useRef } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
-const state = { nearViewport: true, reducedMotion: false }
+const state = {
+  nearViewport: true,
+  reducedMotion: false,
+  observedRootMargin: undefined as string | undefined,
+  boundaryRootMargin: undefined as string | undefined,
+}
 
 mock.module('@nl/ui/hooks/useOnScreen', () => ({
-  useOnScreen: () => state.nearViewport,
+  useOnScreen: (_ref: unknown, rootMargin?: string) => {
+    state.observedRootMargin = rootMargin
+    return state.nearViewport
+  },
 }))
 mock.module('@nl/ui/hooks/useMediaQuery', () => ({
   default: () => state.reducedMotion,
 }))
-mock.module('next/dynamic', () => ({ default: () => () => null }))
+mock.module('next/dynamic', () => ({
+  default: () => (props: { rootMargin?: string }) => {
+    state.boundaryRootMargin = props.rootMargin
+    return null
+  },
+}))
 
 describe('ViewportVideo', () => {
   let ViewportVideo: typeof import('./index').ViewportVideo
@@ -19,6 +32,8 @@ describe('ViewportVideo', () => {
   beforeEach(() => {
     state.nearViewport = true
     state.reducedMotion = false
+    state.observedRootMargin = undefined
+    state.boundaryRootMargin = undefined
   })
 
   beforeEach(async () => {
@@ -35,6 +50,16 @@ describe('ViewportVideo', () => {
     expect(video.autoplay).toBe(false)
     expect(video.preload).toBe('none')
     expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
+  })
+
+  it('waits for the viewport by default while preserving explicit prefetch windows', () => {
+    const { rerender } = render(<ViewportVideo data-testid="video" src="/video/example.mp4" />)
+
+    expect(state.boundaryRootMargin).toBe('0px')
+
+    rerender(<ViewportVideo data-testid="video" rootMargin="300px" src="/video/example.mp4" />)
+
+    expect(state.boundaryRootMargin).toBe('300px')
   })
 
   it('only enables playback and metadata loading near the viewport', async () => {
@@ -55,6 +80,7 @@ describe('ViewportVideo', () => {
     await waitFor(() => {
       expect(video.autoplay).toBe(true)
       expect(video.preload).toBe('metadata')
+      expect(state.observedRootMargin).toBe('300px')
     })
 
     state.nearViewport = false

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1897,7 +1897,9 @@ describe('public route dependency contract', () => {
 
     expect(shell).not.toContain("'use client'")
     expect(shell).toContain("from './ViewportVideoBoundary'")
+    expect(shell).toContain("rootMargin = '0px'")
     expect(boundary).toContain("dynamic(() => import('./ViewportVideoEnhancer')")
+    expect(boundary).toContain("rootMargin = '0px'")
     expect(boundary).toContain('preload="none"')
     expect(enhancer).toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")


### PR DESCRIPTION
## Summary
- keep shared marketing video markup server-rendered
- start playback and metadata preparation at the viewport by default
- preserve explicit rootMargin opt-in for intentional prefetching

## Validation
- shared UI tests
- route-surface contract
- shared UI lint/type-check
- apps/web production build

This draft is held until the local milestone is complete, then will be marked ready for hosted validation.