### PR TITLE
perf: keep public class graphs lightweight

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -7,7 +7,7 @@ import DeferredAnalytics from '@nl/ui/gtm/deferred'
 import { defaultFont } from '@nl/ui/fonts/default'
 import { headerFont } from '@nl/ui/fonts/header'
 import { subheaderFont } from '@nl/ui/fonts/subheader'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
@@ -68,7 +68,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn(defaultFont.variable, headerFont.variable, subheaderFont.variable, 'dark')}
+      className={cx(defaultFont.variable, headerFont.variable, subheaderFont.variable, 'dark')}
     >
       <DeferredAnalytics />
       <DeferredSentry enabled={process.env.VERCEL_ENV === 'production'} options={sentryOptions} />

--- a/apps/app/src/components/providers/PublicNavigation.tsx
+++ b/apps/app/src/components/providers/PublicNavigation.tsx
@@ -1,9 +1,9 @@
 import type { PropsWithChildren } from 'react'
 
 import AppBar from '@nl/ui/custom/app-bar'
+import { cx } from '@nl/ui/class-names'
 import { ExternalIcon } from '@nl/ui/custom/external-icon'
 import MobileNavigationDisclosure from '@nl/ui/custom/mobile-navigation'
-import { cn } from '@nl/ui/utils'
 
 import LogoSection from '@/app/_layout/_MainLayout/_LogoSection'
 import styles from '@/app/_layout/_MainLayout/MainLayout.module.css'
