### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -14,7 +14,10 @@ describe('home page', () => {
     mock.module('@/components/BouncingNFTL', () => ({ default: () => null }))
     mock.module('@/components/MintOMatic', () => ({ default: () => null }))
     mock.module('@/components/Sponsors', () => ({ default: () => null }))
-    mock.module('@nl/ui/custom/theme-button-group', () => ({ default: () => null }))
+    mock.module('@nl/ui/custom/theme-button-group', () => ({
+      default: () => null,
+      ThemeButtonGroup: () => null,
+    }))
     mock.module('@nl/ui/custom/deferred-console-game', () => ({ DeferredConsoleGame: () => null }))
     mock.module('next/link', () => ({
       default: ({ children, href, ...props }: PropsWithChildren<{ href: string }>) => (

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -10,7 +10,7 @@ import {
   DeferredSponsors,
 } from '@/components/DeferredHomeSections'
 import MainLayout from '@/components/MainLayout'
-import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
+import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 import { DEGEN_COLLECTION_URL } from '@/constants/degen-assets'
 
 import '@/styles/home.css'
@@ -202,7 +202,7 @@ const MobileIntro = () => {
         <h1 className="mt-0 sm:mt-4 md:mt-5">Nifty League</h1>
         <h5 className="mt-2 [word-spacing:-10px]">By Gamers. For Gamers.</h5>
         <p className="my-4 text-center whitespace-nowrap">Community-Governed Game Studio</p>
-        <ThemeBtnGroup
+        <ThemeButtonGroup
           className="mt-2 xl:mt-2 mb-2"
           primary={{ href: 'https://app.niftyleague.com', title: 'PLAY NOW', external: true }}
         />
@@ -252,7 +252,7 @@ const Home = () => {
 
         <DeferredConsoleGame src="/video/smashers.mp4" />
 
-        <ThemeBtnGroup
+        <ThemeButtonGroup
           className="absolute bottom-0 sm:bottom-4"
           primary={{ href: 'https://niftysmashers.com', title: 'SMASHERS', external: true }}
           secondary={{ href: '/games', title: 'MORE GAMES' }}
@@ -310,7 +310,7 @@ const Home = () => {
             <p className="my-0 py-1 md:py-3 section-description transition-vertical-fade">
               4 - 16 PLAYERS COMPETE IN A CUT-THROAT BATTLE FOR THE SURVIVAL OF THE FITTEST!
             </p>
-            <ThemeBtnGroup
+            <ThemeButtonGroup
               className="md:justify-start"
               primary={{
                 href: 'https://niftysmashers.com',
@@ -376,7 +376,7 @@ const Home = () => {
             <p className="my-0 py-1 lg:py-3 section-description transition-vertical-fade">
               A VIRTUAL SOCIAL HUB LIKE NONE OTHER FOR GAMERS.
             </p>
-            <ThemeBtnGroup
+            <ThemeButtonGroup
               className="md:justify-start"
               primary={{ title: 'COMING SOON', disabled: true }}
               secondary={{ href: '/niftyworld', title: 'LEARN MORE' }}
@@ -405,7 +405,7 @@ const Home = () => {
             ACCESS WEB3-ENABLED PLAYER DASHBOARDS TO SEE YOUR GAME STATS, WINNINGS, AND NIFTY LEAGUE
             ASSETS.
           </p>
-          <ThemeBtnGroup
+          <ThemeButtonGroup
             className="md:justify-start"
             primary={{ href: 'https://app.niftyleague.com', title: 'WEB3 APP', external: true }}
             secondary={{ href: DEGEN_COLLECTION_URL, title: 'BUY A DEGEN', external: true }}
@@ -426,7 +426,7 @@ const Home = () => {
             NFTL IS OUR GOVERNANCE &amp; UTILITY TOKEN. GOVERN THE FUTURE OF NIFTY LEAGUE &amp;
             ACCESS EXCLUSIVE GAME ASSETS.
           </p>
-          <ThemeBtnGroup
+          <ThemeButtonGroup
             className="md:justify-start"
             primary={{
               href: 'https://quickswap.exchange/#/analytics/v3/token/0xb0d7e9ff5fb8e739c4990f7920d8047acfae4884',
@@ -485,7 +485,7 @@ const Home = () => {
               WE HATE TO BRAG, BUT OUR COMMUNITY IS TRULY TOP-NOTCH! JOIN OUR DISCORD TO CONNECT
               WITH OTHERS DEGENS &amp; HELP SHAPE NIFTY LEAGUE&apos;S FUTURE.
             </p>
-            <ThemeBtnGroup
+            <ThemeButtonGroup
               className="md:justify-start"
               primary={{
                 href: 'https://discord.gg/niftyleague',
@@ -503,7 +503,7 @@ const Home = () => {
       <section className="section w-screen relative text-center">
         <h2 className="my-3 lg:my-5 section-heading transition-vertical-fade">PROUDLY BACKED BY</h2>
         <DeferredSponsors />
-        <ThemeBtnGroup
+        <ThemeButtonGroup
           primary={{ href: '/careers', title: 'JOIN THE TEAM' }}
           secondary={{
             href: '/blog',

--- a/apps/web/src/components/Invite/InviteRedirect.tsx
+++ b/apps/web/src/components/Invite/InviteRedirect.tsx
@@ -57,20 +57,20 @@ const InviteRedirect = () => {
           : 'Web Store',
       referrer_id: refcode,
     })
-  }, [game, partyID, refcode, userAgent])
 
-  switch (game) {
-    case 'smashers':
-      if (refcode.length > 7 && (isAndroid(userAgent) || isIOS(userAgent))) {
-        redirectToNativeApp(userAgent, refcode, partyID)
-      } else {
-        redirectToAppStore(userAgent, refcode)
-      }
-      break
-    case 'royale':
-    default:
-      router.push('/')
-  }
+    switch (game) {
+      case 'smashers':
+        if (refcode.length > 7 && (isAndroid(userAgent) || isIOS(userAgent))) {
+          redirectToNativeApp(userAgent, refcode, partyID)
+        } else {
+          redirectToAppStore(userAgent, refcode)
+        }
+        break
+      case 'royale':
+      default:
+        router.push('/')
+    }
+  }, [game, partyID, refcode, router, userAgent])
 
   return <Loading />
 }

--- a/packages/sentry-client/src/client.ts
+++ b/packages/sentry-client/src/client.ts
@@ -1,13 +1,14 @@
 type SentryModule = typeof import('@sentry/nextjs')
+type DeferredSentryModule = typeof import('./nextjs-client')
 export type SentryInitOptions = Parameters<SentryModule['init']>[0]
 type RouterTransitionArgs = Parameters<SentryModule['captureRouterTransitionStart']>
 
-let sentryModulePromise: Promise<SentryModule> | undefined
-let sentryInitPromise: Promise<SentryModule> | undefined
+let sentryModulePromise: Promise<DeferredSentryModule> | undefined
+let sentryInitPromise: Promise<DeferredSentryModule> | undefined
 let sentryInitOptions: SentryInitOptions | undefined
 
-export function loadSentry(): Promise<SentryModule> {
-  sentryModulePromise ??= import('@sentry/nextjs')
+export function loadSentry(): Promise<DeferredSentryModule> {
+  sentryModulePromise ??= import('./nextjs-client')
   return sentryModulePromise
 }
 
@@ -15,7 +16,7 @@ const reportSentryLoadError = (error: unknown): void => {
   console.error('Failed to load Sentry client SDK', error)
 }
 
-export function initializeSentry(options: SentryInitOptions): Promise<SentryModule> {
+export function initializeSentry(options: SentryInitOptions): Promise<DeferredSentryModule> {
   const initOptions = (sentryInitOptions ??= options)
   sentryInitPromise ??= loadSentry().then((sentry) => {
     sentry.init(initOptions)
@@ -24,7 +25,7 @@ export function initializeSentry(options: SentryInitOptions): Promise<SentryModu
   return sentryInitPromise
 }
 
-function getSentryForCapture(): Promise<SentryModule> {
+function getSentryForCapture(): Promise<DeferredSentryModule> {
   return sentryInitOptions ? initializeSentry(sentryInitOptions) : loadSentry()
 }
 

--- a/packages/sentry-client/src/nextjs-client.ts
+++ b/packages/sentry-client/src/nextjs-client.ts
@@ -1,0 +1,3 @@
+import { captureException, captureRouterTransitionStart, init } from '@sentry/nextjs'
+
+export { captureException, captureRouterTransitionStart, init }

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -10,6 +10,8 @@ const appNextConfig = 'apps/app/next.config.ts'
 const smashersNextConfig = 'apps/smashers/next.config.ts'
 const webManifest = 'apps/web/package.json'
 const webNextConfig = 'apps/web/next.config.ts'
+const deferredSentryClient = 'packages/sentry-client/src/client.ts'
+const deferredSentryModule = 'packages/sentry-client/src/nextjs-client.ts'
 const appRootLayout = 'apps/app/src/app/layout.tsx'
 const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
@@ -169,6 +171,18 @@ describe('app performance contracts', () => {
 
     expect(source).toContain('id="device-stats"')
     expect(source).toContain('strategy="lazyOnload"')
+  })
+
+  it('keeps deferred Sentry on a named async module graph', () => {
+    const clientSource = readFileSync(deferredSentryClient, 'utf8')
+    const moduleSource = readFileSync(deferredSentryModule, 'utf8')
+
+    expect(clientSource).toContain("import('./nextjs-client')")
+    expect(clientSource).not.toContain("sentryModulePromise ??= import('@sentry/nextjs')")
+    expect(moduleSource).toContain("from '@sentry/nextjs'")
+    expect(moduleSource).toContain('captureException')
+    expect(moduleSource).toContain('captureRouterTransitionStart')
+    expect(moduleSource).toContain('init')
   })
 
   it('uses Turbopack for local app development', () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -253,6 +253,7 @@ const sharedWebNavbarScrollState = 'packages/ui/src/components/custom/navbar/Nav
 const sharedWebMobileNavbar = 'packages/ui/src/components/custom/navbar/MobileNavMenu.tsx'
 const sharedWebNavLinkContent = 'packages/ui/src/components/custom/navbar/NavLinkContent.tsx'
 const sharedWebMobileTrigger = 'packages/ui/src/components/custom/navbar/MobileNavTrigger.tsx'
+const webInviteRedirect = 'apps/web/src/components/Invite/InviteRedirect.tsx'
 const sharedConsoleGame = 'packages/ui/src/components/custom/console-game/index.tsx'
 const sharedDeferredConsoleGame =
   'packages/ui/src/components/custom/deferred-console-game/index.tsx'
@@ -343,6 +344,17 @@ describe('external route surface contract', () => {
       }
     })
   }
+})
+
+describe('web invite redirect contract', () => {
+  it('keeps navigation and deep-link side effects out of render', () => {
+    const source = readFileSync(join(process.cwd(), webInviteRedirect), 'utf8')
+
+    expect(source).toMatch(
+      /useEffect\(\(\) => \{[\s\S]*switch \(game\)[\s\S]*router\.push\('\/'\)[\s\S]*\}, \[game, partyID, refcode, router, userAgent\]\)/
+    )
+    expect(source).not.toMatch(/\n\s*switch \(game\) \{[\s\S]*\n\s*\}\n\n\s*return <Loading \/>/)
+  })
 })
 
 describe('public leaderboard loading contract', () => {


### PR DESCRIPTION
## Summary

Promote the validated staging tree to main after the staged visual regression audit and shared Sentry performance fix.

This is an exact-tree promotion: the resulting main tree will match staging byte-for-byte.

## Validation

- staging PR #814 passed the required Validation / Gate
- local route/import/behavior/performance contracts: 250 passed
- local web, app, Smashers, and docs builds passed
- browser route, responsive, visual, GLTF, sidebar, navbar-scroll, and auth smoke audits passed
- promotion commit tree matches `origin/staging` exactly