### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/app/(public-routes)/games/DeferredInstallerAction.tsx
+++ b/apps/app/src/app/(public-routes)/games/DeferredInstallerAction.tsx
@@ -1,23 +1,28 @@
 'use client'
 
-import { Button } from '@nl/ui/base/button'
+import { buttonVariants } from '@nl/ui/base/button-variants'
 import DeferredComponent from '@nl/ui/custom/deferred-component'
 
 const loadInstallerAction = () => import('./InstallerAction')
 
 function InstallerActionLoading() {
   return (
-    <Button type="button" variant="outline" disabled aria-label="Loading installer action">
+    <button
+      type="button"
+      className={buttonVariants({ variant: 'outline' })}
+      disabled
+      aria-label="Loading installer action"
+    >
       Checking installer…
-    </Button>
+    </button>
   )
 }
 
 function InstallerActionError(onRetry: () => void) {
   return (
-    <Button type="button" variant="outline" onClick={onRetry}>
+    <button type="button" className={buttonVariants({ variant: 'outline' })} onClick={onRetry}>
       Retry installer
-    </Button>
+    </button>
   )
 }
 

--- a/apps/app/src/app/_layout/AppShell.tsx
+++ b/apps/app/src/app/_layout/AppShell.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren, ReactNode } from 'react'
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { ScrollArea } from '@nl/ui/base/scroll-area'
 import AppBar from '@nl/ui/custom/app-bar'
 
@@ -12,8 +12,6 @@ import Breadcrumbs from '@/components/extended/Breadcrumbs'
 import { NavigationProvider, useNavigation } from '@/contexts/NavigationContext'
 import navigation from '@/constants/menu-items'
 import styles from './_MainLayout/MainLayout.module.css'