@@ -17,11 +17,11 @@ const pages = [
 
 export default function PublicNavigation({ children }: PropsWithChildren) {
   return (
-    <div className={cn('flex', styles.publicNavigationShell)} data-public-navigation>
+    <div className={cx('flex', styles.publicNavigationShell)} data-public-navigation>
       <header className="fixed top-0 right-0 left-0 z-50 border-0 bg-sidebar">
         <AppBar>
           <div className="flex w-full flex-row items-center justify-between">
-            <div className={cn('flex items-center', styles.publicHeaderControls)}>
+            <div className={cx('flex items-center', styles.publicHeaderControls)}>
               <div className="hidden flex-grow lg:block">
                 <LogoSection />
               </div>
@@ -81,7 +81,7 @@ export default function PublicNavigation({ children }: PropsWithChildren) {
         className="hidden w-[260px] shrink-0 lg:block"
       >
         <aside
-          className={cn(
+          className={cx(
             styles.publicDesktopSidebar,
             'bg-sidebar text-sidebar-foreground fixed bottom-0 left-0 z-40 border-r-0 transition-transform duration-200'
           )}

--- a/apps/smashers/src/app/layout.tsx
+++ b/apps/smashers/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { defaultFont } from '@nl/ui/fonts/default'
 import { headerFont } from '@nl/ui/fonts/header'
 import { specialFont } from '@nl/ui/fonts/special'
 import { subheaderFont } from '@nl/ui/fonts/subheader'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import { sentryOptions } from '@/constants/sentry'
 import '@/styles/app.css'
@@ -83,7 +83,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn(
+      className={cx(
         defaultFont.variable,
         headerFont.variable,
         subheaderFont.variable,

--- a/apps/smashers/src/components/Header/Navbar/index.tsx
+++ b/apps/smashers/src/components/Header/Navbar/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import styles from './index.module.css'
 export default function Navbar() {
@@ -22,7 +22,7 @@ export default function Navbar() {
         </a>
         <nav className={styles.navbar}>
           <Link href="/profile">
-            <div className={cn(styles.nav_item, styles.profile_mobile)}>
+            <div className={cx(styles.nav_item, styles.profile_mobile)}>
               <Image
                 src="/icons/user.svg"
                 alt="Profile Icon"
@@ -36,7 +36,7 @@ export default function Navbar() {
       </div>
 
       {/* Desktop Navbar */}
-      <div className={cn('hidden sm:block', styles.desktop_nav)}>
+      <div className={cx('hidden sm:block', styles.desktop_nav)}>
         <a href="https://niftyleague.com" target="_blank" rel="noreferrer">
           <div className={styles.logo_container}>
             <Image
@@ -84,7 +84,7 @@ export default function Navbar() {
             </a>
           </div>
           <Link href="/profile">
-            <div className={cn(styles.nav_item, styles.profile)}>
+            <div className={cx(styles.nav_item, styles.profile)}>
               <div className={styles.profile_icon}>
                 <Image src="/icons/user.svg" alt="Profile Icon" width={22} height={22} />
               </div>

--- a/apps/web/src/app/(main)/compete-and-earn/page.tsx
+++ b/apps/web/src/app/(main)/compete-and-earn/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import type { NextPage } from 'next'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
 import styles from './index.module.css'
@@ -9,7 +9,7 @@ const CompeteAndEarn: NextPage = () => {
   return (
     <div className="container pt-20">
       <section className="section flex flex-col-reverse md:flex-row items-center justify-center relative">
-        <div className={cn(styles.block, 'flex flex-col w-full md:w-1/2 pr-0 md:pr-5 relative')}>
+        <div className={cx(styles.block, 'flex flex-col w-full md:w-1/2 pr-0 md:pr-5 relative')}>
           <div className="mb-2 mb-md-4">
             <h1>COMPETE &amp; EARN</h1>
           </div>
@@ -38,7 +38,7 @@ const CompeteAndEarn: NextPage = () => {
       </section>
 
       <section className="section flex flex-col-reverse md:flex-row mt-3 md:mt-5 py-5 items-center relative">
-        <div className={cn(styles.block, 'w-full md:w-1/2 pr-5')}>
+        <div className={cx(styles.block, 'w-full md:w-1/2 pr-5')}>
           <div className="mb-3">
             <h3>HOW IT WORKS</h3>
           </div>
@@ -62,7 +62,7 @@ const CompeteAndEarn: NextPage = () => {
 
       <section className="section">
         <h3 className="mt-3 mt-md-5 text-center">GAME MODES</h3>
-        <div className={cn(styles.features, 'flex pt-3 md:pt-5 mx-auto relative')}>
+        <div className={cx(styles.features, 'flex pt-3 md:pt-5 mx-auto relative')}>
           <div className="w-1/3">
             <h6 className={styles.headerCell}>FEATURES:</h6>
             <p className={styles.cell}>Requires an invite:</p>

--- a/apps/web/src/app/(main)/degens/page.tsx
+++ b/apps/web/src/app/(main)/degens/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
 import { DegenSpecialsTable } from '@nl/ui/custom/degen-specials-table'
 import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import { NIFTY_DEGENS_ALL } from '@/constants/degens'
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
@@ -62,7 +62,7 @@ const Degens: NextPage = () => (
       <section className="section relative">
         <div className="purple-bg-orb orb-bottom-right" />
         <div
-          className={cn(
+          className={cx(
             styles.list,
             'flex flex-wrap items-center md:flex-row w-full justify-between'
           )}

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 
 import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
 import { NIFTY_GAMES } from '@/constants/games'
@@ -55,10 +55,10 @@ const Games: NextPage = () => (
     <section className="section">
       {NIFTY_GAMES.map(({ name, description, video, tag, action }, index) => (
         <article className="flex flex-col-reverse md:flex-row relative mb-8" key={name}>
-          <div className={cn(styles.block, 'w-full md:w-7/12 pr-0 md:pr-5')}>
+          <div className={cx(styles.block, 'w-full md:w-7/12 pr-0 md:pr-5')}>
             <div className="flex flex-row items-center justify-between mb-3">
               <h4 className="m-0">{name}</h4>
-              <p className={cn(styles.tagGame, 'm-0')}>{tag}</p>
+              <p className={cx(styles.tagGame, 'm-0')}>{tag}</p>
             </div>
             <p>{description}</p>
             <div className="flex justify-center md:justify-start mt-4">
@@ -116,7 +116,7 @@ const Games: NextPage = () => (
             </div>
           </div>
           <div
-            className={cn(
+            className={cx(
               index === 0
                 ? 'orb-bottom-left'
                 : index === 1

--- a/apps/web/src/app/(main)/lore/page.tsx
+++ b/apps/web/src/app/(main)/lore/page.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next'
 import Image from 'next/image'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
 
 import styles from './index.module.css'
@@ -100,7 +100,7 @@ const Lore: NextPage = () => {
           </div>
         </div>
         <div className={styles.satoshiContainer}>
-          <div className={cn(styles.satoshi, 'relative flex-1')}>
+          <div className={cx(styles.satoshi, 'relative flex-1')}>
             <Image
               alt="Satoshi"
               src="/img/hero/satoshi.webp"
@@ -111,7 +111,7 @@ const Lore: NextPage = () => {
           </div>
         </div>
         <div className={styles.degensContainer}>
-          <div className={cn(styles.degens, 'relative flex-1')}>
+          <div className={cx(styles.degens, 'relative flex-1')}>
             <Image
               alt="DEGENs"
               src="/img/degens/community-characters.webp"

--- a/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
+++ b/apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx
@@ -45,7 +45,6 @@ export default async function DegenViewsPage({ params }: DegenViewsPageProps) {
           alt="Nifty League Logo"
           width={200}
           height={70}
-          priority
           style={{ maxWidth: '24vw', height: 'auto' }}
           src="/img/logos/NL/wordmark.webp"
         />

--- a/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
+++ b/apps/web/src/components/RoadmapTimeline/roadmapCard.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image'
 import { Check } from 'lucide-react'
 
+import { cx } from '@nl/ui/class-names'
 import { AnimatedImage } from '@nl/ui/custom/animated-image'
-import { cn } from '@nl/ui/utils'
 import styles from './index.module.css'
 
 interface RoadmapCardProps {
@@ -30,12 +30,12 @@ const RoadmapCard = ({
   image,
   title,
 }: RoadmapCardProps): React.ReactNode => (
-  <div className={cn(styles.cd_timeline_block, styles.fade_in)}>
+  <div className={cx(styles.cd_timeline_block, styles.fade_in)}>
     {divider ? (
       <h4 className={styles.cd_timeline_divider}>Options below are TBD!</h4>
     ) : (
       <div
-        className={cn(styles.cd_timeline_checkpoint, { [styles.completed as string]: completed })}
+        className={cx(styles.cd_timeline_checkpoint, { [styles.completed as string]: completed })}
       >
         {completed && (
           <Check

--- a/packages/ui/src/components/custom/app-bar/index.tsx
+++ b/packages/ui/src/components/custom/app-bar/index.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 
-import { cn } from '@nl/ui/utils'
+import { cx } from '@nl/ui/class-names'
 import styles from './app-bar.module.css'
 
 export type AppBarProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
@@ -10,7 +10,7 @@ export function AppBar({ children, className, ...props }: AppBarProps) {
     <div
       data-slot="app-bar"
       data-layout="responsive"
-      className={cn(styles.appBar, className)}
+      className={cx(styles.appBar, className)}
       {...props}
     >
       {children}

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -32,6 +32,7 @@ const sharedAppBarStyles = 'packages/ui/src/components/custom/app-bar/app-bar.mo
 const lightweightClassNames = 'packages/ui/src/lib/class-names.ts'
 const deferredConsoleGame = 'packages/ui/src/components/custom/deferred-console-game/index.tsx'
 const gltfViews = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/components/DegenViews.tsx'
+const gltfPage = 'apps/web/src/app/(special-routes)/gltf/[tokenId]/page.tsx'
 const marketingShellClassNameSources = [
   'apps/web/src/app/layout.tsx',
   'apps/web/src/components/Footer/index.tsx',
@@ -41,6 +42,18 @@ const marketingShellClassNameSources = [
   'packages/ui/src/components/custom/navbar/NavbarScrollFrame.tsx',
   'packages/ui/src/components/custom/socials-footer/index.tsx',
   'packages/ui/src/components/custom/theme-button-group/index.tsx',
+]
+const nonConflictingClassNameSources = [
+  'apps/app/src/app/layout.tsx',
+  'apps/app/src/components/providers/PublicNavigation.tsx',
+  'apps/smashers/src/app/layout.tsx',
+  'apps/smashers/src/components/Header/Navbar/index.tsx',
+  'apps/web/src/app/(main)/compete-and-earn/page.tsx',
+  'apps/web/src/app/(main)/degens/page.tsx',
+  'apps/web/src/app/(main)/games/page.tsx',
+  'apps/web/src/app/(main)/lore/page.tsx',
+  'apps/web/src/components/RoadmapTimeline/roadmapCard.tsx',
+  'packages/ui/src/components/custom/app-bar/index.tsx',
 ]
 const appBreadcrumbs = 'apps/app/src/components/extended/Breadcrumbs.tsx'
 const appSidebarFrame = 'apps/app/src/app/_layout/_MainLayout/_Sidebar/SidebarFrame.tsx'
@@ -143,6 +156,24 @@ describe('app performance contracts', () => {
     const source = readFileSync(gltfViews, 'utf8')
     expect(source).toContain("from '@nl/ui/class-names'")
     expect(source).not.toContain("from '@nl/ui/utils'")
+  })
+
+  it('keeps non-conflicting public class composition off the conflict-merging utility', () => {
+    for (const file of nonConflictingClassNameSources) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).toContain("from '@nl/ui/class-names'")
+      expect(source).not.toContain("from '@nl/ui/utils'")
+    }
+  })
+
+  it('does not prioritize the GLTF logo that is hidden in the initial 2D view', () => {
+    const source = readFileSync(gltfPage, 'utf8')
+    const logoStart = source.indexOf('alt="Nifty League Logo"')
+    const logoEnd = source.indexOf('src="/img/logos/NL/wordmark.webp"')
+
+    expect(logoStart).toBeGreaterThanOrEqual(0)
+    expect(logoEnd).toBeGreaterThan(logoStart)
+    expect(source.slice(logoStart, logoEnd)).not.toContain('priority')
   })
 
   it('loads the accessible mobile sidebar sheet only when opened', () => {

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -470,7 +470,12 @@ describe('GLTF viewer loading contract', () => {
     expect(source).toContain(
       'className={styles.sprite}\n            fill\n            sizes="100vw"'
     )
-    expect(source).toContain("priority\n          style={{ maxWidth: '24vw', height: 'auto' }}")
+    const logoStart = source.indexOf('alt="Nifty League Logo"')
+    const logoEnd = source.indexOf('src="/img/logos/NL/wordmark.webp"')
+
+    expect(logoStart).toBeGreaterThanOrEqual(0)
+    expect(logoEnd).toBeGreaterThan(logoStart)
+    expect(source.slice(logoStart, logoEnd)).not.toContain('priority')
     expect(source).not.toContain('quality={100}')
   })
 


### PR DESCRIPTION
## Summary
- use lightweight class joining for non-conflicting public composition paths across web, app, Smashers, and shared UI
- stop preloading the GLTF logo that is hidden until the viewer mode changes
- keep the visible NFT artwork priority and add regression contracts for both behaviors

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run type-check`
- `bun run test:coverage` — 1,090 passed, 6 skipped, 0 failed
- `bun run build` — API, app, docs, Smashers, and web passed
- visual/route regression audit completed against the pre-refactor baseline
