### PR TITLE
promote: staging to main

### DIFF
--- a/packages/ui/src/components/custom/custom-components.test.tsx
+++ b/packages/ui/src/components/custom/custom-components.test.tsx
@@ -17,14 +17,23 @@ const state = {
   stop: mock(),
   parallax: mock(),
 }
+const nextLinkPrefetches: Array<boolean | undefined> = []
 
 beforeEach(() => {
   mock.module('next/link', () => ({
-    default: ({ children, href, ...props }: PropsWithChildren<{ href: string }>) => (
-      <a href={href} {...props}>
-        {children}
-      </a>
-    ),
+    default: ({
+      children,
+      href,
+      prefetch,
+      ...props
+    }: PropsWithChildren<{ href: string; prefetch?: boolean }>) => {
+      nextLinkPrefetches.push(prefetch)
+      return (
+        <a href={href} {...props}>
+          {children}
+        </a>
+      )
+    },
   }))
   mock.module('next/image', () => ({
     default: ({
@@ -53,6 +62,7 @@ beforeEach(() => {
 afterEach(() => {
   jest.useRealTimers()
   undefined
+  nextLinkPrefetches.length = 0
   state.mobile = true
   state.milliseconds = 1_500
   state.pathname = '/about'
@@ -165,6 +175,8 @@ describe('Navbar', () => {
     )
 
     expect(screen.getByRole('img', { name: 'Home' }).getAttribute('loading')).toBe('eager')
+    expect(nextLinkPrefetches.length).toBeGreaterThan(0)
+    expect(nextLinkPrefetches.every((prefetch) => prefetch === false)).toBe(true)
     expect(screen.getAllByRole('link', { name: /About/ })[0]?.getAttribute('href')).toBe('/about')
     fireEvent.click(screen.getByText('Products', { selector: 'summary' }))
     expect(screen.getAllByRole('link', { name: /Docs/ })[0]?.getAttribute('target')).toBe('_blank')

--- a/packages/ui/src/components/custom/navbar/MobileNavMenu.tsx
+++ b/packages/ui/src/components/custom/navbar/MobileNavMenu.tsx
@@ -22,6 +22,7 @@ function MobileMenuGroup({ group, pages }: Extract<NavItemData, { type: 'group' 
             <Link
               className={`${NAV_LINK_CONTENT_CLASS} text-base font-medium`}
               href={page.href}
+              prefetch={false}
               target={page.external ? '_blank' : undefined}
               rel={page.external ? 'noreferrer' : undefined}
             >
@@ -44,6 +45,7 @@ function MobileMenuItem({ type: _type, ...page }: Extract<NavItemData, { type: '
       <Link
         className={`${NAV_LINK_CONTENT_CLASS} text-base font-medium`}
         href={page.href}
+        prefetch={false}
         target={page.external ? '_blank' : undefined}
         rel={page.external ? 'noreferrer' : undefined}
       >
@@ -84,6 +86,7 @@ export default function MobileNavMenu({ actionButton, navItems }: MobileNavMenuP
             <hr aria-hidden="true" className="bg-separator my-6 h-px w-full shrink-0 border-0" />
             <Link
               href={actionButton.href}
+              prefetch={false}
               target={actionButton.external ? '_blank' : undefined}
               rel={actionButton.external ? 'noreferrer' : undefined}
               className={buttonVariants({

--- a/packages/ui/src/components/custom/navbar/index.tsx
+++ b/packages/ui/src/components/custom/navbar/index.tsx
@@ -47,6 +47,7 @@ function DesktopNavLink({
   return (
     <Link
       href={href}
+      prefetch={false}
       target={external ? '_blank' : undefined}
       rel={external ? 'noreferrer' : undefined}
       className={cx(NAV_LINK_CONTENT_CLASS, className)}
@@ -121,6 +122,7 @@ function DesktopNavMenu({ actionButton, navItems }: NavbarProps) {
           <li>
             <Link
               href={actionButton.href}
+              prefetch={false}
               target={actionButton.external ? '_blank' : undefined}
               rel={actionButton.external ? 'noreferrer' : undefined}
               className="theme-btn-primary theme-btn-rounded ml-3 max-w-fit"
@@ -142,7 +144,7 @@ export function Navbar({ actionButton, navItems, className }: NavbarProps) {
   return (
     <NavbarScrollFrame className={className}>
       <div className="flex h-full w-screen items-center justify-between px-4 sm:px-6 lg:px-8">
-        <Link href="/" className="flex-shrink-0">
+        <Link href="/" prefetch={false} className="flex-shrink-0">
           <Image
             src="/img/logos/NL/white.webp"
             height={50}

--- a/packages/ui/src/components/custom/theme-button-group/index.tsx
+++ b/packages/ui/src/components/custom/theme-button-group/index.tsx
@@ -51,6 +51,7 @@ export function ThemeButton({
   return (
     <Link
       href={href}
+      prefetch={false}
       target={external ? '_blank' : undefined}
       rel={external ? 'noreferrer' : undefined}
       className={buttonVariants({ variant: 'ghost', className: buttonClassName })}

--- a/packages/ui/src/components/custom/theme-button-group/theme-button-group.test.tsx
+++ b/packages/ui/src/components/custom/theme-button-group/theme-button-group.test.tsx
@@ -3,12 +3,18 @@ import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 let ThemeButtonGroup: typeof import('./index').default
+const nextLinkPrefetches: Array<boolean | undefined> = []
 
 beforeEach(() => {
   mock.module('next/link', () => ({
-    default: ({ children, ...props }: { children: ReactNode } & Record<string, unknown>) => (
-      <a {...props}>{children}</a>
-    ),
+    default: ({
+      children,
+      prefetch,
+      ...props
+    }: { children: ReactNode; prefetch?: boolean } & Record<string, unknown>) => {
+      nextLinkPrefetches.push(prefetch)
+      return <a {...props}>{children}</a>
+    },
   }))
 
   return import('./index').then((module) => {
@@ -26,6 +32,7 @@ describe('ThemeButtonGroup', () => {
     )
 
     expect(screen.getByRole('link', { name: 'Play now' }).getAttribute('href')).toBe('/games')
+    expect(nextLinkPrefetches).toEqual([false, false])
     expect(screen.getByRole('link', { name: /Smashers/ }).getAttribute('target')).toBe('_blank')
     expect(screen.getByRole('link', { name: /Smashers/ }).getAttribute('rel')).toBe('noreferrer')
   })


### PR DESCRIPTION
Promote the validated staging tree to main.

Included:
- Disable eager navigation prefetching in shared navbar and themed CTA links.
- Preserve rendered behavior, accessibility, and styling while reducing background route work.

Validation:
- Staging PR #864 checks passed.
- Exact promotion tree verified against origin/staging.