### PR TITLE
fix(app): restore sidebar interaction and app bar spacing

### DIFF
--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 const navigationState = {
   drawerOpen: false,
   isDesktopNavigation: false,
+  setDrawerOpen: mock(),
   toggleDrawer: mock(),
 }
 
@@ -27,6 +28,7 @@ beforeEach(async () => {
 afterEach(() => {
   navigationState.drawerOpen = false
   navigationState.isDesktopNavigation = false
+  navigationState.setDrawerOpen.mockClear()
   navigationState.toggleDrawer.mockClear()
   mock.restore()
 })
@@ -36,7 +38,7 @@ describe('private sidebar frame', () => {
     const { rerender } = render(<SidebarFrame>Navigation</SidebarFrame>)
     const navigation = screen.getByRole('navigation', { name: 'Primary navigation' })
 
-    expect(navigation.id).toBe('app-primary-navigation')
+    expect(navigation.id).toBe('')
     expect(navigation.getAttribute('data-state')).toBe('closed')
     expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull()
     rerender(<SidebarFrame>Navigation updated</SidebarFrame>)
@@ -45,31 +47,29 @@ describe('private sidebar frame', () => {
   it('renders an accessible compact close action while open', () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
-    const navigation = screen.getByRole('navigation', { name: 'Primary navigation' })
 
-    expect(navigation.getAttribute('data-state')).toBe('open')
     fireEvent.click(screen.getByRole('button', { name: 'Close sidebar' }))
-    expect(navigationState.toggleDrawer).toHaveBeenCalledOnce()
+    expect(navigationState.setDrawerOpen).toHaveBeenCalledWith(false)
   })
 
-  it('closes when the compact drawer backdrop is clicked', () => {
+  it('renders the compact drawer backdrop below the app bar', () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
 
-    const backdrop = screen.getByRole('button', { name: 'Close sidebar by clicking outside' })
+    const backdrop = document.querySelector('[data-slot="sheet-overlay"]')
 
-    fireEvent.click(backdrop)
-
-    expect(navigationState.toggleDrawer).toHaveBeenCalledOnce()
+    expect(backdrop).not.toBeNull()
+    expect((backdrop as HTMLElement).className).toContain('bg-black/50')
+    expect((backdrop as HTMLElement).style.top).toBe('56px')
   })
 
   it('keeps the compact drawer below the app bar', () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
 
-    const navigation = screen.getByRole('navigation', { name: 'Primary navigation' })
-    const overlay = navigation.querySelector('[aria-hidden="false"]')
-    const scrollArea = navigation.querySelector('[style*="height"]')
+    const panel = screen.getByRole('dialog', { name: 'Primary navigation' })
+    const overlay = document.querySelector('[data-slot="sheet-overlay"]')
+    const scrollArea = panel.querySelector('[style*="height"]')
 
     expect((overlay as HTMLElement | null)?.style.top).toBe('56px')
     expect((scrollArea as HTMLElement | null)?.style.height).toBe('calc(100dvh - 56px)')

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
@@ -2,10 +2,9 @@
 
 import type { PropsWithChildren, ReactNode } from 'react'
 import { memo, useMemo } from 'react'
-import { X } from 'lucide-react'
 
-import { Button } from '@nl/ui/base/button'
 import { ScrollArea } from '@nl/ui/base/scroll-area'
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@nl/ui/base/sheet'
 import { cn } from '@nl/ui/utils'
 
 import { useNavigation } from '@/contexts/NavigationContext'
@@ -20,7 +19,7 @@ interface SidebarFrameProps extends PropsWithChildren {
 }
 
 function SidebarFrame({ children, footer }: SidebarFrameProps) {
-  const { drawerOpen, isDesktopNavigation, toggleDrawer } = useNavigation()
+  const { drawerOpen, isDesktopNavigation, setDrawerOpen } = useNavigation()
   const isCompactScreen = !isDesktopNavigation
   const appHeaderHeight = isCompactScreen ? compactAppHeaderHeight : desktopAppHeaderHeight
 
@@ -52,52 +51,36 @@ function SidebarFrame({ children, footer }: SidebarFrameProps) {
 
   return (
     <nav
-      id="app-primary-navigation"
       aria-label="Primary navigation"
       data-state={drawerOpen ? 'open' : 'closed'}
       className={cn('shrink-0', isCompactScreen ? 'w-0' : 'w-[260px]')}
     >
       {isCompactScreen && (
-        <div
-          className={cn(
-            'fixed right-0 bottom-0 left-0 z-40 bg-black/50 transition-opacity',
-            drawerOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
-          )}
-          aria-hidden={!drawerOpen}
-          style={{ top: appHeaderHeight }}
-        >
-          {drawerOpen && (
-            <button
-              type="button"
-              aria-label="Close sidebar by clicking outside"
-              className="absolute inset-0 h-full w-full cursor-default border-0 bg-transparent p-0"
-              onClick={toggleDrawer}
-            />
-          )}
-          <div
-            className="bg-sidebar text-sidebar-foreground absolute inset-y-0 left-0 z-10 border-r-0"
-            style={{ width: appDrawerWidth }}
+        <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
+          <SheetContent
+            id="app-primary-navigation"
+            side="left"
+            aria-label="Primary navigation"
+            closeLabel="Close sidebar"
+            closeClassName="top-2 right-2 z-20 h-8 w-8 opacity-100 hover:opacity-100"
+            overlayClassName="bg-black/50"
+            overlayStyle={{ top: appHeaderHeight }}
+            className="w-[260px] max-w-[260px] gap-0 border-r-0 bg-sidebar p-0 text-sidebar-foreground"
+            style={{ top: appHeaderHeight, bottom: 0, height: 'auto' }}
           >
-            {drawerOpen && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Close sidebar"
-                className="absolute top-2 right-2 z-20 h-8 w-8"
-                onClick={toggleDrawer}
-              >
-                <X aria-hidden="true" size={18} strokeWidth={1.5} />
-              </Button>
-            )}
-            {drawerOpen && logo}
-            {drawerOpen && drawer}
-          </div>
-        </div>
+            <SheetTitle className="sr-only">Primary navigation</SheetTitle>
+            <SheetDescription className="sr-only">
+              Navigate through the private app
+            </SheetDescription>
+            {logo}
+            {drawer}
+          </SheetContent>
+        </Sheet>
       )}
 
       {isDesktopNavigation && (
         <aside
+          id="app-primary-navigation"
           className={cn(
             'bg-sidebar text-sidebar-foreground fixed bottom-0 left-0 z-40 border-r-0 transition-transform duration-200',
             drawerOpen

--- a/packages/ui/src/components/base/sheet.tsx
+++ b/packages/ui/src/components/base/sheet.tsx
@@ -48,13 +48,21 @@ function SheetContent({
   className,
   children,
   side = 'right',
+  closeClassName,
+  closeLabel = 'Close',
+  overlayClassName,
+  overlayStyle,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  closeClassName?: string
+  closeLabel?: string
+  overlayClassName?: string
+  overlayStyle?: React.CSSProperties
   side?: 'top' | 'right' | 'bottom' | 'left'
 }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      <SheetOverlay className={overlayClassName} style={overlayStyle} />
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
@@ -72,12 +80,18 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden cursor-pointer disabled:pointer-events-none">
+        <SheetPrimitive.Close
+          aria-label={closeLabel}
+          className={cn(
+            'ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none',
+            closeClassName
+          )}
+        >
           <span aria-hidden="true" className="relative block size-4">
             <span className="bg-current absolute top-1/2 left-0 block h-0.5 w-4 rotate-45" />
             <span className="bg-current absolute top-1/2 left-0 block h-0.5 w-4 -rotate-45" />
           </span>
-          <span className="sr-only">Close</span>
+          <span className="sr-only">{closeLabel}</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>

--- a/packages/ui/src/components/custom/app-bar/index.tsx
+++ b/packages/ui/src/components/custom/app-bar/index.tsx
@@ -10,11 +10,7 @@ export function AppBar({ children, className, ...props }: AppBarProps) {
     <div
       data-slot="app-bar"
       data-layout="responsive"
-      className={cn(
-        styles.appBar,
-        'box-border flex min-h-14 w-full items-center px-4 py-2 lg:h-[60px] lg:min-h-0 lg:px-6 lg:py-0',
-        className
-      )}
+      className={cn(styles.appBar, className)}
       {...props}
     >
       {children}

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -8,6 +8,7 @@ const webNextConfig = 'apps/web/next.config.ts'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
+const sharedAppBarStyles = 'packages/ui/src/components/custom/app-bar/app-bar.module.css'
 const appBreadcrumbs = 'apps/app/src/components/extended/Breadcrumbs.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
 const appNavigationContext = 'apps/app/src/contexts/NavigationContext.tsx'
@@ -90,13 +91,15 @@ describe('app performance contracts', () => {
   it('keeps the private app bar padded and vertically centered', () => {
     const shellSource = readFileSync(appShell, 'utf8')
     const appBarSource = readFileSync(sharedAppBar, 'utf8')
+    const appBarStyles = readFileSync(sharedAppBarStyles, 'utf8')
 
     expect(shellSource).toContain("from '@nl/ui/custom/app-bar'")
     expect(shellSource).toContain('<AppBar>{header}</AppBar>')
-    expect(appBarSource).toContain('min-h-14')
-    expect(appBarSource).toContain('px-4 py-2')
-    expect(appBarSource).toContain('lg:h-[60px]')
-    expect(appBarSource).toContain('lg:px-6 lg:py-0')
+    expect(appBarSource).toContain("import styles from './app-bar.module.css'")
+    expect(appBarStyles).toContain('min-height: 56px')
+    expect(appBarStyles).toContain('padding: 8px 16px')
+    expect(appBarStyles).toContain('height: 60px')
+    expect(appBarStyles).toContain('padding: 0 24px')
   })
 
   it('resolves breadcrumbs from the current pathname without a post-mount scan', () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -310,6 +310,7 @@ const degensTopNav = 'apps/app/src/components/extended/DegensTopNav/index.tsx'
 const publicMainLayout = 'apps/app/src/app/_layout/_PublicMainLayout/index.tsx'
 const publicNavigation = 'apps/app/src/components/providers/PublicNavigation.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
+const sharedAppBarStyles = 'packages/ui/src/components/custom/app-bar/app-bar.module.css'
 const publicContentContainer = 'apps/app/src/components/wrapper/PublicContentContainer.tsx'
 const publicNavLinks = 'apps/app/src/components/providers/PublicNavLinks.tsx'
 const sharedMobileNavigation = 'packages/ui/src/components/custom/mobile-navigation/index.tsx'
@@ -850,13 +851,15 @@ describe('public app shell contract', () => {
   it('keeps the public app bar padded and vertically centered', () => {
     const navigationSource = readFileSync(join(process.cwd(), publicNavigation), 'utf8')
     const appBarSource = readFileSync(join(process.cwd(), sharedAppBar), 'utf8')
+    const appBarStyles = readFileSync(join(process.cwd(), sharedAppBarStyles), 'utf8')
 
     expect(navigationSource).toContain("from '@nl/ui/custom/app-bar'")
     expect(navigationSource).toContain('<AppBar>')
-    expect(appBarSource).toContain('min-h-14')
-    expect(appBarSource).toContain('px-4 py-2')
-    expect(appBarSource).toContain('lg:h-[60px]')
-    expect(appBarSource).toContain('lg:px-6 lg:py-0')
+    expect(appBarSource).toContain("import styles from './app-bar.module.css'")
+    expect(appBarStyles).toContain('min-height: 56px')
+    expect(appBarStyles).toContain('padding: 8px 16px')
+    expect(appBarStyles).toContain('height: 60px')
+    expect(appBarStyles).toContain('padding: 0 24px')
   })
 
   it('keeps mobile navigation server-rendered and avoids heavy shell primitives', () => {
@@ -1282,13 +1285,15 @@ describe('private app bar contract', () => {
   it('keeps the shared app bar padded and vertically centered', () => {
     const source = readFileSync(join(process.cwd(), appShell), 'utf8')
     const appBarSource = readFileSync(join(process.cwd(), sharedAppBar), 'utf8')
+    const appBarStyles = readFileSync(join(process.cwd(), sharedAppBarStyles), 'utf8')
 
     expect(source).toContain("from '@nl/ui/custom/app-bar'")
     expect(source).toContain('<AppBar>{header}</AppBar>')
-    expect(appBarSource).toContain('min-h-14')
-    expect(appBarSource).toContain('px-4 py-2')
-    expect(appBarSource).toContain('lg:h-[60px]')
-    expect(appBarSource).toContain('lg:px-6 lg:py-0')
+    expect(appBarSource).toContain("import styles from './app-bar.module.css'")
+    expect(appBarStyles).toContain('min-height: 56px')
+    expect(appBarStyles).toContain('padding: 8px 16px')
+    expect(appBarStyles).toContain('height: 60px')
+    expect(appBarStyles).toContain('padding: 0 24px')
   })
 })
 


### PR DESCRIPTION
## Summary
- replace the private compact sidebar overlay with the shared accessible Sheet primitive
- preserve the 260px drawer, app-bar offset, theme, and desktop sidebar geometry
- make the shared app-bar CSS module the single responsive spacing source of truth
- extend focused and contract coverage for the sidebar and app-bar behavior

## Validation
- `bun run --filter @nl/ui lint`
- `bun run --filter @nl/ui type-check`
- `bun run --filter @nl/ui test`
- `bun run --filter app lint`
- `bun run --filter app type-check`
- `bun run --filter app test`
- `bun run --filter app build`
- focused sidebar/UI tests and route/performance contracts
- isolated browser verification at desktop and 375px compact widths
