### PR TITLE
chore: promote staging to main

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -42,8 +42,10 @@ const sentryOptions = {
   // Only upload source maps in production
   sourcemaps: { disable: ENV !== 'production' },
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: ENV === 'production',
+  // Keep production source maps enabled without uploading every client chunk.
+  // The widened upload increases build time and deployment bandwidth without
+  // changing the browser error signal we collect.
+  widenClientFileUpload: false,
 
   // Only enable internal plugin errors and performance data on production
   telemetry: ENV === 'production',

--- a/apps/smashers/next.config.ts
+++ b/apps/smashers/next.config.ts
@@ -145,8 +145,10 @@ const sentryOptions = {
   // Only upload source maps in production
   sourcemaps: { disable: ENV !== 'production' },
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: ENV === 'production',
+  // Keep production source maps enabled without uploading every client chunk.
+  // The widened upload increases build time and deployment bandwidth without
+  // changing the browser error signal we collect.
+  widenClientFileUpload: false,
 
   // Only enable internal plugin errors and performance data on production
   telemetry: ENV === 'production',

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -121,8 +121,10 @@ const sentryOptions = {
   // Only upload source maps in production
   sourcemaps: { disable: ENV !== 'production' },
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: ENV === 'production',
+  // Keep production source maps enabled without uploading every client chunk.
+  // The widened upload increases build time and deployment bandwidth without
+  // changing the browser error signal we collect.
+  widenClientFileUpload: false,
 
   // Only enable internal plugin errors and performance data on production
   telemetry: ENV === 'production',

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -281,6 +281,14 @@ describe('app performance contracts', () => {
     }
   })
 
+  it('keeps Sentry source-map uploads narrow enough for production builds', () => {
+    for (const file of [appNextConfig, smashersNextConfig, webNextConfig]) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).toContain("sourcemaps: { disable: ENV !== 'production' }")
+      expect(source).toContain('widenClientFileUpload: false')
+    }
+  })
+
   it('keeps every TypeScript project on incremental checking', () => {
     for (const file of incrementalTypecheckConfigs) {
       expect(readFileSync(file, 'utf8')).toContain('"incremental": true')


### PR DESCRIPTION
## Promotion

Promote the validated staging tree to `main` after PR #849.

## Verification

The promotion branch is based on `origin/main` and cherry-picks the staged change. Its tree is byte-for-byte identical to `origin/staging`:

- staging tree: `8a8c62fd63f0531a2699b5d87b8530fa06c6e195`
- promotion tree: `8a8c62fd63f0531a2699b5d87b8530fa06c6e195`

Local validation for the promoted tree: format, lint, type-check, coverage (1091 pass, 6 skip, 0 fail), and the full five-app build.