### PR TITLE
promote: staging to main

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -68,7 +68,7 @@ const nextConfig: NextConfig = {
         ? [
             {
               source: '/docs/:path*',
-              destination: `http://localhost:3002/docs/:path*`,
+              destination: `http://localhost:3002/:path*`,
               permanent: true,
             },
             { source: '/app', destination: 'http://localhost:3001', permanent: true },

--- a/test/contract/docs-routing.test.ts
+++ b/test/contract/docs-routing.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 const docsRoot = join(process.cwd(), 'apps/docs')
 const docsConfig = readFileSync(join(docsRoot, 'docusaurus.config.ts'), 'utf8')
+const webConfig = readFileSync(join(process.cwd(), 'apps/web/next.config.ts'), 'utf8')
 
 describe('documentation routing contract', () => {
   it('serves Docusaurus at the root of the docs custom domain', () => {
@@ -24,5 +25,10 @@ describe('documentation routing contract', () => {
       const source = readFileSync(join(docsRoot, file), 'utf8')
       expect(source).not.toMatch(/(?:to|href|src):?\s*["']\/docs\//)
     }
+  })
+
+  it('keeps the local web redirect aligned with the docs root', () => {
+    expect(webConfig).toContain('destination: `http://localhost:3002/:path*`')
+    expect(webConfig).not.toContain('destination: `http://localhost:3002/docs/:path*`')
   })
 })


### PR DESCRIPTION
## Summary
Promote the validated staging tree to main using the exact-tree release flow.

## Included change
- align the development-only web docs redirect with the docs site root
- add a routing contract test for the local redirect

## Release validation
- staging PR #861 merged after format, lint, type-check, build, unit, and validation gate passed
- promotion commit tree matches origin/staging exactly
- production route and deployment verification will follow the merge