### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/gltf.module.css
@@ -31,6 +31,12 @@
   composes: pixelated;
 }
 
+.sprite__wrapper {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+}
+
 .image {
   position: absolute;
   width: 112%;

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
@@ -29,13 +29,23 @@ export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
         />
       }
       spriteImage={
-        <Image alt="Degen Sprite" className={styles.sprite} fill unoptimized src={spriteSrc} />
+        <div className={styles.sprite__wrapper}>
+          <Image
+            alt="Degen Sprite"
+            className={styles.sprite}
+            fill
+            sizes="100vw"
+            unoptimized
+            src={spriteSrc}
+          />
+        </div>
       }
       logo={
         <Image
           alt="Nifty League Logo"
           width={200}
           height={70}
+          priority
           style={{ maxWidth: '24vw', height: 'auto' }}
           src="/img/logos/NL/wordmark.webp"
         />

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -466,7 +466,11 @@ describe('GLTF viewer loading contract', () => {
     const source = readFileSync(join(process.cwd(), gltfPage), 'utf8')
 
     expect(source).toContain('priority\n          src={imageSrc}')
-    expect(source).not.toContain('className={styles.sprite}\n          fill\n          priority')
+    expect(source).toContain('className={styles.sprite__wrapper}')
+    expect(source).toContain(
+      'className={styles.sprite}\n            fill\n            sizes="100vw"'
+    )
+    expect(source).toContain("priority\n          style={{ maxWidth: '24vw', height: 'auto' }}")
     expect(source).not.toContain('quality={100}')
   })
 


### PR DESCRIPTION
## Summary

Promote the fully validated staging tree to `main`.

This promotion includes:

- GLTF Sprite layout correction and mode-logo loading fix from PR #834.
- Existing validated staging changes already promoted through the normal release path.

## Promotion evidence

- `origin/staging` tree: `aca4f3c4e38a113c0a57904fba6435ad465955d3`
- Promotion branch tree matches `origin/staging` exactly.
- The feature PR #834 passed all applicable hosted checks before squash merge.
- Repository-wide local build passed for API, app, docs, Smashers, and web.

Use the repository-required rebase merge strategy for this promotion.