-
-const container = true
 
 interface AppShellProps extends PropsWithChildren {
   header: ReactNode
@@ -65,10 +63,10 @@ function AppShellContent({ children, header, sidebar, networkWarning }: AppShell
 
         {sidebar}
 
-        <main className={cn(styles.main, drawerOpen ? styles.mainOpen : styles.mainClosed)}>
+        <main className={cx(styles.main, drawerOpen ? styles.mainOpen : styles.mainClosed)}>
           {!isNoFilterPage ? (
             <ScrollArea className="h-full" viewportClassName="py-5 md:py-10">
-              {container ? <div className="container">{content}</div> : content}
+              <div className="container">{content}</div>
             </ScrollArea>
           ) : (
             content

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/MobileSidebarSheet.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/MobileSidebarSheet.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@nl/ui/base/sheet'
+
+interface MobileSidebarSheetProps {
+  appHeaderHeight: number
+  drawer: ReactNode
+  logo: ReactNode
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}
+
+export default function MobileSidebarSheet({
+  appHeaderHeight,
+  drawer,
+  logo,
+  onOpenChange,
+  open,
+}: MobileSidebarSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        id="app-primary-navigation"
+        side="left"
+        aria-label="Primary navigation"
+        closeLabel="Close sidebar"
+        closeClassName="top-2 right-2 z-20 h-8 w-8 opacity-100 hover:opacity-100"
+        overlayClassName="bg-black/50"
+        overlayStyle={{ top: appHeaderHeight }}
+        className="w-[260px] max-w-[260px] gap-0 border-r-0 bg-sidebar p-0 text-sidebar-foreground"
+        style={{ top: appHeaderHeight, bottom: 0, height: 'auto' }}
+      >
+        <SheetTitle className="sr-only">Primary navigation</SheetTitle>
+        <SheetDescription className="sr-only">Navigate through the private app</SheetDescription>
+        {logo}
+        {drawer}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.test.tsx
@@ -44,18 +44,19 @@ describe('private sidebar frame', () => {
     rerender(<SidebarFrame>Navigation updated</SidebarFrame>)
   })
 
-  it('renders an accessible compact close action while open', () => {
+  it('renders an accessible compact close action while open', async () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close sidebar' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Close sidebar' }))
     expect(navigationState.setDrawerOpen).toHaveBeenCalledWith(false)
   })
 
-  it('renders the compact drawer backdrop below the app bar', () => {
+  it('renders the compact drawer backdrop below the app bar', async () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
 
+    await screen.findByRole('button', { name: 'Close sidebar' })
     const backdrop = document.querySelector('[data-slot="sheet-overlay"]')
 
     expect(backdrop).not.toBeNull()
@@ -63,11 +64,11 @@ describe('private sidebar frame', () => {
     expect((backdrop as HTMLElement).style.top).toBe('56px')
   })
 
-  it('keeps the compact drawer below the app bar', () => {
+  it('keeps the compact drawer below the app bar', async () => {
     navigationState.drawerOpen = true
     render(<SidebarFrame>Navigation</SidebarFrame>)
 
-    const panel = screen.getByRole('dialog', { name: 'Primary navigation' })
+    const panel = await screen.findByRole('dialog', { name: 'Primary navigation' })
     const overlay = document.querySelector('[data-slot="sheet-overlay"]')
     const scrollArea = panel.querySelector('[style*="height"]')
 

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import type { PropsWithChildren, ReactNode } from 'react'
-import { memo, useMemo } from 'react'
+import { lazy, memo, Suspense, useMemo } from 'react'
 
 import { ScrollArea } from '@nl/ui/base/scroll-area'
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@nl/ui/base/sheet'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import { useNavigation } from '@/contexts/NavigationContext'
 import LogoSection from '../_LogoSection'
@@ -13,6 +12,8 @@ import LogoSection from '../_LogoSection'
 const appDrawerWidth = 260
 const desktopAppHeaderHeight = 60
 const compactAppHeaderHeight = 56
+
+const MobileSidebarSheet = lazy(() => import('./MobileSidebarSheet'))
 
 interface SidebarFrameProps extends PropsWithChildren {
   footer?: ReactNode
@@ -53,35 +54,24 @@ function SidebarFrame({ children, footer }: SidebarFrameProps) {
     <nav
       aria-label="Primary navigation"
       data-state={drawerOpen ? 'open' : 'closed'}
-      className={cn('shrink-0', isCompactScreen ? 'w-0' : 'w-[260px]')}
+      className={cx('shrink-0', isCompactScreen ? 'w-0' : 'w-[260px]')}
     >
-      {isCompactScreen && (
-        <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
-          <SheetContent
-            id="app-primary-navigation"
-            side="left"
-            aria-label="Primary navigation"
-            closeLabel="Close sidebar"
-            closeClassName="top-2 right-2 z-20 h-8 w-8 opacity-100 hover:opacity-100"
-            overlayClassName="bg-black/50"
-            overlayStyle={{ top: appHeaderHeight }}
-            className="w-[260px] max-w-[260px] gap-0 border-r-0 bg-sidebar p-0 text-sidebar-foreground"
-            style={{ top: appHeaderHeight, bottom: 0, height: 'auto' }}
-          >
-            <SheetTitle className="sr-only">Primary navigation</SheetTitle>
-            <SheetDescription className="sr-only">
-              Navigate through the private app
-            </SheetDescription>
-            {logo}
-            {drawer}
-          </SheetContent>
-        </Sheet>
+      {isCompactScreen && drawerOpen && (
+        <Suspense fallback={null}>
+          <MobileSidebarSheet
+            appHeaderHeight={appHeaderHeight}
+            drawer={drawer}
+            logo={logo}
+            onOpenChange={setDrawerOpen}
+            open={drawerOpen}
+          />
+        </Suspense>
       )}
 
       {isDesktopNavigation && (
         <aside
           id="app-primary-navigation"
-          className={cn(
+          className={cx(
             'bg-sidebar text-sidebar-foreground fixed bottom-0 left-0 z-40 border-r-0 transition-transform duration-200',
             drawerOpen
               ? 'pointer-events-auto translate-x-0'

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 import { AppNavIcon } from '@/components/AppNavIcon'
 
 // project imports
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { NavGroupProps } from '../_NavGroup'
 import NavItem from '../_NavItem'
 
@@ -61,7 +61,7 @@ const NavCollapse = ({ menu, level }: NavCollapseProps) => {
     <>
       <button
         type="button"
-        className={cn(
+        className={cx(
           'mb-0.5 flex w-full items-center rounded-md px-2 text-left',
           level > 1 ? 'py-2' : 'py-2.5',
           selected === menu.id ? 'bg-muted font-bold' : 'font-normal',
@@ -84,7 +84,7 @@ const NavCollapse = ({ menu, level }: NavCollapseProps) => {
         <AppNavIcon
           name="chevron-down"
           size="md"
-          className={cn('transition-transform', open && 'rotate-180 transform')}
+          className={cx('transition-transform', open && 'rotate-180 transform')}
         />
       </button>
       {open && (

--- a/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx
+++ b/apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { AppNavIcon } from '@/components/AppNavIcon'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { useNavigation } from '@/contexts/NavigationContext'
 
 // types
@@ -36,7 +36,7 @@ const NavItem = ({ item, level }: NavItemProps) => {
       </span>
       <span className="flex-1">
         <span
-          className={cn('text-base', isSelected ? 'font-bold' : 'font-normal')}
+          className={cx('text-base', isSelected ? 'font-bold' : 'font-normal')}
           style={{ color: 'inherit' }}
         >
           {item.title}
@@ -50,7 +50,7 @@ const NavItem = ({ item, level }: NavItemProps) => {
     </>
   )
 
-  const linkClass = cn(
+  const linkClass = cx(
     'mb-0.5 flex items-start gap-2 rounded-md border border-transparent bg-transparent px-2 py-2 text-left transition-colors hover:border-purple hover:bg-muted',
     isSelected && 'border-purple bg-muted'
   )

--- a/apps/app/src/components/providers/DeferredDegenCard.tsx
+++ b/apps/app/src/components/providers/DeferredDegenCard.tsx
@@ -2,8 +2,7 @@
 
 import { useRef } from 'react'
 
-import { Button } from '@nl/ui/base/button'
-import useDeferredComponent from '@nl/ui/hooks/useDeferredComponent'
+import DeferredComponent from '@nl/ui/custom/deferred-component'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
 import SkeletonDegenPlaceholder from '@/components/cards/Skeleton/DegenPlaceholder'
@@ -14,26 +13,17 @@ const loadDegenCard = () => import('@/components/cards/DegenCard')
 export default function DeferredDegenCard({ size = 'normal', ...props }: DegenCardProps) {
   const cardRef = useRef<HTMLDivElement>(null)
   const isNearViewport = useOnScreen(cardRef, '320px')
-  const {
-    Component: DegenCard,
-    hasError: loadError,
-    retry,
-  } = useDeferredComponent<DegenCardProps>(loadDegenCard, isNearViewport)
 
   return (
-    <div ref={cardRef} aria-busy={!DegenCard && !loadError}>
-      {loadError ? (
-        <div className="flex min-h-48 flex-col items-center justify-center gap-3" role="alert">
-          <span>DEGEN card could not be loaded.</span>
-          <Button type="button" variant="outline" onClick={retry}>
-            Retry
-          </Button>
-        </div>
-      ) : DegenCard ? (
-        <DegenCard size={size} {...props} />
-      ) : (
-        <SkeletonDegenPlaceholder size={size} />
-      )}
+    <div ref={cardRef}>
+      <DeferredComponent
+        disabledFallback={<SkeletonDegenPlaceholder size={size} />}
+        enabled={isNearViewport}
+        label="DEGEN card"
+        load={loadDegenCard}
+        loadingFallback={<SkeletonDegenPlaceholder size={size} />}
+        props={{ size, ...props }}
+      />
     </div>
   )
 }

--- a/apps/app/src/contexts/NavigationContext.tsx
+++ b/apps/app/src/contexts/NavigationContext.tsx
@@ -26,9 +26,7 @@ const NavigationContext = createContext<NavigationContextValue | null>(null)
 
 export function NavigationProvider({ children }: PropsWithChildren) {
   const [drawerOpen, setDrawerOpen] = useState(false)
-  const isDesktopNavigation = useMediaQuery(desktopNavigationMediaQuery, {
-    initializeWithValue: false,
-  })
+  const isDesktopNavigation = useMediaQuery(desktopNavigationMediaQuery)
   const toggleDrawer = useCallback(() => setDrawerOpen((open) => !open), [])
   const value = useMemo(
     () => ({ drawerOpen, isDesktopNavigation, setDrawerOpen, toggleDrawer }),

--- a/apps/app/src/contexts/Web3ModalContext.tsx
+++ b/apps/app/src/contexts/Web3ModalContext.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import {
-  useEffect,
-  useState,
-  type ComponentType,
-  type PropsWithChildren,
-  type ReactNode,
-} from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
+
+import useDeferredComponent from '@nl/ui/hooks/useDeferredComponent'
 
 import {
   WalletProviderError,
@@ -17,7 +13,7 @@ type Web3ModalProviderProps = {
   cookies?: string | null
   loadingFallback?: ReactNode
 }
-type Web3ModalRuntimeComponent = ComponentType<PropsWithChildren<Web3ModalProviderProps>>
+type Web3ModalRuntimeProps = PropsWithChildren<{ cookies?: string | null }>
 
 const loadWeb3ModalRuntime = () => import('./Web3ModalRuntime')
 
@@ -26,30 +22,14 @@ export function Web3ModalProvider({
   cookies,
   loadingFallback,
 }: PropsWithChildren<Web3ModalProviderProps>) {
-  const [Runtime, setRuntime] = useState<Web3ModalRuntimeComponent | null>(null)
-  const [loadError, setLoadError] = useState(false)
-  const [retryCount, setRetryCount] = useState(0)
-
-  useEffect(() => {
-    let active = true
-    setRuntime(null)
-    setLoadError(false)
-
-    loadWeb3ModalRuntime()
-      .then(({ default: nextRuntime }) => {
-        if (active) setRuntime(() => nextRuntime)
-      })
-      .catch(() => {
-        if (active) setLoadError(true)
-      })
-
-    return () => {
-      active = false
-    }
-  }, [retryCount])
+  const {
+    Component: Runtime,
+    hasError: loadError,
+    retry,
+  } = useDeferredComponent<Web3ModalRuntimeProps>(loadWeb3ModalRuntime)
 
   if (loadError) {
-    return <WalletProviderError onRetry={() => setRetryCount((count) => count + 1)} />
+    return <WalletProviderError onRetry={retry} />
   }
 
   if (!Runtime) {

--- a/apps/smashers/src/components/Header/ActionButtonsGroup/index.test.tsx
+++ b/apps/smashers/src/components/Header/ActionButtonsGroup/index.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { ComponentProps } from 'react'
+
+mock.module('next/image', () => ({
+  default: ({
+    alt,
+    priority: _priority,
+    ...props
+  }: ComponentProps<'img'> & { priority?: boolean }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}))
+
+describe('ActionButtonsGroup', () => {
+  let ActionButtonsGroup: typeof import('./index').default
+
+  beforeEach(async () => {
+    ActionButtonsGroup = (await import('./index')).default
+  })
+
+  it('renders accessible themed actions without preloading modal content', () => {
+    render(<ActionButtonsGroup activeModal={null} />)
+
+    for (const label of ['Play', 'Trailer', 'Credits']) {
+      const button = screen.getByRole('button', { name: label })
+
+      expect(button.getAttribute('type')).toBe('button')
+      expect(button.getAttribute('aria-busy')).toBe('false')
+    }
+  })
+})

--- a/apps/smashers/src/components/Header/ActionButtonsGroup/index.tsx
+++ b/apps/smashers/src/components/Header/ActionButtonsGroup/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import Image from 'next/image'
-import { useCallback, useEffect, useState, type ComponentType } from 'react'
+import { useEffect, useState, type ComponentType } from 'react'
 
 import { Button } from '@nl/ui/base/button'
+import useDeferredComponent from '@nl/ui/hooks/useDeferredComponent'
 
 import styles from './index.module.css'
 
@@ -39,62 +40,58 @@ const modalActions: Record<ModalType, ModalAction> = {
   },
 }
 
+function DeferredModalAction({
+  action,
+  open,
+  onRequest,
+}: {
+  action: ModalAction
+  open: boolean
+  onRequest: () => void
+}) {
+  const { Component: Modal, hasError, retry } = useDeferredComponent(action.load, open)
+
+  if (Modal) return <Modal open={open} />
+
+  const isLoading = open && !hasError
+  const label = hasError ? `Retry ${action.label}` : action.label
+
+  return (
+    <Button
+      type="button"
+      aria-busy={isLoading}
+      aria-label={label}
+      onClick={() => {
+        onRequest()
+        if (hasError) retry()
+      }}
+    >
+      <Image src={action.image} alt={action.alt} width={22} height={22} />
+      {action.label}
+    </Button>
+  )
+}
+
 const ActionButtonsGroup = ({ activeModal }: { activeModal: ActiveModal }) => {
   const [requestedModal, setRequestedModal] = useState<ModalType | null>(
     activeModal && activeModal !== 'unity' ? activeModal : null
   )
-  const [loadedModals, setLoadedModals] = useState<Partial<Record<ModalType, ModalComponent>>>({})
-  const [loadingModal, setLoadingModal] = useState<ModalType | null>(null)
-  const [failedModal, setFailedModal] = useState<ModalType | null>(null)
-
-  const loadModal = useCallback(
-    (type: ModalType) => {
-      setRequestedModal(type)
-      setFailedModal(null)
-
-      if (loadedModals[type] || loadingModal === type) return
-
-      setLoadingModal(type)
-      void modalActions[type]
-        .load()
-        .then(({ default: LoadedModal }) => {
-          setLoadedModals((previous) => ({ ...previous, [type]: LoadedModal }))
-          setLoadingModal((current) => (current === type ? null : current))
-        })
-        .catch(() => {
-          setFailedModal(type)
-          setLoadingModal((current) => (current === type ? null : current))
-        })
-    },
-    [loadedModals, loadingModal]
-  )
 
   useEffect(() => {
-    if (activeModal && activeModal !== 'unity') loadModal(activeModal)
-  }, [activeModal, loadModal])
+    if (activeModal && activeModal !== 'unity') setRequestedModal(activeModal)
+  }, [activeModal])
 
   return (
     <div className={styles.heroBtnGroup}>
       {(Object.keys(modalActions) as ModalType[]).map((type) => {
         const action = modalActions[type]
-        const Modal = loadedModals[type]
-
-        if (Modal) return <Modal key={type} open={requestedModal === type} />
-
-        const isLoading = loadingModal === type
-        const label = failedModal === type ? `Retry ${action.label}` : action.label
-
         return (
-          <Button
+          <DeferredModalAction
             key={type}
-            type="button"
-            aria-busy={isLoading}
-            aria-label={label}
-            onClick={() => loadModal(type)}
-          >
-            <Image src={action.image} alt={action.alt} width={22} height={22} />
-            {action.label}
-          </Button>
+            action={action}
+            open={requestedModal === type}
+            onRequest={() => setRequestedModal(type)}
+          />
         )
       })}
     </div>

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -48,6 +48,16 @@ const nextConfig: NextConfig = {
         : []),
     ]
   },
+  async headers() {
+    // OpenSea embeds /gltf/* in sandboxed frames with an opaque origin. The
+    // client chunks and local fonts still need to opt into that CORS request.
+    return [
+      {
+        source: '/_next/static/:path*',
+        headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
+      },
+    ]
+  },
   async redirects() {
     return [
       ...(ENV === 'development'

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -102,7 +102,7 @@ const Games: NextPage = () => (
                 <LazyYouTubeEmbed src={video} title={name} className={styles.video} />
               ) : (
                 <ViewportVideo
-                  id="console-video"
+                  id={`game-video-${index}`}
                   width="100%"
                   height="100%"
                   muted

--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -101,6 +101,16 @@ describe('home page', () => {
     expect(heroArtwork.getAttribute('data-fetch-priority')).toBeNull()
   })
 
+  it('keeps desktop-only hero artwork out of the mobile image request path', () => {
+    render(<Home />)
+
+    const heroArtwork = screen.getByAltText('Nifty Hero Characters')
+    const desktopSource = heroArtwork.closest('picture')?.querySelector('source')
+
+    expect(desktopSource?.getAttribute('media')).toBe('(min-width: 769px)')
+    expect(heroArtwork.getAttribute('src')).toContain('data:image/gif;base64,')
+  })
+
   it('does not compete with the hero background for high-priority loading', () => {
     render(<Home />)
 

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -23,6 +23,36 @@ const ResponsiveLabel = ({ mobile, desktop }: { mobile: string; desktop: string 
   </>
 )
 
+const DESKTOP_ONLY_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+
+interface DesktopOnlyImageProps {
+  alt: string
+  className?: string
+  height: number
+  sizes: string
+  src: string
+  width: number
+}
+
+const DesktopOnlyImage = ({ alt, className, height, sizes, src, width }: DesktopOnlyImageProps) => {
+  const { props } = getImageProps({ alt, height, sizes, src, width })
+  const { src: _src, srcSet: _srcSet, sizes: _sizes, ...fallbackProps } = props
+
+  return (
+    <picture className="block">
+      <source media="(min-width: 769px)" sizes={sizes} srcSet={props.srcSet} />
+      <img
+        {...fallbackProps}
+        alt={alt}
+        className={className}
+        height={height}
+        src={DESKTOP_ONLY_PLACEHOLDER}
+        width={width}
+      />
+    </picture>
+  )
+}
+
 const ResponsiveIntroBackground = () => {
   const commonProps = {
     alt: '',
@@ -77,7 +107,7 @@ const DesktopIntro = () => {
     <section className="desktop relative w-screen max-h-screen overflow-hidden home-desktop-intro">
       <div className="relative h-full w-full">
         <div className="absolute home-hero-characters-image flex-grow animate-zoom-out-large">
-          <Image
+          <DesktopOnlyImage
             src="/img/hero/characters.webp"
             alt="Nifty Hero Characters"
             width={1920}
@@ -89,7 +119,7 @@ const DesktopIntro = () => {
         <div className="home-hero-companion">
           <div className="relative flex-grow">
             <div className="animate-hover transition-fade">
-              <Image
+              <DesktopOnlyImage
                 src="/img/hero/companion-base.webp"
                 alt="Home Hero Companion Base"
                 width={175}
@@ -104,7 +134,7 @@ const DesktopIntro = () => {
         <div className="home-hero-halo">
           <div className="flex-grow">
             <div className="animate-hover transition-fade">
-              <Image
+              <DesktopOnlyImage
                 src="/img/hero/halo.webp"
                 alt="Home Hero Halo"
                 width={133}
@@ -120,7 +150,7 @@ const DesktopIntro = () => {
 
       <div className="home-satoshi-container">
         <div className="relative flex-grow home-satoshi transition-quick-pop-left">
-          <Image
+          <DesktopOnlyImage
             alt="Satoshi"
             src="/img/hero/satoshi.webp"
             width={180}
@@ -148,7 +178,7 @@ const DesktopIntro = () => {
           aria-label="Learn more about Nifty League"
           className="inline-block relative flex-grow satoshi-learn-more transition-fade-slow"
         >
-          <Image
+          <DesktopOnlyImage
             src="/img/hero/speech-bubble.webp"
             alt="Learn More"
             width={348}

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/ModelView.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/components/ModelView.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import '@google/model-viewer'
+// Prefer the ESM build so Next can analyze the optional 3D graph instead of
+// treating the prebundled UMD entry as opaque.
+import '@google/model-viewer/dist/model-viewer-module.min.js'
 import { useEffect, useState } from 'react'
 import { CircularProgress } from '@nl/ui/custom/circular-progress'
 

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
@@ -3,9 +3,9 @@
   --default-font-size: var(--text-sm); /* 0.875rem */
 }
 
-:global(html),
-:global(body),
-:global(main) {
+:global(html):has(.main__wrapper),
+:global(body):has(.main__wrapper),
+:global(main).main__wrapper {
   margin: 0;
   padding: 0;
   height: 100%;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     "./base/*": "./src/components/base/*.tsx",
     "./custom/*": "./src/components/custom/*/index.tsx",
     "./hooks/*": "./src/hooks/*.ts",
+    "./class-names": "./src/lib/class-names.ts",
     "./fonts": "./src/lib/fonts/index.ts",
     "./fonts/*": "./src/lib/fonts/*.ts",
     "./gtm": "./src/lib/gtm/index.tsx",

--- a/packages/ui/src/components/custom/deferred-component/deferred-component.test.tsx
+++ b/packages/ui/src/components/custom/deferred-component/deferred-component.test.tsx
@@ -45,4 +45,20 @@ describe('DeferredComponent', () => {
     expect(load).not.toHaveBeenCalled()
     expect(screen.queryByRole('status')).toBeNull()
   })
+
+  it('keeps a caller-provided placeholder while disabled', () => {
+    const load = mock()
+    render(
+      <DeferredComponent
+        disabledFallback={<div role="status">Waiting for visibility</div>}
+        enabled={false}
+        label="disabled"
+        load={load}
+        props={{}}
+      />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Waiting for visibility')
+    expect(load).not.toHaveBeenCalled()
+  })
 })

--- a/packages/ui/src/components/custom/deferred-component/index.tsx
+++ b/packages/ui/src/components/custom/deferred-component/index.tsx
@@ -7,6 +7,7 @@ import DeferredSkeleton from '@nl/ui/custom/deferred-skeleton'
 import useDeferredComponent from '@nl/ui/hooks/useDeferredComponent'
 
 export interface DeferredComponentProps<T extends object> {
+  disabledFallback?: ReactNode
   enabled?: boolean
   errorFallback?: (onRetry: () => void) => ReactNode
   label: string
@@ -41,6 +42,7 @@ function DefaultError({ label, onRetry }: { label: string; onRetry: () => void }
  * from carrying its own copy of the same loading state machine.
  */
 export function DeferredComponent<T extends object>({
+  disabledFallback,
   enabled = true,
   errorFallback,
   label,
@@ -54,7 +56,7 @@ export function DeferredComponent<T extends object>({
     retry,
   } = useDeferredComponent(load, enabled)
 
-  if (!enabled) return null
+  if (!enabled) return disabledFallback ?? null
 
   if (loadError) {
     return errorFallback ? errorFallback(retry) : <DefaultError label={label} onRetry={retry} />

--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -7,7 +7,6 @@ import { buttonVariants } from '@nl/ui/base/button-variants'
 import DeferredSkeleton from '@nl/ui/custom/deferred-skeleton'
 import useDeferredComponent from '@nl/ui/hooks/useDeferredComponent'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
-import { cn } from '@nl/ui/utils'
 
 interface DeferredSectionProps {
   label: string

--- a/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
@@ -1,54 +1,28 @@
-'use client'
-
 import type { ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
 
 import { cn } from '@nl/ui/utils'
+
+import NavbarScrollState from './NavbarScrollState'
 
 interface NavbarScrollFrameProps {
   children: ReactNode
   className?: string
 }
 
+export const NAVBAR_SCROLL_FRAME_ID = 'nifty-navbar-scroll-frame'
+
 export function NavbarScrollFrame({ children, className }: NavbarScrollFrameProps) {
-  const [isScrolled, setIsScrolled] = useState(false)
-  const frameRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    const supportsScrollTimeline =
-      typeof CSS !== 'undefined' && CSS.supports?.('animation-timeline: scroll()')
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (supportsScrollTimeline && !prefersReducedMotion) return
-
-    const updateScrollState = () => {
-      frameRef.current = null
-      const nextIsScrolled = window.scrollY > 80
-      setIsScrolled((current) => (current === nextIsScrolled ? current : nextIsScrolled))
-    }
-
-    const handleScroll = () => {
-      if (frameRef.current !== null) return
-      frameRef.current = window.requestAnimationFrame(updateScrollState)
-    }
-
-    updateScrollState()
-    window.addEventListener('scroll', handleScroll, { passive: true })
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll)
-      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current)
-    }
-  }, [])
-
   return (
     <header
+      id={NAVBAR_SCROLL_FRAME_ID}
       className={cn(
         'navbar-scroll-frame fixed inset-x-0 top-0 z-50 h-20 bg-transparent data-[scrolled=true]:backdrop-blur-xs',
         className
       )}
-      data-scrolled={isScrolled}
+      data-scrolled="false"
     >
       {children}
+      <NavbarScrollState targetId={NAVBAR_SCROLL_FRAME_ID} />
     </header>
   )
 }

--- a/packages/ui/src/components/custom/navbar/NavbarScrollState.test.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollState.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import NavbarScrollState from './NavbarScrollState'
+
+describe('NavbarScrollState', () => {
+  it('updates the server-rendered header at the scroll threshold', () => {
+    const originalCss = globalThis.CSS
+    const scrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY')
+    const requestAnimationFrame = window.requestAnimationFrame
+    const cancelAnimationFrame = window.cancelAnimationFrame
+    const callbacks: FrameRequestCallback[] = []
+
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: { supports: () => false },
+    })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 })
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        callbacks.push(callback)
+        return callbacks.length
+      },
+    })
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      value: () => undefined,
+    })
+
+    try {
+      const { container, unmount } = render(
+        <>
+          <header id="navbar-target" data-scrolled="false" />
+          <NavbarScrollState targetId="navbar-target" />
+        </>
+      )
+
+      expect(container.querySelector('header')?.dataset.scrolled).toBe('false')
+
+      Object.defineProperty(window, 'scrollY', { configurable: true, value: 120 })
+      fireEvent.scroll(window)
+      expect(container.querySelector('header')?.dataset.scrolled).toBe('false')
+
+      act(() => callbacks.shift()?.(0))
+      expect(container.querySelector('header')?.dataset.scrolled).toBe('true')
+
+      unmount()
+    } finally {
+      Object.defineProperty(globalThis, 'CSS', { configurable: true, value: originalCss })
+      if (scrollYDescriptor) Object.defineProperty(window, 'scrollY', scrollYDescriptor)
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: requestAnimationFrame,
+      })
+      Object.defineProperty(window, 'cancelAnimationFrame', {
+        configurable: true,
+        value: cancelAnimationFrame,
+      })
+    }
+  })
+})

--- a/packages/ui/src/components/custom/navbar/NavbarScrollState.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollState.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface NavbarScrollStateProps {
+  targetId: string
+}
+
+export default function NavbarScrollState({ targetId }: NavbarScrollStateProps): null {
+  useEffect(() => {
+    const header = document.getElementById(targetId)
+    if (!header) return
+
+    const supportsScrollTimeline =
+      typeof CSS !== 'undefined' && CSS.supports?.('animation-timeline: scroll()')
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (supportsScrollTimeline && !prefersReducedMotion) return
+
+    let frameId: number | null = null
+    const updateScrollState = () => {
+      frameId = null
+      header.dataset.scrolled = String(window.scrollY > 80)
+    }
+
+    const handleScroll = () => {
+      if (frameId !== null) return
+      frameId = window.requestAnimationFrame(updateScrollState)
+    }
+
+    updateScrollState()
+    window.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+      if (frameId !== null) window.cancelAnimationFrame(frameId)
+    }
+  }, [targetId])
+
+  return null
+}

--- a/packages/ui/src/components/custom/responsive-carousel/index.tsx
+++ b/packages/ui/src/components/custom/responsive-carousel/index.tsx
@@ -208,7 +208,10 @@ const ResponsiveCarousel = forwardRef<ResponsiveCarouselRef, ResponsiveCarouselP
       updateViewport()
       const resizeObserver = 'ResizeObserver' in window ? new ResizeObserver(updateViewport) : null
       if (resizeObserver && viewportRef.current) resizeObserver.observe(viewportRef.current)
-      window.addEventListener('resize', updateViewport, { passive: true })
+      // ResizeObserver already tracks the element's effective width. Keep the
+      // window listener only as the compatibility path for older browsers so
+      // every carousel does not process the same resize twice.
+      if (!resizeObserver) window.addEventListener('resize', updateViewport, { passive: true })
 
       const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
       const updateMotionPreference = () => setPrefersReducedMotion(motionQuery.matches)
@@ -221,7 +224,7 @@ const ResponsiveCarousel = forwardRef<ResponsiveCarouselRef, ResponsiveCarouselP
           scrollFrameRef.current = null
         }
         resizeObserver?.disconnect()
-        window.removeEventListener('resize', updateViewport)
+        if (!resizeObserver) window.removeEventListener('resize', updateViewport)
         motionQuery.removeEventListener?.('change', updateMotionPreference)
       }
     }, [])

--- a/packages/ui/src/components/custom/responsive-carousel/responsive-carousel.test.tsx
+++ b/packages/ui/src/components/custom/responsive-carousel/responsive-carousel.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import ResponsiveCarousel from './index'
+
+let restoreWindowAddEventListener: (() => void) | undefined
+
+afterEach(() => {
+  restoreWindowAddEventListener?.()
+  restoreWindowAddEventListener = undefined
+})
+
+describe('ResponsiveCarousel', () => {
+  it('uses ResizeObserver without adding a duplicate window resize listener', () => {
+    const originalAddEventListener = window.addEventListener
+    const addEventListener = mock<typeof window.addEventListener>()
+
+    window.addEventListener = addEventListener
+    restoreWindowAddEventListener = () => {
+      window.addEventListener = originalAddEventListener
+    }
+
+    const { unmount } = render(
+      <ResponsiveCarousel>
+        <div>Slide</div>
+      </ResponsiveCarousel>
+    )
+
+    expect(addEventListener.mock.calls.some(([type]) => type === 'resize')).toBe(false)
+    unmount()
+  })
+})

--- a/packages/ui/src/hooks/useDeferredComponent.test.tsx
+++ b/packages/ui/src/hooks/useDeferredComponent.test.tsx
@@ -28,6 +28,21 @@ describe('useDeferredComponent', () => {
     expect(load).not.toHaveBeenCalled()
   })
 
+  it('shares an in-flight load between enabled consumers', async () => {
+    const load = mock(async () => ({ default: Preview }))
+    const first = renderHook(() => useDeferredComponent<PreviewProps>(load))
+    const second = renderHook(() => useDeferredComponent<PreviewProps>(load))
+
+    await waitFor(() => {
+      expect(first.result.current.Component).toBe(Preview)
+      expect(second.result.current.Component).toBe(Preview)
+    })
+    expect(load).toHaveBeenCalledTimes(1)
+
+    first.unmount()
+    second.unmount()
+  })
+
   it('reports failures and retries through the shared callback', async () => {
     const load = mock()
     load

--- a/packages/ui/src/hooks/useDeferredComponent.ts
+++ b/packages/ui/src/hooks/useDeferredComponent.ts
@@ -12,6 +12,17 @@ export interface DeferredComponentState<T extends object> {
   retry: () => void
 }
 
+const componentLoadCache = new WeakMap<object, Promise<unknown>>()
+
+function getComponentLoad<T extends object>(load: DeferredComponentLoader<T>) {
+  const cachedLoad = componentLoadCache.get(load)
+  if (cachedLoad) return cachedLoad as Promise<{ default: ComponentType<T> }>
+
+  const nextLoad = Promise.resolve().then(load)
+  componentLoadCache.set(load, nextLoad)
+  return nextLoad
+}
+
 /**
  * Shares the cancellable lazy-component state machine used by immediate and
  * viewport-gated boundaries across the apps.
@@ -30,11 +41,14 @@ export function useDeferredComponent<T extends object>(
     let active = true
     setHasError(false)
 
-    load()
+    const pendingLoad = getComponentLoad(load)
+
+    pendingLoad
       .then(({ default: nextComponent }) => {
         if (active) setComponent(() => nextComponent)
       })
       .catch(() => {
+        if (componentLoadCache.get(load) === pendingLoad) componentLoadCache.delete(load)
         if (active) setHasError(true)
       })
 

--- a/packages/ui/src/hooks/useMediaQuery.ts
+++ b/packages/ui/src/hooks/useMediaQuery.ts
@@ -1,10 +1,8 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
-
-type UseMediaQueryOptions = { defaultValue?: boolean; initializeWithValue?: boolean }
+type UseMediaQueryOptions = { defaultValue?: boolean }
 
 const IS_SERVER = typeof window === 'undefined'
 
@@ -63,32 +61,19 @@ const subscribeToMediaQuery = (query: string, listener: () => void): (() => void
 
 export const useMediaQuery = (
   query: string,
-  { defaultValue = false, initializeWithValue = true }: UseMediaQueryOptions = {}
+  { defaultValue = false }: UseMediaQueryOptions = {}
 ): boolean => {
-  const getMatches = (query: string): boolean => {
-    return IS_SERVER ? defaultValue : (getMediaQueryEntry(query)?.media.matches ?? defaultValue)
-  }
+  const getSnapshot = useCallback(() => {
+    if (IS_SERVER) return defaultValue
+    return getMediaQueryEntry(query)?.media.matches ?? defaultValue
+  }, [defaultValue, query])
+  const getServerSnapshot = useCallback(() => defaultValue, [defaultValue])
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeToMediaQuery(query, listener),
+    [query]
+  )
 
-  const [matches, setMatches] = useState<boolean>(() => {
-    if (initializeWithValue) {
-      return getMatches(query)
-    }
-    return defaultValue
-  })
-
-  // Handles the change event of the media query.
-  function handleChange() {
-    setMatches(getMatches(query))
-  }
-
-  useIsomorphicLayoutEffect(() => {
-    // Triggered at the first client-side load and if query changes
-    handleChange()
-
-    return subscribeToMediaQuery(query, handleChange)
-  }, [query])
-
-  return matches
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
 export default useMediaQuery

--- a/packages/ui/src/hooks/useParallax.ts
+++ b/packages/ui/src/hooks/useParallax.ts
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react'
 
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
 export type ParallaxDirection = 'up' | 'down' | 'left' | 'right'
 export type ParallaxIntensity = 'lite' | 'normal' | 'strong' | 'extreme'
 
@@ -102,12 +104,16 @@ interface UseParallaxOptions {
   intensity: ParallaxIntensity
 }
 
+const PARALLAX_ROOT_MARGIN = '200px'
+
 export function useParallax<T extends HTMLElement = HTMLDivElement>(
   elementRef: React.RefObject<T | null>,
   options: UseParallaxOptions
 ) {
+  const isNearViewport = useOnScreen(elementRef, PARALLAX_ROOT_MARGIN)
+
   useEffect(() => {
-    if (!elementRef.current || !options.enabled) return
+    if (!elementRef.current || !options.enabled || !isNearViewport) return
 
     const handleParallax = () => {
       const element = elementRef.current
@@ -119,7 +125,7 @@ export function useParallax<T extends HTMLElement = HTMLDivElement>(
 
     handleParallax()
     return subscribeToParallaxUpdates(handleParallax)
-  }, [elementRef, options.enabled, options.direction, options.intensity])
+  }, [elementRef, options.enabled, options.direction, options.intensity, isNearViewport])
 }
 
 export default useParallax

--- a/packages/ui/src/hooks/visibility.test.tsx
+++ b/packages/ui/src/hooks/visibility.test.tsx
@@ -158,6 +158,22 @@ describe('useOnScreen', () => {
 })
 
 describe('useParallax', () => {
+  let intersectionCallback: IntersectionObserverCallback
+
+  beforeEach(() => {
+    stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+        observe = mock()
+        unobserve = mock()
+        disconnect = mock()
+      }
+    )
+  })
+
   function elementWithTop(top: number, withChild = true) {
     const element = document.createElement('div')
     if (withChild) {
@@ -169,6 +185,15 @@ describe('useParallax', () => {
     return element
   }
 
+  function markIntersecting(element: Element, isIntersecting = true) {
+    act(() =>
+      intersectionCallback(
+        [{ target: element, isIntersecting } as IntersectionObserverEntry],
+        {} as never
+      )
+    )
+  }
+
   it('applies vertical movement to the child and removes its scroll listener', () => {
     spyOn(window, 'addEventListener')
     spyOn(window, 'removeEventListener')
@@ -176,6 +201,7 @@ describe('useParallax', () => {
     const { unmount } = renderHook(() =>
       useParallax({ current: element }, { enabled: true, direction: 'down', intensity: 'strong' })
     )
+    markIntersecting(element)
 
     expect((element.firstElementChild as HTMLElement).style.transform).toBe(
       `translateY(${(-100 * 100 * 2) / window.innerHeight}px)`
@@ -192,6 +218,7 @@ describe('useParallax', () => {
     renderHook(() =>
       useParallax({ current: element }, { enabled: true, direction: 'right', intensity: 'lite' })
     )
+    markIntersecting(element)
 
     expect(element.style.transform).toBe(`translateX(${(-50 * 100 * 0.5) / window.innerHeight}px)`)
   })
@@ -230,6 +257,8 @@ describe('useParallax', () => {
           { enabled: true, direction: 'up', intensity: 'normal' }
         )
       )
+      markIntersecting(firstElement)
+      markIntersecting(secondElement)
 
       expect(addEventListener).toHaveBeenCalledTimes(1)
       window.dispatchEvent(new Event('scroll'))
@@ -261,6 +290,27 @@ describe('useParallax', () => {
         value: originalCancelAnimationFrame,
       })
     }
+  })
+
+  it('stops the shared scroll subscription when the element leaves the near-viewport margin', () => {
+    const addEventListener = spyOn(window, 'addEventListener')
+    const removeEventListener = spyOn(window, 'removeEventListener')
+    const element = elementWithTop(100)
+    renderHook(() =>
+      useParallax({ current: element }, { enabled: true, direction: 'down', intensity: 'normal' })
+    )
+
+    expect(addEventListener).not.toHaveBeenCalledWith('scroll', expect.any(Function), {
+      passive: true,
+    })
+
+    markIntersecting(element)
+    expect(addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function), {
+      passive: true,
+    })
+
+    markIntersecting(element, false)
+    expect(removeEventListener).toHaveBeenCalledWith('scroll', expect.any(Function))
   })
 
   it('does nothing while disabled or before the ref is mounted', () => {

--- a/packages/ui/src/lib/class-names.ts
+++ b/packages/ui/src/lib/class-names.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from 'clsx'
+
+/**
+ * Joins conditional class names without loading the heavier Tailwind conflict
+ * resolver. Use this when the class list has no competing utility classes.
+ */
+export function cx(...inputs: ClassValue[]) {
+  return clsx(inputs)
+}

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -9,8 +9,10 @@ const appRootLayout = 'apps/app/src/app/layout.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
 const sharedAppBarStyles = 'packages/ui/src/components/custom/app-bar/app-bar.module.css'
+const lightweightClassNames = 'packages/ui/src/lib/class-names.ts'
 const appBreadcrumbs = 'apps/app/src/components/extended/Breadcrumbs.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
+const mobileSidebarSheet = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/MobileSidebarSheet.tsx'
 const appNavigationContext = 'apps/app/src/contexts/NavigationContext.tsx'
 const appNavigationBreakpoints = 'apps/app/src/app/_layout/navigation-breakpoints.ts'
 const bridgeDialog = 'apps/app/src/components/dialog/BridgeButtonDialog/index.tsx'
@@ -75,6 +77,37 @@ const appIconRegistrySources = [
 ]
 
 describe('app performance contracts', () => {
+  it('keeps the eager private shell on lightweight class joining', () => {
+    const helperSource = readFileSync(lightweightClassNames, 'utf8')
+    expect(helperSource).toContain("from 'clsx'")
+    expect(helperSource).not.toContain('tailwind-merge')
+
+    for (const file of [
+      'apps/app/src/app/_layout/AppShell.tsx',
+      'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx',
+      'apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavCollapse/index.tsx',
+      'apps/app/src/app/_layout/_MainLayout/_Sidebar/_MenuList/_NavItem/index.tsx',
+    ]) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).toContain("from '@nl/ui/class-names'")
+      expect(source).not.toContain("from '@nl/ui/utils'")
+    }
+  })
+
+  it('loads the accessible mobile sidebar sheet only when opened', () => {
+    const sidebarSource = readFileSync(appSidebarFrame, 'utf8')
+    const mobileSheetSource = readFileSync(mobileSidebarSheet, 'utf8')
+
+    expect(sidebarSource).toContain("lazy(() => import('./MobileSidebarSheet'))")
+    expect(sidebarSource).toContain('isCompactScreen && drawerOpen')
+    expect(sidebarSource).toContain('<Suspense fallback={null}>')
+    expect(sidebarSource).not.toContain("from '@nl/ui/base/sheet'")
+    expect(mobileSheetSource).toContain("from '@nl/ui/base/sheet'")
+    expect(mobileSheetSource).toContain('SheetTitle')
+    expect(mobileSheetSource).toContain('SheetDescription')
+    expect(mobileSheetSource).toContain('closeLabel="Close sidebar"')
+  })
+
   it('keeps the private shell and sidebar on the same desktop breakpoint', () => {
     const shellSource = readFileSync(appShell, 'utf8')
     const sidebarSource = readFileSync(appSidebarFrame, 'utf8')
@@ -82,8 +115,7 @@ describe('app performance contracts', () => {
     const breakpointSource = readFileSync(appNavigationBreakpoints, 'utf8')
 
     expect(breakpointSource).toContain("desktopNavigationMediaQuery = '(min-width: 1024px)'")
-    expect(contextSource).toContain('useMediaQuery(desktopNavigationMediaQuery, {')
-    expect(contextSource).toContain('initializeWithValue: false')
+    expect(contextSource).toContain('useMediaQuery(desktopNavigationMediaQuery)')
     expect(shellSource).toContain('isDesktopNavigation')
     expect(sidebarSource).not.toContain('useMediaQuery')
     expect(sidebarSource).toContain('const isCompactScreen = !isDesktopNavigation')
@@ -182,6 +214,10 @@ describe('app performance contracts', () => {
     expect(pageSource).not.toContain("import InstallerAction from './InstallerAction'")
     expect(pageSource).toContain('actions={<DeferredInstallerAction />}')
     expect(deferredSource).toContain("from '@nl/ui/custom/deferred-component'")
+    expect(deferredSource).toContain("from '@nl/ui/base/button-variants'")
+    expect(deferredSource).not.toContain("from '@nl/ui/base/button'")
+    expect(deferredSource).toContain("className={buttonVariants({ variant: 'outline' })}")
+    expect(deferredSource).toContain('<button')
     expect(deferredSource).toContain("import('./InstallerAction')")
     expect(deferredSource).toContain('aria-label="Loading installer action"')
     expect(deferredSource).toContain('Retry installer')

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -238,6 +238,7 @@ const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
 const gltfClient = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
 const gltfRouteBoundary =
   'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViewsRouteBoundary.tsx'
+const gltfModelView = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/ModelView.tsx'
 const webViemClient = 'apps/web/src/lib/viemClient.ts'
 const webClaimableNFTL = 'apps/web/src/hooks/useClaimableNFTL.ts'
 const webDegenAssets = 'apps/web/src/constants/degen-assets.ts'
@@ -245,6 +246,7 @@ const webDegenCatalog = 'apps/web/src/constants/degens.ts'
 const webNavbar = 'apps/web/src/components/Navbar/index.tsx'
 const sharedWebNavbar = 'packages/ui/src/components/custom/navbar/index.tsx'
 const sharedWebNavbarScrollFrame = 'packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx'
+const sharedWebNavbarScrollState = 'packages/ui/src/components/custom/navbar/NavbarScrollState.tsx'
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
 const sharedWebNavLinkContent = 'packages/ui/src/components/custom/navbar/NavLinkContent.tsx'
 const sharedWebMobileTrigger = 'packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx'
@@ -394,6 +396,7 @@ describe('GLTF viewer loading contract', () => {
     const pageSource = readFileSync(join(process.cwd(), gltfPage), 'utf8')
     const clientSource = readFileSync(join(process.cwd(), gltfClient), 'utf8')
     const routeBoundarySource = readFileSync(join(process.cwd(), gltfRouteBoundary), 'utf8')
+    const modelViewSource = readFileSync(join(process.cwd(), gltfModelView), 'utf8')
 
     expect(pageSource).not.toContain("'use client'")
     expect(pageSource).toContain('await params')
@@ -406,6 +409,18 @@ describe('GLTF viewer loading contract', () => {
     expect(clientSource).not.toContain("from 'next/image'")
     expect(clientSource).toContain("dynamic(() => import('./ModelView')")
     expect(clientSource).toContain('ssr: false')
+    expect(modelViewSource).toContain(
+      "import '@google/model-viewer/dist/model-viewer-module.min.js'"
+    )
+    expect(modelViewSource).not.toContain("import '@google/model-viewer'")
+  })
+
+  it('keeps embedded viewer controls loadable in sandboxed frames', () => {
+    const nextConfigSource = readFileSync(join(process.cwd(), 'apps/web/next.config.ts'), 'utf8')
+
+    expect(nextConfigSource).toContain("source: '/_next/static/:path*'")
+    expect(nextConfigSource).toContain("key: 'Access-Control-Allow-Origin'")
+    expect(nextConfigSource).toContain("value: '*'")
   })
 
   it('preloads only the visible NFT artwork', () => {
@@ -469,7 +484,6 @@ describe('shared notification loading contract', () => {
 describe('shared deferred loader contract', () => {
   it('uses the shared cancellable loader for app-only boundaries', () => {
     for (const file of [
-      deferredDegenCard,
       deferredCharacterCreator,
       deferredMintWalletBoundary,
       mintNetworkBoundary,
@@ -480,6 +494,12 @@ describe('shared deferred loader contract', () => {
       expect(source).toContain("from '@nl/ui/hooks/useDeferredComponent'")
       expect(source).toContain('useDeferredComponent')
     }
+
+    const degenSource = readFileSync(join(process.cwd(), deferredDegenCard), 'utf8')
+    expect(degenSource).toContain("from '@nl/ui/custom/deferred-component'")
+    expect(degenSource).toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(degenSource).toContain('disabledFallback')
+    expect(degenSource).toContain('loadingFallback')
   })
 
   it('shares viewport visibility state with the interactive web carousel', () => {
@@ -531,11 +551,14 @@ describe('Smashers public shell contract', () => {
     expect(actionButtonsSource).toContain("'use client'")
     expect(actionButtonsSource).not.toContain("from 'next/dynamic'")
     expect(actionButtonsSource).toContain("from '@nl/ui/base/button'")
+    expect(actionButtonsSource).toContain("from '@nl/ui/hooks/useDeferredComponent'")
     expect(actionButtonsSource).toContain('<Button')
     expect(actionButtonsSource).not.toContain('<button')
     expect(actionButtonsSource).toContain("import('@/components/PlayDialog')")
     expect(actionButtonsSource).toContain("import('@/components/TrailerDialog')")
     expect(actionButtonsSource).toContain("import('@/components/CreditsDialog')")
+    expect(actionButtonsSource).toContain('useDeferredComponent(action.load, open)')
+    expect(actionButtonsSource).not.toContain('loadedModals')
     expect(actionButtonsSource).toContain('aria-busy={isLoading}')
   })
 
@@ -1071,6 +1094,9 @@ describe('private provider loading contract', () => {
     const modalSource = readFileSync(join(process.cwd(), walletModal), 'utf8')
 
     expect(providerSource).toContain("import('./Web3ModalRuntime')")
+    expect(providerSource).toContain("from '@nl/ui/hooks/useDeferredComponent'")
+    expect(providerSource).not.toContain('useEffect')
+    expect(providerSource).not.toContain('useState')
     expect(providerSource).not.toContain("from 'wagmi'")
     expect(providerSource).not.toContain("from '@tanstack/react-query'")
     expect(runtimeSource).toContain("import('./Web3ModalConfig')")
@@ -1082,6 +1108,7 @@ describe('private provider loading contract', () => {
     expect(fallbackSource).toContain('role="status"')
     expect(fallbackSource).toContain('role="alert"')
     expect(providerSource).toContain('Retry')
+    expect(providerSource).toContain('onRetry={retry}')
     expect(authSource).not.toContain('useAppKit')
     expect(authSource).not.toContain('useAppKitEvents')
     expect(authSource).not.toContain("from 'wagmi'")
@@ -1517,6 +1544,10 @@ describe('web public navigation contract', () => {
       join(process.cwd(), sharedWebNavbarScrollFrame),
       'utf8'
     )
+    const sharedNavbarScrollStateSource = readFileSync(
+      join(process.cwd(), sharedWebNavbarScrollState),
+      'utf8'
+    )
     const mobileNavbarSource = readFileSync(join(process.cwd(), sharedWebMobileNavbar), 'utf8')
     const sharedNavLinkContentSource = readFileSync(
       join(process.cwd(), sharedWebNavLinkContent),
@@ -1526,8 +1557,10 @@ describe('web public navigation contract', () => {
     expect(navbarSource).not.toContain("'use client'")
     expect(navbarSource).toContain("from '@nl/ui/custom/navbar'")
     expect(sharedNavbarSource).not.toContain("'use client'")
-    expect(sharedNavbarScrollFrameSource).toContain("'use client'")
-    expect(sharedNavbarScrollFrameSource).toContain('requestAnimationFrame')
+    expect(sharedNavbarScrollFrameSource).not.toContain("'use client'")
+    expect(sharedNavbarScrollFrameSource).toContain('NavbarScrollState')
+    expect(sharedNavbarScrollStateSource).toContain("'use client'")
+    expect(sharedNavbarScrollStateSource).toContain('requestAnimationFrame')
     expect(sharedNavbarSource).not.toContain("import ActiveNavLink from './ActiveNavLink'")
     expect(sharedNavbarSource).toContain('function DesktopNavLink')
     expect(sharedNavbarScrollFrameSource).toContain('navbar-scroll-frame')
@@ -1911,6 +1944,16 @@ describe('public route dependency contract', () => {
     expect(enhancer).toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")
     expect(enhancer).toContain("video.preload = shouldPlay ? 'metadata' : 'none'")
+  })
+
+  it('keeps marketing game video identifiers unique', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'apps/web/src/app/(main)/games/page.tsx'),
+      'utf8'
+    )
+
+    expect(source).toContain('id={`game-video-${index}`}')
+    expect(source).not.toContain('id="console-video"')
   })
 
   it('keeps API-only constants separate from the contract registry', () => {


### PR DESCRIPTION
## Promotion

Promotes the exact validated `staging` tree to `main` using the repository’s rebase promotion flow.

## Included changes

- Fixes OpenSea’s sandboxed GLTF viewer so 2D, 3D, and Sprite controls load and remain interactive.
- Includes the already validated grouped app/web performance and styling repairs currently on `staging`.

## Validation

- Feature PR #771 was squash-merged into `staging` after hosted build, format, lint, type-check, unit, and aggregate gate checks passed.
- Staging push workflow completed successfully.
- Promotion branch tree matches `origin/staging` exactly; parent is current `origin/main`.
- Local GLTF sandbox smoke passed: 3D initialized the token GLTF, Sprite loaded the 128x128 animation, and no browser errors were emitted.
- Local web production build, tests, lint, type-check, route contracts, formatting, and diff checks passed.
