### PR TITLE
perf(ui): eagerly load shared navbar logo

### DIFF
--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -164,7 +164,7 @@ describe('Navbar', () => {
       />
     )
 
-    expect(screen.getByRole('img', { name: 'Home' })).not.toBeNull()
+    expect(screen.getByRole('img', { name: 'Home' }).getAttribute('loading')).toBe('eager')
     expect(screen.getAllByRole('link', { name: /About/ })[0]?.getAttribute('href')).toBe('/about')
     fireEvent.click(screen.getByText('Products', { selector: 'summary' }))
     expect(screen.getAllByRole('link', { name: /Docs/ })[0]?.getAttribute('target')).toBe('_blank')

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -149,7 +149,7 @@ export function Navbar({ actionButton, navItems, className }: NavbarProps) {
             width={52}
             alt="Home"
             className="h-12 w-auto transition-transform hover:scale-105"
-            loading="lazy"
+            loading="eager"
           />
         </Link>
 


### PR DESCRIPTION
## Summary
- load the shared above-the-fold navbar logo eagerly on marketing/game pages
- add a regression assertion so it does not regress to lazy loading

## Validation
- bunx turbo run web#build app#build --force --output-logs=full
- bun run format:check
- bun run lint
- bun run type-check
- focused UI, homepage, route-surface, and app-performance tests

This PR is ready for hosted validation after local checks pass.