### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/src/contexts/GameWalletProviders.tsx
+++ b/apps/app/src/contexts/GameWalletProviders.tsx
@@ -4,10 +4,7 @@ import dynamic from 'next/dynamic'
 import type { PropsWithChildren } from 'react'
 
 import AuditFixtureContextWrapper from '@/contexts/AuditFixtureContextWrapper'
-import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
-import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletAuthProviders from '@/contexts/WalletAuthProviders'
 
 const WalletFeatureProviders = dynamic(() => import('@/contexts/WalletFeatureProviders'), {
   ssr: false,
@@ -37,13 +34,5 @@ export default function GameWalletProviders({
     children
   )
 
-  return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>
-        <AuthStatusProvider>
-          <AuthTokenProvider>{walletFeatures}</AuthTokenProvider>
-        </AuthStatusProvider>
-      </Web3ModalProvider>
-    </LocalStorageProvider>
-  )
+  return <WalletAuthProviders cookies={cookies}>{walletFeatures}</WalletAuthProviders>
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -100,7 +100,6 @@ const publicRoutesLayout = 'apps/app/src/app/(public-routes)/layout.tsx'
 const stalePublicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.tsx'
 const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletAuthProviders.tsx',
-  'apps/app/src/contexts/GameWalletProviders.tsx',
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
 const leaderboardProviders = 'apps/app/src/contexts/LeaderboardProviders.tsx'
@@ -894,6 +893,19 @@ describe('public storage provider contract', () => {
       expect(source).toContain("from '@/contexts/LocalStorageContext'")
     })
   }
+
+  it('reuses the shared wallet auth provider composition for game routes', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'apps/app/src/contexts/GameWalletProviders.tsx'),
+      'utf8'
+    )
+
+    expect(source).toContain("from '@/contexts/WalletAuthProviders'")
+    expect(source).not.toContain("from '@/contexts/LocalStorageContext'")
+    expect(source).not.toContain("from '@/contexts/Web3ModalContext'")
+    expect(source).not.toContain("from '@/contexts/AuthStatusContext'")
+    expect(source).not.toContain("from '@/contexts/AuthTokenContext'")
+  })
 })
 
 describe('public app shell contract', () => {


### PR DESCRIPTION
## Summary
Promote the validated staging tree from PR #792 to main using the repository release workflow.

## Source
- staging: 08aee3ad7880368bee3ab7a90f9881a03bad8632
- promotion tree matches staging exactly
- promotion commit: 47d76901

## Validation
- PR #792 ready-PR checks passed: Format, Lint, Type-Check, Build, Unit, Mode, Gate
- local app tests: 197 passed
- local route contract: 207 passed
- production GLTF viewer smoke: https://niftyleague.com/gltf/1 returned HTTP 200

This uses the canonical staging-to-main rebase promotion path.