### PR TITLE
promote: staging to main

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -5,27 +5,30 @@
 import type { NextConfig } from 'next'
 
 const ENV = (process.env.VERCEL_ENV as 'production' | 'preview' | undefined) ?? 'development'
+const isExplicitWebpackBuild = process.argv.includes('--webpack')
+
+const webpackFallback: NonNullable<NextConfig['webpack']> = (config) => {
+  // Map @wagmi/core connectors package to wagmi/connectors to avoid ESM issues
+  config.resolve.alias = { ...config.resolve.alias, '@wagmi/connectors': 'wagmi/connectors' }
+
+  // Externalize native modules: https://github.com/vercel/next.js/issues/86099
+  config.externals.push('pino-pretty', 'lokijs', 'encoding', 'sodium-native', 'require-addon')
+
+  return config
+}
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nl/contracts', '@nl/imx-passport', '@nl/ui'],
+  serverExternalPackages: ['pino-pretty', 'lokijs', 'encoding', 'sodium-native', 'require-addon'],
   experimental: {
     optimizePackageImports: ['lucide-react'],
     useTypeScriptCli: true,
   },
-  turbopack: {},
-  images: {
-    formats: ['image/avif', 'image/webp'],
-  },
+  turbopack: { resolveAlias: { '@wagmi/connectors': 'wagmi/connectors' } },
+  images: { formats: ['image/avif', 'image/webp'] },
   // Keep the Webpack compatibility path for explicit `next build --webpack`
-  // fallback runs; local development uses Turbopack for faster iteration.
-  // serverExternalPackages: ['pino-pretty', 'lokijs', 'encoding', 'sodium-native', 'require-addon'],
-  webpack: (config, { isServer }) => {
-    // Map @wagmi/core connectors package to wagmi/connectors to avoid ESM issues
-    config.resolve.alias = { ...config.resolve.alias, '@wagmi/connectors': 'wagmi/connectors' }
-    // Externalize native modules: https://github.com/vercel/next.js/issues/86099
-    config.externals.push('pino-pretty', 'lokijs', 'encoding', 'sodium-native', 'require-addon')
-    return config
-  },
+  // fallback runs; the normal build and dev paths stay on the Turbopack worker.
+  ...(isExplicitWebpackBuild ? { webpack: webpackFallback } : {}),
 }
 
 const sentryOptions = {

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -275,6 +275,17 @@ describe('app performance contracts', () => {
     }
   })
 
+  it('keeps default app builds on the Turbopack worker with a scoped Webpack fallback', () => {
+    const source = readFileSync(appNextConfig, 'utf8')
+
+    expect(source).toContain("const isExplicitWebpackBuild = process.argv.includes('--webpack')")
+    expect(source).toContain("serverExternalPackages: ['pino-pretty', 'lokijs'")
+    expect(source).toContain(
+      "turbopack: { resolveAlias: { '@wagmi/connectors': 'wagmi/connectors' } }"
+    )
+    expect(source).toContain('...(isExplicitWebpackBuild ? { webpack: webpackFallback } : {}),')
+  })
+
   it('modularizes shared Lucide imports before the app graph is bundled', () => {
     for (const file of [appNextConfig, smashersNextConfig, webNextConfig, templateNextConfig]) {
       expect(readFileSync(file, 'utf8')).toContain("optimizePackageImports: ['lucide-react']")


### PR DESCRIPTION
## Promotion

Promotes the validated staging tree to `main` using the repository's exact-tree promotion flow.

## Included change

- keep default `apps/app` builds on the Turbopack worker while preserving the explicit Webpack fallback
- retain the performance contract covering the bundler split

## Promotion evidence

- staging source: `5a59b78611746edeaee74a883611d89d278cf7a6`
- promotion tree: `774c501c5a0ee85685f0f9df15114ee1193fc60c`
- staging tree: `774c501c5a0ee85685f0f9df15114ee1193fc60c`
- local format, lint, type-check, coverage, default builds, and explicit Webpack fallback build passed
- hosted PR #852 validation gate passed

No component, CSS, asset, or route markup changes are included beyond the already validated staging tree.