### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "minty": "commander.ts"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/copy-config.mjs && node scripts/copy-api-app.mjs",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && node scripts/copy-config.mjs && node scripts/copy-contract-deployments.mjs && node scripts/copy-api-app.mjs",
     "vercel-build": "bun run build",
     "clean": "rm -rf dist api/.app api/config .turbo coverage",
     "dev": "NODE_CONFIG_TS_DIR=config tsx watch src/index.ts",

--- a/apps/api/scripts/copy-contract-deployments.mjs
+++ b/apps/api/scripts/copy-contract-deployments.mjs
@@ -1,0 +1,33 @@
+// Bundle the shared contract registries into the API function.
+//
+// The API imports small local wrappers so TypeScript keeps one canonical source
+// in @nl/contracts. Vercel cannot follow the workspace symlink to that source
+// from the deployed function, so compile the two data-only modules into the
+// API's own dist tree before copy-api-app.mjs assembles the function bundle.
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const sourceRoot = resolve(root, '..', '..', 'packages', 'contracts', 'src', 'deployments')
+const destinationRoot = resolve(root, 'dist', 'src', 'contracts', 'deployments')
+const bun = process.env.BUN_BINARY || 'bun'
+
+mkdirSync(destinationRoot, { recursive: true })
+
+for (const name of ['mainnet', 'sepolia']) {
+  const source = resolve(sourceRoot, `${name}.ts`)
+  const destination = resolve(destinationRoot, `${name}.js`)
+
+  if (!existsSync(source)) {
+    throw new Error(`[copy-contract-deployments] source not found: ${source}`)
+  }
+
+  execFileSync(
+    bun,
+    ['build', source, '--outfile', destination, '--format', 'esm', '--target', 'node'],
+    { cwd: root, stdio: 'inherit' }
+  )
+  console.log(`[copy-contract-deployments] bundled ${source} -> ${destination}`)
+}

--- a/apps/api/src/constants/contracts.ts
+++ b/apps/api/src/constants/contracts.ts
@@ -1,5 +1,5 @@
-import MAINNET_DEPLOYMENTS from '@nl/contracts/deployments/mainnet'
-import TESTNET_DEPLOYMENTS from '@nl/contracts/deployments/sepolia'
+import MAINNET_DEPLOYMENTS from '@/contracts/deployments/mainnet'
+import TESTNET_DEPLOYMENTS from '@/contracts/deployments/sepolia'
 
 export const CONTRACT_METHODS = {
   RENAME: '0xc39cbef1',

--- a/apps/api/src/contracts/deployments/mainnet.ts
+++ b/apps/api/src/contracts/deployments/mainnet.ts
@@ -1,0 +1,1 @@
+export { default } from '@nl/contracts/deployments/mainnet'

--- a/apps/api/src/contracts/deployments/sepolia.ts
+++ b/apps/api/src/contracts/deployments/sepolia.ts
@@ -1,0 +1,1 @@
+export { default } from '@nl/contracts/deployments/sepolia'

--- a/apps/api/src/contracts/index.ts
+++ b/apps/api/src/contracts/index.ts
@@ -1,7 +1,7 @@
 import { Contract } from 'ethers'
 import type { TargetNetwork, ContractName } from '@/types'
-import MAINNET_DEPLOYMENTS from '@nl/contracts/deployments/mainnet'
-import TESTNET_DEPLOYMENTS from '@nl/contracts/deployments/sepolia'
+import MAINNET_DEPLOYMENTS from '@/contracts/deployments/mainnet'
+import TESTNET_DEPLOYMENTS from '@/contracts/deployments/sepolia'
 import { getWallet } from '@/utils/wallet'
 
 export const getDeployedContract = (targetNetwork: TargetNetwork, contractName: ContractName) => {

--- a/test/contract/api-deployment-packaging.test.ts
+++ b/test/contract/api-deployment-packaging.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'bun:test'
+
+const apiPackage = join(process.cwd(), 'apps/api/package.json')
+const apiContracts = join(process.cwd(), 'apps/api/src/contracts/index.ts')
+const apiConstants = join(process.cwd(), 'apps/api/src/constants/contracts.ts')
+const bundleScript = join(process.cwd(), 'apps/api/scripts/copy-contract-deployments.mjs')
+
+describe('API deployment packaging', () => {
+  it('bundles shared contract registries into the serverless function', () => {
+    const packageJson = JSON.parse(readFileSync(apiPackage, 'utf8')) as {
+      scripts?: { build?: string }
+    }
+    const contracts = readFileSync(apiContracts, 'utf8')
+    const constants = readFileSync(apiConstants, 'utf8')
+    const script = readFileSync(bundleScript, 'utf8')
+
+    expect(packageJson.scripts?.build).toContain('copy-contract-deployments.mjs')
+    expect(contracts).toContain("from '@/contracts/deployments/mainnet'")
+    expect(constants).toContain("from '@/contracts/deployments/mainnet'")
+    expect(script).toContain("'packages', 'contracts', 'src', 'deployments'")
+    expect(script).toContain("'dist', 'src', 'contracts', 'deployments'")
+  })
+})


### PR DESCRIPTION
Promotes the validated staging tree after PR #840 to the protected main release branch.

This promotion includes the production API packaging hotfix: shared contract deployment registries are bundled into the serverless function so the API no longer depends on a workspace TypeScript symlink at runtime.

PR #840 passed staging format, lint, type-check, build, unit, and gate checks. This PR runs the full main audit tier before the required rebase promotion.