### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,7 +5,7 @@ import DeferredSentry from '@nl/sentry-client/react'
 import { defaultFont } from '@nl/ui/fonts/default'
 import { headerFont } from '@nl/ui/fonts/header'
 import { specialFont } from '@nl/ui/fonts/special'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
@@ -65,7 +65,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn(defaultFont.variable, headerFont.variable, specialFont.variable, 'dark')}
+      className={cx(defaultFont.variable, headerFont.variable, specialFont.variable, 'dark')}
     >
       <DeferredSentry enabled={process.env.VERCEL_ENV === 'production'} options={sentryOptions} />
       <body suppressHydrationWarning>{children}</body>

--- a/apps/web/src/components/Footer/index.tsx
+++ b/apps/web/src/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { UrlObject } from 'url'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { SocialsFooter, animateClass, linkClass } from '@nl/ui/custom/socials-footer'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 
@@ -14,7 +14,7 @@ interface FooterLinkProps {
 const FooterLink = ({ href, name, external = false, first = false }: FooterLinkProps) => (
   <Link
     href={href}
-    className={cn(
+    className={cx(
       'inline-flex items-center justify-center sm:justify-start',
       linkClass,
       animateClass,

--- a/packages/ui/src/components/custom/console-game/index.tsx
+++ b/packages/ui/src/components/custom/console-game/index.tsx
@@ -3,8 +3,8 @@
 import Image from 'next/image'
 import { memo, useRef, useState, useCallback, useEffect } from 'react'
 import { Button } from '@nl/ui/base/button'
+import { cx } from '@nl/ui/class-names'
 import { ParallaxWrapper } from '@nl/ui/custom/parallax-wrapper'
-import { cn } from '@nl/ui/utils'
 
 import styles from './index.module.css'
 
@@ -85,7 +85,7 @@ export const ConsoleGame = memo(function ConsoleGame({
           variant="ghost"
           size="icon"
           aria-label={isPlaying ? 'Pause video' : 'Play video'}
-          className={cn(styles.bonk_note, 'h-auto w-auto rounded-none p-0 hover:bg-transparent')}
+          className={cx(styles.bonk_note, 'h-auto w-auto rounded-none p-0 hover:bg-transparent')}
         >
           <Image
             alt="Bonk Sticker"

--- a/packages/ui/src/components/custom/deferred-console-game/index.tsx
+++ b/packages/ui/src/components/custom/deferred-console-game/index.tsx
@@ -16,7 +16,9 @@ const loadConsoleGame = () =>
 
 const DeferredConsoleGame = ({ src }: DeferredConsoleGameProps) => {
   const rootRef = useRef<HTMLDivElement>(null)
-  const isNearViewport = useOnScreen(rootRef, '200px')
+  // Keep the interactive video chunk out of the initial page load until the
+  // preview actually intersects the viewport.
+  const isNearViewport = useOnScreen(rootRef, '0px')
   const { Component: ConsoleGame } = useDeferredComponent<ConsoleGameProps>(
     loadConsoleGame,
     isNearViewport

--- a/packages/ui/src/components/custom/external-icon/index.tsx
+++ b/packages/ui/src/components/custom/external-icon/index.tsx
@@ -1,11 +1,11 @@
 import type { ComponentProps } from 'react'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 export function ExternalIcon({ className = '', ...props }: ComponentProps<'span'>) {
   return (
     <span
-      className={cn('ml-1 mb-1.5 inline-block size-3 flex-shrink-0 cursor-pointer', className)}
+      className={cx('ml-1 mb-1.5 inline-block size-3 flex-shrink-0 cursor-pointer', className)}
       aria-hidden="true"
       {...props}
     >

--- a/packages/ui/src/components/custom/mobile-navigation/index.tsx
+++ b/packages/ui/src/components/custom/mobile-navigation/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 interface MobileNavigationDisclosureProps {
   children: ReactNode
@@ -20,12 +20,12 @@ export function MobileNavigationDisclosure({
   summaryClassName,
 }: MobileNavigationDisclosureProps) {
   return (
-    <details className={cn('group relative', className)}>
+    <details className={cx('group relative', className)}>
       <summary
         role="button"
         aria-controls={id}
         aria-label={label}
-        className={cn(
+        className={cx(
           'flex size-10 cursor-pointer list-none items-center justify-center rounded-md text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden',
           summaryClassName
         )}
@@ -37,7 +37,7 @@ export function MobileNavigationDisclosure({
         </span>
         <span className="sr-only">{label}</span>
       </summary>
-      <div id={id} className={cn(panelClassName)}>
+      <div id={id} className={cx(panelClassName)}>
         {children}
       </div>
     </details>

--- a/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
+++ b/packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import NavbarScrollState from './NavbarScrollState'
 
@@ -15,7 +15,7 @@ export function NavbarScrollFrame({ children, className }: NavbarScrollFrameProp
   return (
     <header
       id={NAVBAR_SCROLL_FRAME_ID}
-      className={cn(
+      className={cx(
         'navbar-scroll-frame fixed inset-x-0 top-0 z-50 h-20 bg-transparent data-[scrolled=true]:backdrop-blur-xs',
         className
       )}

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Fragment } from 'react'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import MobileNavMenu from './MobileNavMenu'
 import NavbarScrollFrame from './NavbarScrollFrame'
@@ -49,7 +49,7 @@ function DesktopNavLink({
       href={href}
       target={external ? '_blank' : undefined}
       rel={external ? 'noreferrer' : undefined}
-      className={cn(NAV_LINK_CONTENT_CLASS, className)}
+      className={cx(NAV_LINK_CONTENT_CLASS, className)}
     >
       <NavLinkContent description={description} external={external} title={title} />
     </Link>
@@ -75,7 +75,7 @@ function DropdownMenuItem({ group, pages }: GroupedMenuItemData) {
     <li>
       <details className="group relative">
         <summary
-          className={cn(
+          className={cx(
             DESKTOP_LINK_CLASS,
             'cursor-pointer list-none [&::-webkit-details-marker]:hidden'
           )}

--- a/packages/ui/src/components/custom/socials-footer/index.tsx
+++ b/packages/ui/src/components/custom/socials-footer/index.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { SOCIAL_LINKS } from './constants'
 
 export const linkClass = 'font-medium text-foreground'
@@ -13,12 +13,12 @@ interface SocialsFooterProps extends React.ComponentProps<'footer'> {
 
 export function SocialsFooter({ children, classes }: SocialsFooterProps) {
   return (
-    <footer className={cn('my-10 px-5', classes?.footer)}>
+    <footer className={cx('my-10 px-5', classes?.footer)}>
       {children}
       <div className="flex flex-col space-y-6">
         <div className="flex justify-center items-center space-x-6">
           <a
-            className={cn(linkClass, animateClass)}
+            className={cx(linkClass, animateClass)}
             href="https://niftyleague.com/terms-of-service"
             target="_blank"
             rel="noreferrer"
@@ -26,7 +26,7 @@ export function SocialsFooter({ children, classes }: SocialsFooterProps) {
             Terms
           </a>
           <a
-            className={cn(linkClass, animateClass)}
+            className={cx(linkClass, animateClass)}
             href="https://niftyleague.com/disclaimer"
             target="_blank"
             rel="noreferrer"
@@ -34,7 +34,7 @@ export function SocialsFooter({ children, classes }: SocialsFooterProps) {
             Disclaimer
           </a>
           <a
-            className={cn(linkClass, animateClass)}
+            className={cx(linkClass, animateClass)}
             href="https://niftyleague.com/privacy-policy"
             target="_blank"
             rel="noreferrer"

--- a/packages/ui/src/components/custom/theme-button-group/index.tsx
+++ b/packages/ui/src/components/custom/theme-button-group/index.tsx
@@ -3,7 +3,7 @@ import type { UrlObject } from 'url'
 
 import { buttonVariants } from '@nl/ui/base/button-variants'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 export interface ThemeButtonProps {
   href?: string | UrlObject
@@ -23,7 +23,7 @@ export function ThemeButton({
   external = false,
   isPrimary = false,
 }: ThemeButtonProps & { isPrimary?: boolean }) {
-  const buttonClassName = cn(isPrimary ? 'theme-btn-primary' : 'theme-btn-transparent', className)
+  const buttonClassName = cx(isPrimary ? 'theme-btn-primary' : 'theme-btn-transparent', className)
   const content = responsiveTitle ? (
     <>
       <span className="responsive-label-mobile">{responsiveTitle.mobile}</span>
@@ -38,7 +38,7 @@ export function ThemeButton({
       <button
         type="button"
         disabled
-        className={buttonVariants({ className: cn(buttonClassName, 'disabled') })}
+        className={buttonVariants({ className: cx(buttonClassName, 'disabled') })}
       >
         {content}
         {external && <ExternalIcon />}
@@ -70,7 +70,7 @@ interface ThemeButtonGroupProps {
 export function ThemeButtonGroup({ className, primary, secondary }: ThemeButtonGroupProps) {
   return (
     <div
-      className={cn(
+      className={cx(
         'w-full flex flex-row flex-wrap justify-center items-center z-10',
         'gap-2 md:gap-3 xl:gap-4',
         'mt-4 xl:mt-6 -mx-2 sm:mx-0',

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -18,6 +18,17 @@ const appShell = 'apps/app/src/app/_layout/AppShell.tsx'
 const sharedAppBar = 'packages/ui/src/components/custom/app-bar/index.tsx'
 const sharedAppBarStyles = 'packages/ui/src/components/custom/app-bar/app-bar.module.css'
 const lightweightClassNames = 'packages/ui/src/lib/class-names.ts'
+const deferredConsoleGame = 'packages/ui/src/components/custom/deferred-console-game/index.tsx'
+const marketingShellClassNameSources = [
+  'apps/web/src/app/layout.tsx',
+  'apps/web/src/components/Footer/index.tsx',
+  'packages/ui/src/components/custom/external-icon/index.tsx',
+  'packages/ui/src/components/custom/mobile-navigation/index.tsx',
+  'packages/ui/src/components/custom/navbar/index.tsx',
+  'packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx',
+  'packages/ui/src/components/custom/socials-footer/index.tsx',
+  'packages/ui/src/components/custom/theme-button-group/index.tsx',
+]
 const appBreadcrumbs = 'apps/app/src/components/extended/Breadcrumbs.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
 const mobileSidebarSheet = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/MobileSidebarSheet.tsx'
@@ -98,6 +109,21 @@ describe('app performance contracts', () => {
       expect(source).toContain("from '@nl/ui/class-names'")
       expect(source).not.toContain("from '@nl/ui/utils'")
     }
+  })
+
+  it('keeps the eager marketing shell off the conflict-merging utility', () => {
+    for (const file of marketingShellClassNameSources) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).toContain("from '@nl/ui/class-names'")
+      expect(source).not.toContain("from '@nl/ui/utils'")
+    }
+  })
+
+  it('keeps the marketing console preview deferred until it is close to view', () => {
+    const source = readFileSync(deferredConsoleGame, 'utf8')
+    expect(source).toContain("useOnScreen(rootRef, '0px')")
+    expect(source).toContain('<DeferredSkeleton')
+    expect(source).toContain('aria-label="Loading game preview"')
   })
 
   it('loads the accessible mobile sidebar sheet only when opened', () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -2137,7 +2137,7 @@ describe('public route dependency contract', () => {
 
     expect(source).toContain("import { buttonVariants } from '@nl/ui/base/button-variants'")
     expect(source).toContain("buttonVariants({ variant: 'ghost'")
-    expect(source).toContain("buttonVariants({ className: cn(buttonClassName, 'disabled') })")
+    expect(source).toContain("buttonVariants({ className: cx(buttonClassName, 'disabled') })")
     expect(source).toContain('<button')
     expect(source).not.toContain("from '@nl/ui/base/button'")
     expect(source).not.toContain('aria-disabled={disabled}')


### PR DESCRIPTION
Promotes the validated staging tree to the protected main release branch.

Included scope:
- staging tree after PR #837: defer the marketing console preview until it is near the viewport
- replace eager marketing-shell class conflict merging with lightweight class joining
- preserve existing visual, accessibility, GLTF, sidebar, navbar, and shared component contracts

Validation already passed on the source PR #837: format, lint, type-check, build, unit/coverage, and gate. This promotion uses an exact staging tree so main receives the same validated files.