### PR TITLE
Release: staging → main (2026-08-15)

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -9,6 +9,7 @@ const ENV = (process.env.VERCEL_ENV as 'production' | 'preview' | undefined) ?? 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/contracts', '@nl/imx-passport', '@nl/ui'],
   experimental: {
+    optimizePackageImports: ['lucide-react'],
     useTypeScriptCli: true,
   },
   turbopack: {},

--- a/apps/smashers/next.config.ts
+++ b/apps/smashers/next.config.ts
@@ -47,6 +47,7 @@ const generateAppleCountryRedirects = (countryCode: string) => [
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/playfab', '@nl/ui'],
   experimental: {
+    optimizePackageImports: ['lucide-react'],
     useTypeScriptCli: true,
   },
   turbopack: {},

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/ui'],
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
 }
 
 export default nextConfig

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,6 +9,7 @@ const ENV = (process.env.VERCEL_ENV as 'production' | 'preview' | undefined) ?? 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/ui'],
   experimental: {
+    optimizePackageImports: ['lucide-react'],
     useTypeScriptCli: true,
   },
   turbopack: {},

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -8,6 +8,7 @@ const retiredAxiosUtility = 'apps/app/src/utils/axios.ts'
 const appGraphQLUtility = 'apps/app/src/utils/graphql.ts'
 const appNextConfig = 'apps/app/next.config.ts'
 const smashersNextConfig = 'apps/smashers/next.config.ts'
+const templateNextConfig = 'apps/template/next.config.ts'
 const webManifest = 'apps/web/package.json'
 const webNextConfig = 'apps/web/next.config.ts'
 const deferredSentryClient = 'packages/sentry-client/src/client.ts'
@@ -195,6 +196,12 @@ describe('app performance contracts', () => {
   it('uses the project TypeScript CLI for Next app builds', () => {
     for (const file of [appNextConfig, smashersNextConfig]) {
       expect(readFileSync(file, 'utf8')).toContain('useTypeScriptCli: true')
+    }
+  })
+
+  it('modularizes shared Lucide imports before the app graph is bundled', () => {
+    for (const file of [appNextConfig, smashersNextConfig, webNextConfig, templateNextConfig]) {
+      expect(readFileSync(file, 'utf8')).toContain("optimizePackageImports: ['lucide-react']")
     }
   })
 


### PR DESCRIPTION
## Promotion

Promote the validated staging tree to `main` through a clean exact-tree promotion commit. This avoids the history-only conflict on the existing staging → main PR while preserving the protected branch workflow.

## Included milestone

- `perf(next): modularize shared Lucide imports`
- staging tree: `7c114fc1`
- promotion tree matches `origin/staging` exactly

## Validation

- Staging PR #820: local 251 route/performance contracts, builds, lint, format, and type-check passed
- Staging PR #820 hosted Validation / Gate passed
- Staging Vercel deployments for API, app, docs, Smashers, and web completed successfully
- Promotion commit has `origin/main` as its parent and an exact `origin/staging` tree

This PR is the canonical rebase promotion into `main`.