### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/components/providers/WalletRouteProvider.tsx
+++ b/apps/app/src/components/providers/WalletRouteProvider.tsx
@@ -9,11 +9,20 @@ const WalletFeatureLoading = () => (
   </div>
 )
 
-const WalletFeatureProviders = dynamic(() => import('@/contexts/WalletFeatureProviders'), {
+const GameWalletProviders = dynamic(() => import('@/contexts/GameWalletProviders'), {
   ssr: false,
   loading: WalletFeatureLoading,
 })
 
-export default function WalletRouteProvider({ children }: PropsWithChildren) {
-  return <WalletFeatureProviders>{children}</WalletFeatureProviders>
+interface WalletRouteProviderProps extends PropsWithChildren {
+  loadWalletFeatures?: boolean
+}
+
+export default function WalletRouteProvider({
+  loadWalletFeatures,
+  children,
+}: WalletRouteProviderProps) {
+  return (
+    <GameWalletProviders loadWalletFeatures={loadWalletFeatures}>{children}</GameWalletProviders>
+  )
 }

--- a/apps/app/src/components/wrapper/GameRoute.tsx
+++ b/apps/app/src/components/wrapper/GameRoute.tsx
@@ -20,7 +20,7 @@ interface GameRouteProps extends PropsWithChildren {
 
 export default function GameRoute({ arcadeTokenRequired, children, unityConfig }: GameRouteProps) {
   return (
-    <WalletRouteProvider>
+    <WalletRouteProvider loadWalletFeatures={arcadeTokenRequired}>
       {children}
       <GameWithAuth unityConfig={unityConfig} arcadeTokenRequired={arcadeTokenRequired} />
     </WalletRouteProvider>

--- a/apps/app/src/contexts/GameWalletProviders.tsx
+++ b/apps/app/src/contexts/GameWalletProviders.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { PropsWithChildren } from 'react'
+
+import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
+import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
+import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+const WalletFeatureProviders = dynamic(() => import('@/contexts/WalletFeatureProviders'), {
+  ssr: false,
+  loading: () => (
+    <div className="sr-only" role="status" aria-live="polite" aria-busy="true">
+      Loading wallet balances
+    </div>
+  ),
+})
+
+interface GameWalletProvidersProps extends PropsWithChildren {
+  loadWalletFeatures?: boolean
+}
+
+export default function GameWalletProviders({
+  loadWalletFeatures = true,
+  children,
+}: GameWalletProvidersProps) {
+  const cookies = typeof document === 'undefined' ? null : document.cookie
+  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
+
+  const walletFeatures = auditFixtureEnabled ? (
+    <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
+  ) : loadWalletFeatures ? (
+    <WalletFeatureProviders>{children}</WalletFeatureProviders>
+  ) : (
+    children
+  )
+
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies}>
+        <AuthStatusProvider>
+          <AuthTokenProvider>{walletFeatures}</AuthTokenProvider>
+        </AuthStatusProvider>
+      </Web3ModalProvider>
+    </LocalStorageProvider>
+  )
+}

--- a/apps/app/src/contexts/WalletFeatureProviders.tsx
+++ b/apps/app/src/contexts/WalletFeatureProviders.tsx
@@ -2,39 +2,19 @@
 
 import type { PropsWithChildren } from 'react'
 
-import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
-import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
-import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { IMXProvider } from '@/contexts/IMXContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { NetworkProvider } from '@/contexts/NetworkProvider'
 import { NFTsBalanceProvider } from '@/contexts/NFTsBalanceContext'
 import { TokensBalanceProvider } from '@/contexts/TokensBalanceContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 
 export default function WalletFeatureProviders({ children }: PropsWithChildren) {
-  const auditFixtureEnabled = process.env.NEXT_PUBLIC_AUDIT_FIXTURE === 'true'
-  const cookies = typeof document === 'undefined' ? null : document.cookie
-
-  const walletContexts = auditFixtureEnabled ? (
-    <AuditFixtureContextWrapper>{children}</AuditFixtureContextWrapper>
-  ) : (
+  return (
     <NetworkProvider>
       <IMXProvider>
-        <AuthStatusProvider>
-          <AuthTokenProvider>
-            <NFTsBalanceProvider>
-              <TokensBalanceProvider>{children}</TokensBalanceProvider>
-            </NFTsBalanceProvider>
-          </AuthTokenProvider>
-        </AuthStatusProvider>
+        <NFTsBalanceProvider>
+          <TokensBalanceProvider>{children}</TokensBalanceProvider>
+        </NFTsBalanceProvider>
       </IMXProvider>
     </NetworkProvider>
-  )
-
-  return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
-    </LocalStorageProvider>
   )
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -100,7 +100,7 @@ const publicRoutesLayout = 'apps/app/src/app/(public-routes)/layout.tsx'
 const stalePublicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.tsx'
 const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletAuthProviders.tsx',
-  'apps/app/src/contexts/WalletFeatureProviders.tsx',
+  'apps/app/src/contexts/GameWalletProviders.tsx',
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
 const leaderboardProviders = 'apps/app/src/contexts/LeaderboardProviders.tsx'


### PR DESCRIPTION
## Promotion

Promote the validated staging tip `599aada65f6e9a971c110a5c921084a84c5cae3f` to `main`.

This includes the merged performance change from PR #788, which defers the heavy Immutable/NFT balance provider graph on non-arcade game routes while preserving arcade-token games, wallet degen dialogs, and audit fixtures.

## Staging evidence

- PR #788 merged to `staging` with the required Validation Gate green
- staging Code Foundry push validation passed
- staging Vercel deployments are READY for app, web, api, docs, and smashers-web
- local app validation: type-check, lint, 197 unit tests, and production build passed

## Promotion policy

This PR follows the repository’s staging-release flow and should be merged with the configured rebase method.
