### PR TITLE
chore: promote docs media optimization to main

### DIFF
--- a/apps/docs/docs/overview/games/mini-games/arcade-tokens.md
+++ b/apps/docs/docs/overview/games/mini-games/arcade-tokens.md
@@ -4,10 +4,10 @@ title: Arcade Tokens
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/arcade-token.mp4';
 
-<ReactPlayer playing playsInline src={VideoURL} width="100%" height={500} />
+<ViewportVideo playsInline src={VideoURL} style={{ display: 'block', width: '100%', height: 500 }} />
 
 ---
 

--- a/apps/docs/docs/overview/games/mini-games/crypto-winter.md
+++ b/apps/docs/docs/overview/games/mini-games/crypto-winter.md
@@ -4,7 +4,7 @@ title: Crypto Winter
 sidebar_position: 3
 ---
 
-import ReactPlayer from 'react-player';
+import LazyYouTubeEmbed from '@nl/ui/custom/lazy-youtube-embed';
 
 <div style={{ maxWidth: 640, margin: 'auto' }}>![](/img/games/crypto-winter.webp)</div>
 <br />
@@ -25,4 +25,8 @@ Currently, earning Arcade Tokens that can be used to play WEN Game is based on N
 
 Interested in testing the old version? Learn how to get started below:
 
-<ReactPlayer controls src="https://www.youtube.com/embed/ZiY-TwtzYVk" width="100%" height={500} />
+<LazyYouTubeEmbed
+src="https://www.youtube.com/embed/ZiY-TwtzYVk"
+title="Crypto Winter gameplay"
+style={{ display: 'block', width: '100%', height: 500 }}
+/>

--- a/apps/docs/docs/overview/games/mini-games/wen-game.md
+++ b/apps/docs/docs/overview/games/mini-games/wen-game.md
@@ -4,10 +4,16 @@ title: WEN Game
 sidebar_position: 2
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/wen-ape.mp4';
 
-<ReactPlayer controls playsInline src={VideoURL} width="100%" height={500} />
+<ViewportVideo
+controls
+playOnViewport={false}
+playsInline
+src={VideoURL}
+style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ---
 

--- a/apps/docs/docs/overview/games/mobile-games/nifty-royale.md
+++ b/apps/docs/docs/overview/games/mobile-games/nifty-royale.md
@@ -4,7 +4,7 @@ title: Nifty Royale
 sidebar_position: 2
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/nakedbeachflyby.mp4';
 
 <div style={{ maxWidth: 450, margin: 'auto' }}>
@@ -29,7 +29,7 @@ Nifty Royale takes place in our Beach City & Naked Beach regions of [NiftyWorld]
   ![](/img/niftyworld/beachcity_04.webp)
 </div>
 
-<ReactPlayer playing playsInline src={VideoURL} width="100%" height={350} />
+<ViewportVideo playsInline src={VideoURL} style={{ display: 'block', width: '100%', height: 350 }} />
 <br />
 
 **The Terrain**: The terrain consists of two area: “underground” and “surface”. The underground has different sections and each section has two holes which connect the underground to the surface. One hole for descending from the surface and the other for ascending to the surface (it pushes you up to the sky). The underground area is a randomly generated maze which is filled with toxic gas and players can’t stay there too long without losing their resistance bar. So, they should to go back to the surface frequently. On the surface players can use their hoverboard and jetpack to move quickly. There are much more gems in the underground than the surface so players have to go down to collect them. On the surface they usually pick up gem if other players drop them due to taking damage.

--- a/apps/docs/docs/overview/games/mobile-games/nifty-smashers.md
+++ b/apps/docs/docs/overview/games/mobile-games/nifty-smashers.md
@@ -4,7 +4,8 @@ title: Nifty Smashers
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player';
+import LazyYouTubeEmbed from '@nl/ui/custom/lazy-youtube-embed';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/lobby.mp4';
 
 <div style={{ maxWidth: 500, margin: 'auto' }}>![](/img/logos/smashers/app_wordmark_logo_small.webp)</div>
@@ -19,7 +20,11 @@ For some background, the local-multiplayer version of Nifty Smashers was made av
 
 You can play using any other compatible controller (Playstation, Xbox, etc.) if you wish. For the deprecated desktop version you must have a [DEGEN NFT](/docs/overview/nfts/degens/about) to play. Simply connect your crypto wallet holding your DEGEN, enter the game lobby, and select your DEGEN for battle.
 
-<ReactPlayer controls src="https://www.youtube.com/embed/4lnDrx4aDq8" width="100%" height={500} />
+<LazyYouTubeEmbed
+src="https://www.youtube.com/embed/4lnDrx4aDq8"
+title="Nifty Smashers gameplay"
+style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ---
 
