### PR TITLE
chore: promote staging Next build optimization to main

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -8,6 +8,9 @@ const ENV = (process.env.VERCEL_ENV as 'production' | 'preview' | undefined) ?? 
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/contracts', '@nl/imx-passport', '@nl/ui'],
+  experimental: {
+    useTypeScriptCli: true,
+  },
   turbopack: {},
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/apps/smashers/next.config.ts
+++ b/apps/smashers/next.config.ts
@@ -46,6 +46,9 @@ const generateAppleCountryRedirects = (countryCode: string) => [
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/playfab', '@nl/ui'],
+  experimental: {
+    useTypeScriptCli: true,
+  },
   turbopack: {},
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from 'node:fs'
 
 const responsiveTableList = 'apps/app/src/components/ResponsiveTable/DataList.tsx'
 const appManifest = 'apps/app/package.json'
+const appNextConfig = 'apps/app/next.config.ts'
+const smashersNextConfig = 'apps/smashers/next.config.ts'
 const webManifest = 'apps/web/package.json'
 const webNextConfig = 'apps/web/next.config.ts'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
@@ -173,6 +175,12 @@ describe('app performance contracts', () => {
 
     expect(manifest.scripts.dev).toBe('next dev --turbopack --port 3001')
     expect(manifest.scripts.dev).not.toContain('--webpack')
+  })
+
+  it('uses the project TypeScript CLI for Next app builds', () => {
+    for (const file of [appNextConfig, smashersNextConfig]) {
+      expect(readFileSync(file, 'utf8')).toContain('useTypeScriptCli: true')
+    }
   })
 
   it('uses Turbopack for local marketing development', () => {


### PR DESCRIPTION
## Promotion

Promote the exact validated `origin/staging` tree to `main`.

- Source staging commit: `e17cc4cd`
- Source staging tree: `7c1cb2e3fde514747b2837916c5aa2b3e4b770ad`
- Source feature PR: #780 (`perf(next): speed up app TypeScript builds`)
- Staging validation run: fast validation completed successfully.
- Promotion branch tree matches staging exactly.

## Merge method

Use the repository's canonical rebase merge for the staging-to-main promotion.

## Rollout

After merge, verify the single main-triggered Vercel deployment and the production app/web routes. No manual duplicate deployment is needed.
