### PR TITLE
perf: defer below-fold media observers

### DIFF
--- a/apps/web/src/components/Carousel/index.tsx
+++ b/apps/web/src/components/Carousel/index.tsx
@@ -29,7 +29,7 @@ const NiftyCarousel = ({
   ariaLabel = 'Featured content',
 }: NiftyCarouselProps): React.ReactNode => {
   const containerRef = useRef<HTMLDivElement>(null)
-  const isNearViewport = useOnScreen(containerRef, '300px 0px')
+  const isNearViewport = useOnScreen(containerRef, '300px 0px', { once: true })
   const { Component: InteractiveCarousel } = useDeferredComponent<NiftyCarouselProps>(
     loadInteractiveCarousel,
     isNearViewport

--- a/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
+++ b/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
-mock.module('@nl/ui/hooks/useOnScreen', () => ({
-  useOnScreen: () => false,
-}))
+const useOnScreen = mock(() => false)
+mock.module('@nl/ui/hooks/useOnScreen', () => ({ useOnScreen }))
 
 describe('DeferredSection', () => {
   let DeferredSection: typeof import('./index').DeferredSection
@@ -20,5 +19,6 @@ describe('DeferredSection', () => {
     expect(screen.getByRole('status', { name: 'Loading Game details' })).toBeTruthy()
     expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
     expect(screen.getAllByRole('status').length).toBe(1)
+    expect(useOnScreen).toHaveBeenCalledWith(expect.anything(), '320px', { once: true })
   })
 })

--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -44,7 +44,7 @@ export function DeferredSection({
   rootMargin = '320px',
 }: DeferredSectionProps): React.ReactNode {
   const sectionRef = useRef<HTMLDivElement>(null)
-  const isNearViewport = useOnScreen(sectionRef, rootMargin)
+  const isNearViewport = useOnScreen(sectionRef, rootMargin, { once: true })
   const {
     Component: LoadedSection,
     hasError: loadError,

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState, type ComponentType } from 'react'
 
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 import type { ViewportVideoProps } from './index'
+import type { ViewportVideoEnhancerProps } from './ViewportVideoEnhancer'
 
-type ViewportVideoEnhancerComponent = typeof import('./ViewportVideoEnhancer').default
-
-const loadViewportVideoEnhancer = () => import('./ViewportVideoEnhancer')
+const ViewportVideoEnhancer = lazy<ComponentType<ViewportVideoEnhancerProps>>(
+  () => import('./ViewportVideoEnhancer')
+)
 
 export default function ViewportVideoBoundary({
   playOnViewport = true,
@@ -15,34 +17,26 @@ export default function ViewportVideoBoundary({
   ...props
 }: ViewportVideoProps): React.ReactNode {
   const videoRef = useRef<HTMLVideoElement>(null)
-  const [ViewportVideoEnhancer, setViewportVideoEnhancer] =
-    useState<ViewportVideoEnhancerComponent | null>(null)
+  const [hasEnteredViewport, setHasEnteredViewport] = useState(false)
+  const isNearViewport = useOnScreen(videoRef, rootMargin)
 
   useEffect(() => {
-    let active = true
-
-    void loadViewportVideoEnhancer()
-      .then(({ default: Enhancer }) => {
-        if (active) setViewportVideoEnhancer(() => Enhancer)
-      })
-      .catch(() => undefined)
-
-    return () => {
-      active = false
-    }
-  }, [])
+    if (isNearViewport) setHasEnteredViewport(true)
+  }, [isNearViewport])
 
   return (
     <>
-      <video {...props} ref={videoRef} preload="none">
+      <video {...props} ref={videoRef} preload={isNearViewport ? 'metadata' : 'none'}>
         <source src={src} type="video/mp4" />
       </video>
-      {ViewportVideoEnhancer ? (
-        <ViewportVideoEnhancer
-          playOnViewport={playOnViewport}
-          rootMargin={rootMargin}
-          videoRef={videoRef}
-        />
+      {hasEnteredViewport || isNearViewport ? (
+        <Suspense fallback={null}>
+          <ViewportVideoEnhancer
+            isNearViewport={isNearViewport}
+            playOnViewport={playOnViewport}
+            videoRef={videoRef}
+          />
+        </Suspense>
       ) : null}
     </>
   )

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoEnhancer.tsx
@@ -3,20 +3,18 @@
 import { useEffect, type RefObject } from 'react'
 
 import useMediaQuery from '@nl/ui/hooks/useMediaQuery'
-import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
 
-interface ViewportVideoEnhancerProps {
+export interface ViewportVideoEnhancerProps {
+  isNearViewport: boolean
   playOnViewport: boolean
-  rootMargin: string
   videoRef: RefObject<HTMLVideoElement | null>
 }
 
 export default function ViewportVideoEnhancer({
+  isNearViewport,
   playOnViewport,
-  rootMargin,
   videoRef,
 }: ViewportVideoEnhancerProps): null {
-  const isNearViewport = useOnScreen(videoRef, rootMargin)
   const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
   const shouldLoad = isNearViewport
   const shouldPlay = playOnViewport && isNearViewport && !prefersReducedMotion

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -33,6 +33,7 @@ describe('ViewportVideo', () => {
   })
 
   it('keeps the video markup server-rendered before playback enhancement', async () => {
+    state.nearViewport = false
     const { container, unmount } = render(
       <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
     )
@@ -63,7 +64,11 @@ describe('ViewportVideo', () => {
       return (
         <>
           <video data-testid="video" ref={videoRef} />
-          <ViewportVideoEnhancer playOnViewport rootMargin="300px" videoRef={videoRef} />
+          <ViewportVideoEnhancer
+            isNearViewport={state.nearViewport}
+            playOnViewport
+            videoRef={videoRef}
+          />
         </>
       )
     }
@@ -74,7 +79,6 @@ describe('ViewportVideo', () => {
     await waitFor(() => {
       expect(video.autoplay).toBe(true)
       expect(video.preload).toBe('metadata')
-      expect(state.observedRootMargin).toBe('300px')
     })
 
     state.nearViewport = false
@@ -97,7 +101,11 @@ describe('ViewportVideo', () => {
       return (
         <>
           <video data-testid="video" ref={videoRef} />
-          <ViewportVideoEnhancer playOnViewport={false} rootMargin="300px" videoRef={videoRef} />
+          <ViewportVideoEnhancer
+            isNearViewport={state.nearViewport}
+            playOnViewport={false}
+            videoRef={videoRef}
+          />
         </>
       )
     }
@@ -119,7 +127,11 @@ describe('ViewportVideo', () => {
       return (
         <>
           <video ref={videoRef} />
-          <ViewportVideoEnhancer playOnViewport rootMargin="300px" videoRef={videoRef} />
+          <ViewportVideoEnhancer
+            isNearViewport={state.nearViewport}
+            playOnViewport
+            videoRef={videoRef}
+          />
         </>
       )
     }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1990,12 +1990,12 @@ describe('public route dependency contract', () => {
     expect(shell).not.toContain("'use client'")
     expect(shell).toContain("from './ViewportVideoBoundary'")
     expect(shell).toContain("rootMargin = '0px'")
-    expect(boundary).toContain(
-      "const loadViewportVideoEnhancer = () => import('./ViewportVideoEnhancer')"
-    )
+    expect(boundary).toContain('lazy<ComponentType<ViewportVideoEnhancerProps>>(')
     expect(boundary).toContain("rootMargin = '0px'")
-    expect(boundary).toContain('preload="none"')
-    expect(enhancer).toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(boundary).toContain("preload={isNearViewport ? 'metadata' : 'none'}")
+    expect(boundary).toContain('hasEnteredViewport || isNearViewport')
+    expect(enhancer).not.toContain("from '@nl/ui/hooks/useOnScreen'")
+    expect(enhancer).toContain('isNearViewport: boolean')
     expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")
     expect(enhancer).toContain("video.preload = shouldLoad ? 'metadata' : 'none'")
   })


### PR DESCRIPTION
## Summary
- defer the viewport-video enhancer until a video first approaches the viewport
- preserve playback pause/resume behavior after the enhancer is loaded
- stop deferred-section and marketing carousel observers after their first intersection
- update regression contracts and component tests for the shared behavior

## Validation
- all app/workspace production builds pass: api, app, docs, smashers, web
- full workspace lint and type-check pass
- full contract suite: 436 passed, 0 failed
- UI, web, app, and Smashers unit suites pass
- browser network smoke confirms the media enhancer chunk is absent before scroll and loads after the section enters view
