### PR TITLE
Promote staging to main

### DIFF
--- a/apps/web/src/app/(main)/overview/page.tsx
+++ b/apps/web/src/app/(main)/overview/page.tsx
@@ -1,5 +1,5 @@
 import type { NextPage } from 'next'
-import Image, { getImageProps } from 'next/image'
+import { getImageProps } from 'next/image'
 
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
 import { DeferredOverviewFAQ } from '@/components/DeferredOverviewSections'

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1769,7 +1769,7 @@ describe('web marketing image sizing contract', () => {
     )
 
     expect(overviewSource).not.toContain('priority')
-    expect(overviewSource).toContain("import Image, { getImageProps } from 'next/image'")
+    expect(overviewSource).toContain("import { getImageProps } from 'next/image'")
     expect(overviewSource).toContain('<picture>')
     expect(overviewSource).toContain('media="(max-width: 767px)"')
     expect(roadmapSource).toContain('src="/img/space/satoshi_move.gif"')


### PR DESCRIPTION
## Summary

Promote the validated `staging` tree to `main`.

This is an exact-tree release promotion. The source and target tree comparison contains only the Overview stale-import cleanup and its contract assertion from PR #808.

## Validation

- PR #808 squash-merged to `staging` after required CI passed
- local production builds passed for API, app, docs, Smashers, and web
- desktop and mobile route smoke audits passed across all three Next apps
- GLTF 2D/3D/Sprite interaction audit passed