@@ -110,7 +115,7 @@ All DEGEN tribes have a Special Ability (”SA”), which are consistent across 
 
 For an in-depth overview of the games progression system read our [Pregression Doc](https://docs.google.com/document/d/160WTUFqiL4oyap0x0Zf1rM9zxQGBCIGQbrWxF_604bM/edit?usp=sharing)
 
-<ReactPlayer playing playsInline src={VideoURL} width="100%" height={500} />
+<ViewportVideo playsInline src={VideoURL} style={{ display: 'block', width: '100%', height: 500 }} />
 
 ---
 

--- a/apps/docs/docs/overview/games/niftyworld/niftyworld.mdx
+++ b/apps/docs/docs/overview/games/niftyworld/niftyworld.mdx
@@ -4,7 +4,7 @@ title: NiftyWorld
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player'
+import ViewportVideo from '@nl/ui/custom/viewport-video'
 import VideoURL from '/video/mansion_showcase.mp4'
 import VideoURL2 from '/video/bank.mp4'
 import VideoURL3 from '/video/rugmans-peak.mp4'
@@ -19,7 +19,13 @@ NiftyWorld is a virtual space for gamers to connect, collaborate, and compete wi
 
 While Nifty League focuses on building a decentralized game platform with titles such as Nifty Smashers and other Nintendo-inspired games, NiftyWorld stands at the heart of our ecosystem tying everything together. It's not only the central lobby system or launch point for many of these games, but the main hub for all social interactions (and quite frankly our biggest game in and of itself).
 
-<ReactPlayer controls playsInline src={VideoURL} width="100%" height={500} />
+<ViewportVideo
+  controls
+  playOnViewport={false}
+  playsInline
+  src={VideoURL}
+  style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ---
 
@@ -31,9 +37,17 @@ Get a first glimpse of NiftyWorld in [Nifty Royale](/docs/overview/games/mobile-
 
 :::
 
-<ReactPlayer playing playsInline src={VideoURL2} width="100%" height={500} />
+<ViewportVideo
+  playsInline
+  src={VideoURL2}
+  style={{ display: 'block', width: '100%', height: 500 }}
+/>
 <br />
-<ReactPlayer playing playsInline src={VideoURL3} width="100%" height={500} />
+<ViewportVideo
+  playsInline
+  src={VideoURL3}
+  style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ---
 

--- a/apps/docs/docs/overview/games/overview.md
+++ b/apps/docs/docs/overview/games/overview.md
@@ -4,10 +4,10 @@ title: Our Games
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/game-console.mp4';
 
-<ReactPlayer playing playsInline src={VideoURL} width="100%" height={500} />
+<ViewportVideo playsInline src={VideoURL} style={{ display: 'block', width: '100%', height: 500 }} />
 
 ---
 

--- a/apps/docs/docs/overview/nfts/nifty-marketplace/comics.md
+++ b/apps/docs/docs/overview/nfts/nifty-marketplace/comics.md
@@ -4,7 +4,7 @@ title: Comics
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL1 from '/video/comics_archive.mp4';
 
 | ![](/img/comics/page/1.webp) | ![](/img/comics/page/2.webp) | ![](/img/comics/page/3.webp) |
@@ -26,7 +26,12 @@ There was a snapshot on 1/31/2022 for **Comic 5** awarded to all DEGEN holders, 
 
 In addition, all [Meta background](/docs/overview/nfts/degens/backgrounds) DEGENs received one **Comic 6** NFT, and all [Legendary background](/docs/overview/nfts/degens/backgrounds) DEGENs received two **Comic 6** NFTs.
 
-<ReactPlayer controls src={VideoURL1} width="100%" height={500} />
+<ViewportVideo
+controls
+playOnViewport={false}
+src={VideoURL1}
+style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 :::tip[Note]
 

--- a/apps/docs/docs/overview/nfts/nifty-marketplace/items.md
+++ b/apps/docs/docs/overview/nfts/nifty-marketplace/items.md
@@ -4,7 +4,7 @@ title: Items
 sidebar_position: 2
 ---
 
-import ReactPlayer from 'react-player';
+import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL1 from '/video/companion.mp4';
 import VideoURL2 from '/video/citadel_key.mp4';
 
@@ -28,13 +28,23 @@ Powerful bats or other weapons used in various Nifty League games such as [Nifty
 
 Earned from burning Comic Page #6
 
-<ReactPlayer controls src={VideoURL1} width="100%" height={500} />
+<ViewportVideo
+controls
+playOnViewport={false}
+src={VideoURL1}
+style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ### Citadel Key
 
 Earned from burning a full-set of all 6 pages
 
-<ReactPlayer controls src={VideoURL2} width="100%" height={500} />
+<ViewportVideo
+controls
+playOnViewport={false}
+src={VideoURL2}
+style={{ display: 'block', width: '100%', height: 500 }}
+/>
 
 ### Immutable zkEVM Items Marketplace
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,12 +29,12 @@
     "@docusaurus/preset-classic": "^3.10.2",
     "@docusaurus/theme-mermaid": "^3.10.2",
     "@mdx-js/react": "^3.1.1",
+    "@nl/ui": "workspace:*",
     "algoliasearch": "^5.56.0",
     "lucide-react": "^1.31.0",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.8",
-    "react-dom": "19.2.8",
-    "react-player": "^3.4.0"
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.2",

--- a/bun.lock
+++ b/bun.lock
@@ -114,12 +114,12 @@
         "@docusaurus/preset-classic": "^3.10.2",
         "@docusaurus/theme-mermaid": "^3.10.2",
         "@mdx-js/react": "^3.1.1",
+        "@nl/ui": "workspace:*",
         "algoliasearch": "^5.56.0",
         "lucide-react": "^1.31.0",
         "prism-react-renderer": "^2.4.1",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-player": "^3.4.0",
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.2",
@@ -1241,16 +1241,6 @@
 
     "@multiformats/multiaddr-to-uri": ["@multiformats/multiaddr-to-uri@12.0.0", "", { "dependencies": { "@multiformats/multiaddr": "^13.0.0" } }, "sha512-3uIEBCiy8tfzxYYBl81x1tISiNBQ7mHU4pGjippbJRoQYHzy/ZdZM/7JvTldr8pc/dzpkaNJxnsuxxlhsPOJsA=="],
 
-    "@mux/mux-data-google-ima": ["@mux/mux-data-google-ima@0.3.17", "", { "dependencies": { "mux-embed": "5.18.1" } }, "sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A=="],
-
-    "@mux/mux-player": ["@mux/mux-player@3.13.0", "", { "dependencies": { "@mux/mux-video": "0.31.0", "@mux/playback-core": "0.35.0", "media-chrome": "~4.19.0", "player.style": "^0.3.0" } }, "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg=="],
-
-    "@mux/mux-player-react": ["@mux/mux-player-react@3.13.0", "", { "dependencies": { "@mux/mux-player": "3.13.0", "@mux/playback-core": "0.35.0", "prop-types": "^15.8.1" }, "peerDependencies": { "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0", "@types/react-dom": "*", "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0", "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ=="],
-
-    "@mux/mux-video": ["@mux/mux-video@0.31.0", "", { "dependencies": { "@mux/mux-data-google-ima": "^0.3.4", "@mux/playback-core": "0.35.0", "castable-video": "~1.1.13", "custom-media-element": "~1.4.6", "media-tracks": "~0.3.5" } }, "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA=="],
-
-    "@mux/playback-core": ["@mux/playback-core@0.35.0", "", { "dependencies": { "hls.js": "~1.6.15", "mux-embed": "^5.16.1" } }, "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A=="],
-
     "@mysten/bcs": ["@mysten/bcs@1.9.2", "", { "dependencies": { "@mysten/utils": "0.2.0", "@scure/base": "^1.2.6" } }, "sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ=="],
 
     "@mysten/sui": ["@mysten/sui@1.45.2", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "1.9.2", "@mysten/utils": "0.2.0", "@noble/curves": "=1.9.4", "@noble/hashes": "^1.8.0", "@protobuf-ts/grpcweb-transport": "^2.11.1", "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1", "@scure/base": "^1.2.6", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "gql.tada": "^1.8.13", "graphql": "^16.11.0", "poseidon-lite": "0.2.1", "valibot": "^1.2.0" } }, "sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg=="],
@@ -2033,26 +2023,6 @@
 
     "@svgr/webpack": ["@svgr/webpack@8.1.0", "", { "dependencies": { "@babel/core": "^7.21.3", "@babel/plugin-transform-react-constant-elements": "^7.21.3", "@babel/preset-env": "^7.20.2", "@babel/preset-react": "^7.18.6", "@babel/preset-typescript": "^7.21.0", "@svgr/core": "8.1.0", "@svgr/plugin-jsx": "8.1.0", "@svgr/plugin-svgo": "8.1.0" } }, "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA=="],
 
-    "@svta/cml-608": ["@svta/cml-608@1.0.2", "", {}, "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ=="],
-
-    "@svta/cml-cmcd": ["@svta/cml-cmcd@2.3.2", "", { "peerDependencies": { "@svta/cml-structured-field-values": "1.1.3", "@svta/cml-utils": "1.5.0" } }, "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A=="],
-
-    "@svta/cml-cmsd": ["@svta/cml-cmsd@1.0.6", "", { "peerDependencies": { "@svta/cml-cta": "1.0.6", "@svta/cml-structured-field-values": "1.1.3", "@svta/cml-utils": "1.5.0" } }, "sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g=="],
-
-    "@svta/cml-cta": ["@svta/cml-cta@1.0.6", "", { "peerDependencies": { "@svta/cml-structured-field-values": "1.1.3", "@svta/cml-utils": "1.5.0" } }, "sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw=="],
-
-    "@svta/cml-dash": ["@svta/cml-dash@1.0.6", "", { "peerDependencies": { "@svta/cml-utils": "1.5.0" } }, "sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA=="],
-
-    "@svta/cml-id3": ["@svta/cml-id3@1.0.6", "", { "peerDependencies": { "@svta/cml-utils": "1.5.0" } }, "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A=="],
-
-    "@svta/cml-request": ["@svta/cml-request@1.0.12", "", { "peerDependencies": { "@svta/cml-cmcd": "2.3.2", "@svta/cml-utils": "1.5.0", "@svta/cml-xml": "1.1.4" } }, "sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w=="],
-
-    "@svta/cml-structured-field-values": ["@svta/cml-structured-field-values@1.1.3", "", { "peerDependencies": { "@svta/cml-utils": "1.5.0" } }, "sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg=="],
-
-    "@svta/cml-utils": ["@svta/cml-utils@1.5.0", "", {}, "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw=="],
-
-    "@svta/cml-xml": ["@svta/cml-xml@1.1.4", "", { "peerDependencies": { "@svta/cml-utils": "1.5.0" } }, "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw=="],
-
     "@swc/core": ["@swc/core@1.15.43", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.27" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.43", "@swc/core-darwin-x64": "1.15.43", "@swc/core-linux-arm-gnueabihf": "1.15.43", "@swc/core-linux-arm64-gnu": "1.15.43", "@swc/core-linux-arm64-musl": "1.15.43", "@swc/core-linux-ppc64-gnu": "1.15.43", "@swc/core-linux-s390x-gnu": "1.15.43", "@swc/core-linux-x64-gnu": "1.15.43", "@swc/core-linux-x64-musl": "1.15.43", "@swc/core-win32-arm64-msvc": "1.15.43", "@swc/core-win32-ia32-msvc": "1.15.43", "@swc/core-win32-x64-msvc": "1.15.43" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw=="],
 
     "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.43", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA=="],
@@ -2445,8 +2415,6 @@
 
     "@vercel/edge": ["@vercel/edge@1.3.2", "", {}, "sha512-bpeHqawJ931YujN2OxcOfknQPem0pvTofpLmfGMvlcSW0FMDLEog+NKNIez3YRkr9aVIIKKyMzozmmg3UtWqEA=="],
 
-    "@vimeo/player": ["@vimeo/player@2.29.0", "", { "dependencies": { "native-promise-only": "0.8.1", "weakmap-polyfill": "2.0.4" } }, "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw=="],
-
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
@@ -2719,8 +2687,6 @@
 
     "batch": ["batch@0.6.1", "", {}, "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="],
 
-    "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
-
     "bech32": ["bech32@2.0.0", "", {}, "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="],
 
     "big.js": ["big.js@6.2.2", "", {}, "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="],
@@ -2807,13 +2773,9 @@
 
     "cardinal": ["cardinal@2.1.1", "", { "dependencies": { "ansicolors": "~0.3.2", "redeyed": "~2.1.0" }, "bin": { "cdl": "./bin/cdl.js" } }, "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw=="],
 
-    "castable-video": ["castable-video@1.1.16", "", { "dependencies": { "custom-media-element": "~1.4.6" } }, "sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w=="],
-
     "cborg": ["cborg@6.1.1", "", { "bin": { "cborg": "lib/bin.js" } }, "sha512-Ci8+V1OMFtqea8EXicsATqV+3kEqCGXCicM+5MEzpKTxqy58WMzhJUjtUqAjfWpKPZ0wpG8F+u5mC8Xy/0Zevg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
-
-    "ce-la-react": ["ce-la-react@0.3.2", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -2861,11 +2823,7 @@
 
     "clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
-    "cloudflare-video-element": ["cloudflare-video-element@1.3.5", "", {}, "sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw=="],
-
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
-    "codem-isoboxer": ["codem-isoboxer@0.3.10", "", {}, "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -2991,8 +2949,6 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "custom-media-element": ["custom-media-element@1.4.6", "", {}, "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA=="],
-
     "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
 
     "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
@@ -3068,10 +3024,6 @@
     "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
-
-    "dash-video-element": ["dash-video-element@0.3.2", "", { "dependencies": { "custom-media-element": "^1.4.6", "dashjs": "^5.0.3", "media-tracks": "^0.3.5" } }, "sha512-eN1IqgtTAbq4zVkbt82BDwQtybQ6WOXyQU5HbftUSnqo+SHAPbZCif1Y7uViAhgvuEPvZtbiXDiacvvTeGxc/g=="],
-
-    "dashjs": ["dashjs@5.2.0", "", { "dependencies": { "@svta/cml-608": "1.0.2", "@svta/cml-cmcd": "2.3.2", "@svta/cml-cmsd": "1.0.6", "@svta/cml-dash": "1.0.6", "@svta/cml-id3": "1.0.6", "@svta/cml-request": "1.0.12", "@svta/cml-xml": "1.1.4", "bcp-47-match": "^2.0.3", "codem-isoboxer": "0.3.10", "fast-deep-equal": "3.1.3", "html-entities": "^2.6.0", "imsc": "^1.1.5", "localforage": "^1.10.0", "path-browserify": "^1.0.1" } }, "sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -3559,17 +3511,11 @@
 
     "history": ["history@4.10.1", "", { "dependencies": { "@babel/runtime": "^7.1.2", "loose-envify": "^1.2.0", "resolve-pathname": "^3.0.0", "tiny-invariant": "^1.0.2", "tiny-warning": "^1.0.0", "value-equal": "^1.0.1" } }, "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew=="],
 
-    "hls-video-element": ["hls-video-element@1.5.11", "", { "dependencies": { "custom-media-element": "^1.4.6", "hls.js": "^1.6.5", "media-tracks": "^0.3.5" } }, "sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA=="],
-
-    "hls.js": ["hls.js@1.6.16", "", {}, "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="],
-
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
     "hpack.js": ["hpack.js@2.1.6", "", { "dependencies": { "inherits": "^2.0.1", "obuf": "^1.0.0", "readable-stream": "^2.0.1", "wbuf": "^1.1.0" } }, "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ=="],
-
-    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -3632,8 +3578,6 @@
     "import-lazy": ["import-lazy@4.0.0", "", {}, "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
-
-    "imsc": ["imsc@1.1.5", "", { "dependencies": { "sax": "1.2.1" } }, "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -4051,12 +3995,6 @@
 
     "mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
-    "media-chrome": ["media-chrome@4.19.2", "", { "dependencies": { "ce-la-react": "^0.3.2" } }, "sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA=="],
-
-    "media-played-ranges-mixin": ["media-played-ranges-mixin@0.1.0", "", {}, "sha512-zTsvkleu5sAyTsPVxDI+KUbCwy/lXwHgOPi3ER9S3lhtAWhGTQH6qxvfrVMym1cvoLU36SPbVr6Qe8Zxyc0WpA=="],
-
-    "media-tracks": ["media-tracks@0.3.5", "", {}, "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA=="],
-
     "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
 
     "memfs": ["memfs@4.64.0", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.64.0", "@jsonjoy.com/fs-fsa": "4.64.0", "@jsonjoy.com/fs-node": "4.64.0", "@jsonjoy.com/fs-node-builtins": "4.64.0", "@jsonjoy.com/fs-node-to-fsa": "4.64.0", "@jsonjoy.com/fs-node-utils": "4.64.0", "@jsonjoy.com/fs-print": "4.64.0", "@jsonjoy.com/fs-snapshot": "4.64.0", "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw=="],
@@ -4203,15 +4141,11 @@
 
     "multiformats": ["multiformats@14.0.5", "", {}, "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ=="],
 
-    "mux-embed": ["mux-embed@5.18.1", "", {}, "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g=="],
-
     "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
 
     "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
-
-    "native-promise-only": ["native-promise-only@0.8.1", "", {}, "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -4371,8 +4305,6 @@
 
     "pascal-case": ["pascal-case@3.1.2", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g=="],
 
-    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -4424,8 +4356,6 @@
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
     "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
-
-    "player.style": ["player.style@0.3.4", "", { "dependencies": { "media-chrome": "~4.19.0" } }, "sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw=="],
 
     "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
 
@@ -4688,8 +4618,6 @@
     "react-loadable-ssr-addon-v5-slorber": ["react-loadable-ssr-addon-v5-slorber@1.0.3", "", { "dependencies": { "@babel/runtime": "^7.10.3" }, "peerDependencies": { "react-loadable": "*", "webpack": ">=4.41.1 || 5.x" } }, "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ=="],
 
     "react-number-format": ["react-number-format@5.4.5", "", { "peerDependencies": { "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="],
-
-    "react-player": ["react-player@3.4.0", "", { "dependencies": { "@mux/mux-player-react": "^3.8.0", "cloudflare-video-element": "^1.3.4", "dash-video-element": "^0.3.0", "hls-video-element": "^1.5.9", "spotify-audio-element": "^1.0.3", "tiktok-video-element": "^0.1.1", "twitch-video-element": "^0.1.5", "vimeo-video-element": "^1.6.1", "wistia-video-element": "^1.3.5", "youtube-video-element": "^1.8.0" }, "peerDependencies": { "@types/react": "^17.0.0 || ^18 || ^19", "react": "^17.0.2 || ^18 || ^19", "react-dom": "^17.0.2 || ^18 || ^19" } }, "sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -4965,8 +4893,6 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "spotify-audio-element": ["spotify-audio-element@1.0.4", "", {}, "sha512-QdKrJPkYCzaNwwz2vN2eDGyoW0KmQFmnwVprB41mpMzj4qujbqr6pegEchQeTn0b5PceKiLoVu0pp2QDpTcWnw=="],
-
     "srcset": ["srcset@4.0.0", "", {}, "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
@@ -5057,8 +4983,6 @@
 
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
-    "super-media-element": ["super-media-element@1.4.2", "", {}, "sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA=="],
-
     "superagent": ["superagent@10.3.0", "", { "dependencies": { "component-emitter": "^1.3.1", "cookiejar": "^2.1.4", "debug": "^4.3.7", "fast-safe-stringify": "^2.1.1", "form-data": "^4.0.5", "formidable": "^3.5.4", "methods": "^1.1.2", "mime": "2.6.0", "qs": "^6.14.1" } }, "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ=="],
 
     "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
@@ -5122,8 +5046,6 @@
     "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
 
     "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
-
-    "tiktok-video-element": ["tiktok-video-element@0.1.2", "", {}, "sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q=="],
 
     "tiny-case": ["tiny-case@1.0.3", "", {}, "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="],
 
@@ -5194,8 +5116,6 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
-
-    "twitch-video-element": ["twitch-video-element@0.1.6", "", {}, "sha512-X7l8gy+DEFKJ/EztUwaVnAYwQN9fUJxPkOVJj2sE62sGvGU4DNLyvmOsmVulM+8Plc5dMg6hYIMNRAPaH+39Uw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -5323,8 +5243,6 @@
 
     "viem": ["viem@2.55.10", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ=="],
 
-    "vimeo-video-element": ["vimeo-video-element@1.7.2", "", { "dependencies": { "@vimeo/player": "2.29.0", "media-played-ranges-mixin": "^0.1.0" } }, "sha512-7QM7fvSZvTTSq4igxBuO6Gc+0u3Exgk4IaLNixVzilCPzHEf7SN8b6YLXSM5QCs0ineTJI4XjiUCSoIbabHvwg=="],
-
     "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "wagmi": ["wagmi@3.7.6", "", { "dependencies": { "@wagmi/connectors": "8.1.0", "@wagmi/core": "3.6.4", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.9.3", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-Zm/ppGHV6GYX9by3ERs1KVcNqpMZ4Vdno48Avdz9U+3QCjC5iFatOwruA9IMOl8poL7n/pJGQOcR1xj8N5c69w=="],
@@ -5334,8 +5252,6 @@
     "watchpack": ["watchpack@2.5.2", "", { "dependencies": { "graceful-fs": "^4.1.2" } }, "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg=="],
 
     "wbuf": ["wbuf@1.7.3", "", { "dependencies": { "minimalistic-assert": "^1.0.0" } }, "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA=="],
-
-    "weakmap-polyfill": ["weakmap-polyfill@2.0.4", "", {}, "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw=="],
 
     "weald": ["weald@1.1.3", "", { "dependencies": { "ms": "^4.0.0-nightly.202508271359", "supports-color": "^10.0.0" } }, "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA=="],
 
@@ -5393,8 +5309,6 @@
 
     "wildcard": ["wildcard@2.0.1", "", {}, "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="],
 
-    "wistia-video-element": ["wistia-video-element@1.4.0", "", { "dependencies": { "super-media-element": "~1.4.2" } }, "sha512-udI8/yiMZ+KIGwYK1qNOFiXl+s/wffiY+XkwTXlBFICZylFalOS0QYEQqYOmuBsm3jNfGUS4O50tLuN7Ejqm3A=="],
-
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrapjs": ["wordwrapjs@4.0.1", "", { "dependencies": { "reduce-flatten": "^2.0.0", "typical": "^5.2.0" } }, "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA=="],
@@ -5436,8 +5350,6 @@
     "yargs-unparser": ["yargs-unparser@2.0.0", "", { "dependencies": { "camelcase": "^6.0.0", "decamelize": "^4.0.0", "flat": "^5.0.2", "is-plain-obj": "^2.1.0" } }, "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "youtube-video-element": ["youtube-video-element@1.9.0", "", { "dependencies": { "media-played-ranges-mixin": "^0.1.0" } }, "sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg=="],
 
     "yup": ["yup@1.7.1", "", { "dependencies": { "property-expr": "^2.0.5", "tiny-case": "^1.0.3", "toposort": "^2.0.2", "type-fest": "^2.19.0" } }, "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw=="],
 
@@ -6218,8 +6130,6 @@
     "http-proxy-middleware/@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
 
     "http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
-
-    "imsc/sax": ["sax@1.2.1", "", {}, "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -1,25 +1,49 @@
 'use client'
 
-import dynamic from 'next/dynamic'
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ViewportVideoProps } from './index'
 
-const ViewportVideoEnhancer = dynamic(() => import('./ViewportVideoEnhancer'), { ssr: false })
+type ViewportVideoEnhancerComponent = typeof import('./ViewportVideoEnhancer').default
+
+const loadViewportVideoEnhancer = () => import('./ViewportVideoEnhancer')
 
 export default function ViewportVideoBoundary({
+  playOnViewport = true,
   rootMargin = '0px',
   src,
   ...props
 }: ViewportVideoProps): React.ReactNode {
   const videoRef = useRef<HTMLVideoElement>(null)
+  const [ViewportVideoEnhancer, setViewportVideoEnhancer] =
+    useState<ViewportVideoEnhancerComponent | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    void loadViewportVideoEnhancer()
+      .then(({ default: Enhancer }) => {
+        if (active) setViewportVideoEnhancer(() => Enhancer)
+      })
+      .catch(() => undefined)
+
+    return () => {
+      active = false
+    }
+  }, [])
 
   return (
     <>
       <video {...props} ref={videoRef} preload="none">
         <source src={src} type="video/mp4" />
       </video>
-      <ViewportVideoEnhancer rootMargin={rootMargin} videoRef={videoRef} />
+      {ViewportVideoEnhancer ? (
+        <ViewportVideoEnhancer
+          playOnViewport={playOnViewport}
+          rootMargin={rootMargin}
+          videoRef={videoRef}
+        />
+      ) : null}
     </>
   )
 }

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
@@ -6,24 +6,27 @@ import useMediaQuery from '@nl/ui/hooks/useMediaQuery'
 import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
 interface ViewportVideoEnhancerProps {
+  playOnViewport: boolean
   rootMargin: string
   videoRef: RefObject<HTMLVideoElement | null>
 }
 
 export default function ViewportVideoEnhancer({
+  playOnViewport,
   rootMargin,
   videoRef,
 }: ViewportVideoEnhancerProps): null {
   const isNearViewport = useOnScreen(videoRef, rootMargin)
   const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
-  const shouldPlay = isNearViewport && !prefersReducedMotion
+  const shouldLoad = isNearViewport
+  const shouldPlay = playOnViewport && isNearViewport && !prefersReducedMotion
 
   useEffect(() => {
     const video = videoRef.current
     if (!video) return
 
     video.autoplay = shouldPlay
-    video.preload = shouldPlay ? 'metadata' : 'none'
+    video.preload = shouldLoad ? 'metadata' : 'none'
 
     if (!shouldPlay) {
       video.pause?.()
@@ -32,7 +35,7 @@ export default function ViewportVideoEnhancer({
 
     const playPromise = video.play?.()
     playPromise?.catch(() => undefined)
-  }, [shouldPlay, videoRef])
+  }, [shouldLoad, shouldPlay, videoRef])
 
   return null
 }

--- a/packages/ui/src/components/custom/viewport-video/index.tsx
+++ b/packages/ui/src/components/custom/viewport-video/index.tsx
@@ -6,16 +6,26 @@ export type ViewportVideoProps = Omit<
   VideoHTMLAttributes<HTMLVideoElement>,
   'autoPlay' | 'preload'
 > & {
+  /** Automatically play while the video is near the viewport. */
+  playOnViewport?: boolean
   rootMargin?: string
   src: string
 }
 
 export const ViewportVideo = memo(function ViewportVideo({
+  playOnViewport = true,
   rootMargin = '0px',
   src,
   ...props
 }: ViewportVideoProps) {
-  return <ViewportVideoBoundary rootMargin={rootMargin} src={src} {...props} />
+  return (
+    <ViewportVideoBoundary
+      playOnViewport={playOnViewport}
+      rootMargin={rootMargin}
+      src={src}
+      {...props}
+    />
+  )
 })
 
 export default ViewportVideo

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -6,7 +6,6 @@ const state = {
   nearViewport: true,
   reducedMotion: false,
   observedRootMargin: undefined as string | undefined,
-  boundaryRootMargin: undefined as string | undefined,
 }
 
 mock.module('@nl/ui/hooks/useOnScreen', () => ({
@@ -18,13 +17,6 @@ mock.module('@nl/ui/hooks/useOnScreen', () => ({
 mock.module('@nl/ui/hooks/useMediaQuery', () => ({
   default: () => state.reducedMotion,
 }))
-mock.module('next/dynamic', () => ({
-  default: () => (props: { rootMargin?: string }) => {
-    state.boundaryRootMargin = props.rootMargin
-    return null
-  },
-}))
-
 describe('ViewportVideo', () => {
   let ViewportVideo: typeof import('./index').ViewportVideo
   let ViewportVideoEnhancer: typeof import('./ViewportVideoEnhancer').default
@@ -33,7 +25,6 @@ describe('ViewportVideo', () => {
     state.nearViewport = true
     state.reducedMotion = false
     state.observedRootMargin = undefined
-    state.boundaryRootMargin = undefined
   })
 
   beforeEach(async () => {
@@ -41,8 +32,8 @@ describe('ViewportVideo', () => {
     ViewportVideoEnhancer = (await import('./ViewportVideoEnhancer')).default
   })
 
-  it('keeps the video markup server-rendered before playback enhancement', () => {
-    const { container } = render(
+  it('keeps the video markup server-rendered before playback enhancement', async () => {
+    const { container, unmount } = render(
       <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
     )
     const video = container.querySelector('[data-testid="video"]') as HTMLVideoElement
@@ -50,16 +41,19 @@ describe('ViewportVideo', () => {
     expect(video.autoplay).toBe(false)
     expect(video.preload).toBe('none')
     expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
+
+    await waitFor(() => expect(state.observedRootMargin).toBe('0px'))
+    unmount()
   })
 
-  it('waits for the viewport by default while preserving explicit prefetch windows', () => {
+  it('waits for the viewport by default while preserving explicit prefetch windows', async () => {
     const { rerender } = render(<ViewportVideo data-testid="video" src="/video/example.mp4" />)
 
-    expect(state.boundaryRootMargin).toBe('0px')
+    await waitFor(() => expect(state.observedRootMargin).toBe('0px'))
 
     rerender(<ViewportVideo data-testid="video" rootMargin="300px" src="/video/example.mp4" />)
 
-    expect(state.boundaryRootMargin).toBe('300px')
+    await waitFor(() => expect(state.observedRootMargin).toBe('300px'))
   })
 
   it('only enables playback and metadata loading near the viewport', async () => {
@@ -69,7 +63,7 @@ describe('ViewportVideo', () => {
       return (
         <>
           <video data-testid="video" ref={videoRef} />
-          <ViewportVideoEnhancer rootMargin="300px" videoRef={videoRef} />
+          <ViewportVideoEnhancer playOnViewport rootMargin="300px" videoRef={videoRef} />
         </>
       )
     }
@@ -96,6 +90,27 @@ describe('ViewportVideo', () => {
     })
   })
 
+  it('keeps controls-only videos paused while still allowing explicit playback', async () => {
+    function PlaybackHarness() {
+      const videoRef = useRef<HTMLVideoElement>(null)
+
+      return (
+        <>
+          <video data-testid="video" ref={videoRef} />
+          <ViewportVideoEnhancer playOnViewport={false} rootMargin="300px" videoRef={videoRef} />
+        </>
+      )
+    }
+
+    const { container } = render(<PlaybackHarness />)
+    const video = container.querySelector('[data-testid="video"]') as HTMLVideoElement
+
+    await waitFor(() => {
+      expect(video.autoplay).toBe(false)
+      expect(video.preload).toBe('metadata')
+    })
+  })
+
   it('honors reduced-motion preferences even when visible', async () => {
     state.reducedMotion = true
     function PlaybackHarness() {
@@ -104,7 +119,7 @@ describe('ViewportVideo', () => {
       return (
         <>
           <video ref={videoRef} />
-          <ViewportVideoEnhancer rootMargin="300px" videoRef={videoRef} />
+          <ViewportVideoEnhancer playOnViewport rootMargin="300px" videoRef={videoRef} />
         </>
       )
     }
@@ -114,7 +129,7 @@ describe('ViewportVideo', () => {
 
     await waitFor(() => {
       expect(video.autoplay).toBe(false)
-      expect(video.preload).toBe('none')
+      expect(video.preload).toBe('metadata')
     })
   })
 })

--- a/test/contract/dependencies.test.ts
+++ b/test/contract/dependencies.test.ts
@@ -230,8 +230,8 @@ const ALLOWED_UNUSED: Record<string, Record<string, string>> = {
     '@docusaurus/theme-mermaid': 'docusaurus theme configured in docusaurus.config.ts',
     '@mdx-js/react': 'MDX provider used by docusaurus themes',
     algoliasearch: 'docusaurus Algolia DocSearch integration',
+    '@nl/ui': 'shared media primitives imported in docs/*.md and *.mdx markdown',
     'prism-react-renderer': 'docusaurus theme code highlighting',
-    'react-player': 'imported in docs/*.md markdown, not src/',
   },
   'packages/playfab': {
     url: 'node polyfill for next-auth/next runtime',

--- a/test/contract/docs-media-policy.test.ts
+++ b/test/contract/docs-media-policy.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 
+const docsMediaPages = [
+  'apps/docs/docs/overview/games/mini-games/arcade-tokens.md',
+  'apps/docs/docs/overview/games/mini-games/crypto-winter.md',
+  'apps/docs/docs/overview/games/mini-games/wen-game.md',
+  'apps/docs/docs/overview/games/niftyworld/niftyworld.mdx',
+  'apps/docs/docs/overview/games/overview.md',
+  'apps/docs/docs/overview/games/mobile-games/nifty-royale.md',
+  'apps/docs/docs/overview/games/mobile-games/nifty-smashers.md',
+  'apps/docs/docs/overview/nfts/nifty-marketplace/items.md',
+  'apps/docs/docs/overview/nfts/nifty-marketplace/comics.md',
+]
+
 const docsPage = 'apps/docs/docs/overview/nfts/degens/about.md'
 const legacyAsset = 'assets/img/games/nifty-royale/nifty-royale.gif'
 const mintGif = 'assets/img/mint-o-matic/degen-mint.gif'
 const mintWebp = 'assets/img/mint-o-matic/degen-mint.webp'
 
 describe('shared docs media policy', () => {
+  it('uses shared lazy media primitives instead of react-player', () => {
+    for (const page of docsMediaPages) {
+      const source = readFileSync(page, 'utf8')
+      expect(source).not.toContain('react-player')
+      expect(source).toMatch(/@nl\/ui\/custom\/(lazy-youtube-embed|viewport-video)/)
+    }
+  })
+
   it('pairs the Mint-O-Matic animation with a smaller WebP source and GIF fallback', () => {
     const source = readFileSync(docsPage, 'utf8')
 

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1990,12 +1990,14 @@ describe('public route dependency contract', () => {
     expect(shell).not.toContain("'use client'")
     expect(shell).toContain("from './ViewportVideoBoundary'")
     expect(shell).toContain("rootMargin = '0px'")
-    expect(boundary).toContain("dynamic(() => import('./ViewportVideoEnhancer')")
+    expect(boundary).toContain(
+      "const loadViewportVideoEnhancer = () => import('./ViewportVideoEnhancer')"
+    )
     expect(boundary).toContain("rootMargin = '0px'")
     expect(boundary).toContain('preload="none"')
     expect(enhancer).toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")
-    expect(enhancer).toContain("video.preload = shouldPlay ? 'metadata' : 'none'")
+    expect(enhancer).toContain("video.preload = shouldLoad ? 'metadata' : 'none'")
   })
 
   it('keeps marketing game video identifiers unique', () => {


### PR DESCRIPTION
## Summary

Promotes the validated `staging` tree to `main` after the cross-app regression audit.

This promotion contains the shared docs media optimization. The promotion branch is based on `origin/main`, cherry-picks the validated staging commit, and has an exact tree match with `origin/staging`.

## Validation

- Local focused viewport-video tests: 5 passed.
- Local route/dependency/docs media contracts: 330 passed.
- Local `@nl/ui` and docs type checks passed.
- Local Docusaurus production build passed.
- Local full monorepo build passed.
- Local forced fresh Next production builds passed for app, web, and Smashers.
- Browser-smoked all 9 changed docs routes with no browser warnings; screenshot checked the Nifty Smashers docs layout.
- Staging PR #797 required checks passed: Format, Lint, Type-Check, Build, Unit, and Gate.
