### PR TITLE
chore: promote validated staging to main

### DIFF
--- a/apps/app/src/components/providers/MintProviders.tsx
+++ b/apps/app/src/components/providers/MintProviders.tsx
@@ -6,8 +6,7 @@ import AuditFixtureMintContextWrapper from '@/contexts/AuditFixtureMintContextWr
 import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { DegenOwnershipProvider } from '@/contexts/DegenOwnershipContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletStorageProviders from '@/contexts/WalletStorageProviders'
 
 type MintProvidersProps = PropsWithChildren<{ cookies?: string | null }>
 
@@ -24,9 +23,5 @@ export default function MintProviders({ children, cookies }: MintProvidersProps)
     </AuthStatusProvider>
   )
 
-  return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>{walletContexts}</Web3ModalProvider>
-    </LocalStorageProvider>
-  )
+  return <WalletStorageProviders cookies={cookies}>{walletContexts}</WalletStorageProviders>
 }

--- a/apps/app/src/components/providers/PrivateRoutesShell.tsx
+++ b/apps/app/src/components/providers/PrivateRoutesShell.tsx
@@ -8,9 +8,8 @@ import MainLayout from '@/app/_layout/_MainLayout'
 import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagsContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
 import { NotificationProvider } from '@/contexts/NotificationContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletStorageProviders from '@/contexts/WalletStorageProviders'
 import DeferredNotifications from './DeferredNotifications'
 
 function PrivateRoutesContentLoading(): React.ReactNode {
@@ -36,26 +35,24 @@ interface PrivateRoutesShellProps extends PropsWithChildren {
 
 export default function PrivateRoutesShell({ children, cookies }: PrivateRoutesShellProps) {
   return (
-    <LocalStorageProvider>
-      <Web3ModalProvider
-        cookies={cookies}
-        loadingFallback={
-          <MainLayout walletReady={false}>
-            <PrivateRoutesContentLoading />
-          </MainLayout>
-        }
-      >
-        <AuthStatusProvider>
-          <NotificationProvider>
-            <AuthTokenProvider>
-              <FeatureFlagProvider>
-                <MainLayout>{children}</MainLayout>
-                <DeferredNotifications />
-              </FeatureFlagProvider>
-            </AuthTokenProvider>
-          </NotificationProvider>
-        </AuthStatusProvider>
-      </Web3ModalProvider>
-    </LocalStorageProvider>
+    <WalletStorageProviders
+      cookies={cookies}
+      loadingFallback={
+        <MainLayout walletReady={false}>
+          <PrivateRoutesContentLoading />
+        </MainLayout>
+      }
+    >
+      <AuthStatusProvider>
+        <NotificationProvider>
+          <AuthTokenProvider>
+            <FeatureFlagProvider>
+              <MainLayout>{children}</MainLayout>
+              <DeferredNotifications />
+            </FeatureFlagProvider>
+          </AuthTokenProvider>
+        </NotificationProvider>
+      </AuthStatusProvider>
+    </WalletStorageProviders>
   )
 }

--- a/apps/app/src/contexts/LeaderboardProviders.tsx
+++ b/apps/app/src/contexts/LeaderboardProviders.tsx
@@ -3,9 +3,8 @@
 import type { PropsWithChildren } from 'react'
 import dynamic from 'next/dynamic'
 
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
 import WalletAuthProviders from '@/contexts/WalletAuthProviders'
+import WalletStorageProviders from '@/contexts/WalletStorageProviders'
 
 const DeferredAuditFixtureContextWrapper = dynamic(
   () => import('@/contexts/AuditFixtureContextWrapper'),
@@ -25,10 +24,8 @@ export default function LeaderboardProviders({ children }: PropsWithChildren) {
   }
 
   return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>
-        <DeferredAuditFixtureContextWrapper>{children}</DeferredAuditFixtureContextWrapper>
-      </Web3ModalProvider>
-    </LocalStorageProvider>
+    <WalletStorageProviders cookies={cookies}>
+      <DeferredAuditFixtureContextWrapper>{children}</DeferredAuditFixtureContextWrapper>
+    </WalletStorageProviders>
   )
 }

--- a/apps/app/src/contexts/WalletAuthProviders.tsx
+++ b/apps/app/src/contexts/WalletAuthProviders.tsx
@@ -4,19 +4,16 @@ import type { PropsWithChildren } from 'react'
 
 import { AuthStatusProvider } from '@/contexts/AuthStatusContext'
 import { AuthTokenProvider } from '@/contexts/AuthTokenContext'
-import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
-import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+import WalletStorageProviders from '@/contexts/WalletStorageProviders'
 
 type WalletAuthProvidersProps = PropsWithChildren<{ cookies?: string | null }>
 
 export default function WalletAuthProviders({ children, cookies }: WalletAuthProvidersProps) {
   return (
-    <LocalStorageProvider>
-      <Web3ModalProvider cookies={cookies}>
-        <AuthStatusProvider>
-          <AuthTokenProvider>{children}</AuthTokenProvider>
-        </AuthStatusProvider>
-      </Web3ModalProvider>
-    </LocalStorageProvider>
+    <WalletStorageProviders cookies={cookies}>
+      <AuthStatusProvider>
+        <AuthTokenProvider>{children}</AuthTokenProvider>
+      </AuthStatusProvider>
+    </WalletStorageProviders>
   )
 }

--- a/apps/app/src/contexts/WalletStorageProviders.tsx
+++ b/apps/app/src/contexts/WalletStorageProviders.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import type { PropsWithChildren, ReactNode } from 'react'
+
+import { LocalStorageProvider } from '@/contexts/LocalStorageContext'
+import { Web3ModalProvider } from '@/contexts/Web3ModalContext'
+
+type WalletStorageProvidersProps = PropsWithChildren<{
+  cookies?: string | null
+  loadingFallback?: ReactNode
+}>
+
+/** Shared storage and wallet-runtime shell for route-specific provider stacks. */
+export default function WalletStorageProviders({
+  children,
+  cookies,
+  loadingFallback,
+}: WalletStorageProvidersProps) {
+  return (
+    <LocalStorageProvider>
+      <Web3ModalProvider cookies={cookies} loadingFallback={loadingFallback}>
+        {children}
+      </Web3ModalProvider>
+    </LocalStorageProvider>
+  )
+}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -100,6 +100,7 @@ const publicRoutesLayout = 'apps/app/src/app/(public-routes)/layout.tsx'
 const stalePublicProviderBoundary = 'apps/app/src/contexts/PublicAppContextWrapper.tsx'
 const walletStorageBoundaries = [
   'apps/app/src/contexts/WalletAuthProviders.tsx',
+  'apps/app/src/contexts/WalletStorageProviders.tsx',
   'apps/app/src/components/providers/MintProviders.tsx',
 ]
 const leaderboardProviders = 'apps/app/src/contexts/LeaderboardProviders.tsx'
@@ -326,6 +327,7 @@ const verificationClient = 'apps/app/src/app/verification/VerificationClient.tsx
 const verificationRouteBoundary = 'apps/app/src/app/verification/VerificationRouteBoundary.tsx'
 const walletAuthContextWrapper = 'apps/app/src/contexts/WalletAuthContextWrapper.tsx'
 const walletAuthProviders = 'apps/app/src/contexts/WalletAuthProviders.tsx'
+const walletStorageProviders = 'apps/app/src/contexts/WalletStorageProviders.tsx'
 const walletAuthProvidersBoundary = 'apps/app/src/contexts/WalletAuthProvidersBoundary.tsx'
 
 describe('external route surface contract', () => {
@@ -368,8 +370,7 @@ describe('public leaderboard loading contract', () => {
     expect(boundary).toContain("from '@/contexts/LeaderboardProviders'")
     expect(boundary).not.toContain('WalletFeatureProviders')
     expect(providers).toContain("from '@/contexts/WalletAuthProviders'")
-    expect(providers).toContain("from '@/contexts/LocalStorageContext'")
-    expect(providers).toContain("from '@/contexts/Web3ModalContext'")
+    expect(providers).toContain("from '@/contexts/WalletStorageProviders'")
     expect(providers).toContain("import('@/contexts/AuditFixtureContextWrapper')")
     expect(providers).not.toContain("from '@/contexts/AuditFixtureContextWrapper'")
 
@@ -890,7 +891,11 @@ describe('public storage provider contract', () => {
     it(`keeps wallet storage available in ${file}`, () => {
       const source = readFileSync(join(process.cwd(), file), 'utf8')
 
-      expect(source).toContain("from '@/contexts/LocalStorageContext'")
+      if (file === walletStorageProviders) {
+        expect(source).toContain("from '@/contexts/LocalStorageContext'")
+      } else {
+        expect(source).toContain("from '@/contexts/WalletStorageProviders'")
+      }
     })
   }
 
@@ -1033,7 +1038,7 @@ describe('verification route shell contract', () => {
     expect(providersBoundarySource).toContain("import('./WalletAuthProviders')")
     expect(providersBoundarySource).toContain('ssr: false')
     expect(providersBoundarySource).toContain("from '@nl/ui/custom/route-loading'")
-    expect(providersSource).toContain("from '@/contexts/Web3ModalContext'")
+    expect(providersSource).toContain("from '@/contexts/WalletStorageProviders'")
     expect(providersSource).toContain("from '@/contexts/AuthTokenContext'")
   })
 })
@@ -1194,7 +1199,7 @@ describe('private provider loading contract', () => {
     expect(boundarySource).toContain('<Skeleton')
     expect(boundarySource).toContain('role="status"')
     expect(shellSource).toContain('MainLayout')
-    expect(shellSource).toContain('Web3ModalProvider')
+    expect(shellSource).toContain('WalletStorageProviders')
     expect(shellSource).toContain('loadingFallback')
     expect(shellSource).toContain('walletReady={false}')
     expect(shellSource).toContain('AuthTokenProvider')


### PR DESCRIPTION
## Summary
Promotes the validated `staging` tree to `main` after the cross-app regression audit.

This promotion contains the shared wallet-storage provider composition and its route-surface contract update. The promotion branch tree is an exact match for `origin/staging`.

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run type-check`
- `bun run build`
- `bun test test/contract/route-surface.test.ts` (208 pass)
- `apps/app`: focused Bun suite (197 pass)
- Production route audit: web 17/17, app 20/20, Smashers 4/4, docs 54/54 returned 200
- GLTF viewer: 2D, 3D, Sprite, model asset, and NFTL display verified
- Screenshot regression comparison against main baseline completed for all 95 routes; settled visual differences were animation/lazy-load timing, not layout regressions
