### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/components/leaderboards/EnhancedTable/EnhancedTableWithWallet.tsx
+++ b/apps/app/src/components/leaderboards/EnhancedTable/EnhancedTableWithWallet.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import type { TableProps } from '@/types/leaderboard'
-import WalletFeatureProviders from '@/contexts/WalletFeatureProviders'
+import LeaderboardProviders from '@/contexts/LeaderboardProviders'
 import EnhancedTable from './EnhancedTable'
 
 export default function EnhancedTableWithWallet(props: TableProps) {
   return (
-    <WalletFeatureProviders>
+    <LeaderboardProviders>
       <EnhancedTable {...props} />
-    </WalletFeatureProviders>
+    </LeaderboardProviders>
   )
 }

--- a/apps/app/src/contexts/LeaderboardProviders.tsx
+++ b/apps/app/src/contexts/LeaderboardProviders.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import type { PropsWithChildren } from 'react'
+import dynamic from 'next/dynamic'
+
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletAuthProviders from '@/contexts/WalletAuthProviders'
+
+const DeferredAuditFixtureContextWrapper = dynamic(
+  () => import('@/contexts/AuditFixtureContextWrapper'),
+  { ssr: false, loading: () => null }
+)
+
+/**
+ * The archived leaderboard only needs wallet authentication. Keep dashboard
+ * network, Immutable, NFT, and token-balance clients out of this public route.
+ */
+export default function LeaderboardProviders({ children }: PropsWithChildren) {
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+  const cookies = typeof document === 'undefined' ? null : document.cookie
+
+  if (!auditFixtureEnabled) {
+    return <WalletAuthProviders cookies={cookies}>{children}</WalletAuthProviders>
+  }
+
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>
+        <DeferredAuditFixtureContextWrapper>{children}</DeferredAuditFixtureContextWrapper>
+      </Web3ModalProvider>
+    </LocalStorageProvider>
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -103,6 +103,9 @@ const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletFeatureProviders.tsx',
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
+const leaderboardProviders = 'apps/app/src/contexts/LeaderboardProviders.tsx'
+const leaderboardWalletBoundary =
+  'apps/app/src/components/leaderboards/EnhancedTable/EnhancedTableWithWallet.tsx'
 const dashboardOverview = 'apps/app/src/app/(private-routes)/dashboard/overview/page.tsx'
 const dashboardOverviewBoundary =
   'apps/app/src/app/(private-routes)/dashboard/overview/DashboardOverviewRouteBoundary.tsx'
@@ -357,6 +360,28 @@ describe('public leaderboard loading contract', () => {
     expect(deferredSource).toContain("from '@nl/ui/base/skeleton'")
     expect(sharedSource).toContain('role="alert"')
     expect(sharedSource).toContain('Retry')
+  })
+
+  it('keeps archived leaderboards on the auth-only wallet boundary', () => {
+    const providers = readFileSync(join(process.cwd(), leaderboardProviders), 'utf8')
+    const boundary = readFileSync(join(process.cwd(), leaderboardWalletBoundary), 'utf8')
+
+    expect(boundary).toContain("from '@/contexts/LeaderboardProviders'")
+    expect(boundary).not.toContain('WalletFeatureProviders')
+    expect(providers).toContain("from '@/contexts/WalletAuthProviders'")
+    expect(providers).toContain("from '@/contexts/LocalStorageContext'")
+    expect(providers).toContain("from '@/contexts/Web3ModalContext'")
+    expect(providers).toContain("import('@/contexts/AuditFixtureContextWrapper')")
+    expect(providers).not.toContain("from '@/contexts/AuditFixtureContextWrapper'")
+
+    for (const provider of [
+      'IMXProvider',
+      'NetworkProvider',
+      'NFTsBalanceProvider',
+      'TokensBalanceProvider',
+    ]) {
+      expect(providers).not.toContain(`import { ${provider} }`)
+    }
   })
 })
 


### PR DESCRIPTION
## Promotion
Promotes the validated `origin/staging` tree to `main` using the repository's exact-tree staging-release flow.

- staging source: `bfd0db1d9a03f4ade97ada2ed04d4885e5f55607`
- staging tree: `3b618bfa7ad145f5cee10be7e28e7977b1f91c85`
- promotion commit tree matches staging exactly
- staging validation run passed: `31854033901`
- source feature PR: #774

This promotion contains the grouped performance branch, including the archived leaderboard provider split and the already-validated GLTF viewer compatibility fix.
