### PR TITLE
promote: staging to main

### DIFF
--- a/packages/ui/src/components/base/accordion.tsx
+++ b/packages/ui/src/components/base/accordion.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Accordion as AccordionPrimitive } from 'radix-ui'
+import * as AccordionPrimitive from 'radix-ui/accordion'
 import { ChevronDownIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/alert-dialog.tsx
+++ b/packages/ui/src/components/base/alert-dialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { AlertDialog as AlertDialogPrimitive } from 'radix-ui'
+import * as AlertDialogPrimitive from 'radix-ui/alert-dialog'
 import { type VariantProps } from 'class-variance-authority'
 import { buttonVariants } from '@nl/ui/base/button'
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/avatar.tsx
+++ b/packages/ui/src/components/base/avatar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Avatar as AvatarPrimitive } from 'radix-ui'
+import * as AvatarPrimitive from 'radix-ui/avatar'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/badge.tsx
+++ b/packages/ui/src/components/base/badge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Slot as SlotPrimitive } from 'radix-ui'
+import * as SlotPrimitive from 'radix-ui/slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/button.tsx
+++ b/packages/ui/src/components/base/button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Slot as SlotPrimitive } from 'radix-ui'
+import * as SlotPrimitive from 'radix-ui/slot'
 import type { VariantProps } from 'class-variance-authority'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/checkbox.tsx
+++ b/packages/ui/src/components/base/checkbox.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Checkbox as CheckboxPrimitive } from 'radix-ui'
+import * as CheckboxPrimitive from 'radix-ui/checkbox'
 import { CheckIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/dialog.tsx
+++ b/packages/ui/src/components/base/dialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Dialog as DialogPrimitive } from 'radix-ui'
+import * as DialogPrimitive from 'radix-ui/dialog'
 import { XIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/form.tsx
+++ b/packages/ui/src/components/base/form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import * as React from 'react'
-import { Label as LabelPrimitive, Slot as SlotPrimitive } from 'radix-ui'
+import * as LabelPrimitive from 'radix-ui/label'
+import * as SlotPrimitive from 'radix-ui/slot'
 
 import {
   Controller,

--- a/packages/ui/src/components/base/label.tsx
+++ b/packages/ui/src/components/base/label.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Label as LabelPrimitive } from 'radix-ui'
+import * as LabelPrimitive from 'radix-ui/label'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/progress.tsx
+++ b/packages/ui/src/components/base/progress.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Progress as ProgressPrimitive } from 'radix-ui'
+import * as ProgressPrimitive from 'radix-ui/progress'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/radio-group.tsx
+++ b/packages/ui/src/components/base/radio-group.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { RadioGroup as RadioGroupPrimitive } from 'radix-ui'
+import * as RadioGroupPrimitive from 'radix-ui/radio-group'
 import { CircleIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/scroll-area.tsx
+++ b/packages/ui/src/components/base/scroll-area.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui'
+import * as ScrollAreaPrimitive from 'radix-ui/scroll-area'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/select.tsx
+++ b/packages/ui/src/components/base/select.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Select as SelectPrimitive } from 'radix-ui'
+import * as SelectPrimitive from 'radix-ui/select'
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/separator.tsx
+++ b/packages/ui/src/components/base/separator.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Separator as SeparatorPrimitive } from 'radix-ui'
+import * as SeparatorPrimitive from 'radix-ui/separator'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/sheet.tsx
+++ b/packages/ui/src/components/base/sheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Dialog as SheetPrimitive } from 'radix-ui'
+import * as SheetPrimitive from 'radix-ui/dialog'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/tabs.tsx
+++ b/packages/ui/src/components/base/tabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Tabs as TabsPrimitive } from 'radix-ui'
+import * as TabsPrimitive from 'radix-ui/tabs'
 
 import { cn } from '@nl/ui/utils'
 

--- a/packages/ui/src/components/base/toggle-group.tsx
+++ b/packages/ui/src/components/base/toggle-group.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { ToggleGroup as ToggleGroupPrimitive } from 'radix-ui'
+import * as ToggleGroupPrimitive from 'radix-ui/toggle-group'
 import { type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/toggle.tsx
+++ b/packages/ui/src/components/base/toggle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Toggle as TogglePrimitive } from 'radix-ui'
+import * as TogglePrimitive from 'radix-ui/toggle'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@nl/ui/utils'

--- a/packages/ui/src/components/base/tooltip.tsx
+++ b/packages/ui/src/components/base/tooltip.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Tooltip as TooltipPrimitive } from 'radix-ui'
+import * as TooltipPrimitive from 'radix-ui/tooltip'
 
 import { cn } from '@nl/ui/utils'
 

--- a/test/contract/turbo-cache-scope.test.ts
+++ b/test/contract/turbo-cache-scope.test.ts
@@ -22,6 +22,34 @@ const rootPackage = JSON.parse(readFileSync('package.json', 'utf8')) as {
 const envFor = (task: string) => new Set(turbo.tasks[task]?.env ?? [])
 const dependenciesFor = (task: string) => turbo.tasks[task]?.dependsOn ?? []
 const inputsFor = (task: string) => turbo.tasks[task]?.inputs ?? []
+const sharedBuildInputs: Record<string, string[]> = {
+  'api#build': ['../../packages/contracts/src/**', '../../packages/contracts/package.json'],
+  'app#build': [
+    '../../packages/contracts/src/**',
+    '../../packages/contracts/package.json',
+    '../../packages/imx-passport/src/**',
+    '../../packages/imx-passport/package.json',
+    '../../packages/sentry-client/src/**',
+    '../../packages/sentry-client/package.json',
+    '../../packages/ui/src/**',
+    '../../packages/ui/package.json',
+  ],
+  'docs#build': ['../../packages/ui/src/**', '../../packages/ui/package.json'],
+  'smashers#build': [
+    '../../packages/playfab/src/**',
+    '../../packages/playfab/package.json',
+    '../../packages/sentry-client/src/**',
+    '../../packages/sentry-client/package.json',
+    '../../packages/ui/src/**',
+    '../../packages/ui/package.json',
+  ],
+  'web#build': [
+    '../../packages/sentry-client/src/**',
+    '../../packages/sentry-client/package.json',
+    '../../packages/ui/src/**',
+    '../../packages/ui/package.json',
+  ],
+}
 const packageJson = (path: string) =>
   JSON.parse(readFileSync(path, 'utf8')) as {
     scripts?: Record<string, string>
@@ -42,7 +70,18 @@ describe('Turbo cache environment scope', () => {
     expect(turbo.globalDependencies ?? []).toEqual(['.env'])
 
     for (const task of ['api#build', 'app#build', 'docs#build', 'smashers#build', 'web#build']) {
-      expect(inputsFor(task)).toEqual(['$TURBO_DEFAULT$', '.env*', '!.env.example'])
+      expect(inputsFor(task)).toEqual([
+        '$TURBO_DEFAULT$',
+        ...(sharedBuildInputs[task] ?? []),
+        '.env*',
+        '!.env.example',
+      ])
+    }
+  })
+
+  it('invalidates app builds when their shared workspace sources change', () => {
+    for (const [task, inputs] of Object.entries(sharedBuildInputs)) {
+      expect(inputsFor(task)).toEqual(['$TURBO_DEFAULT$', ...inputs, '.env*', '!.env.example'])
     }
   })
 

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,19 @@
       "outputs": ["dist/**"]
     },
     "app#build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/contracts/src/**",
+        "../../packages/contracts/package.json",
+        "../../packages/imx-passport/src/**",
+        "../../packages/imx-passport/package.json",
+        "../../packages/sentry-client/src/**",
+        "../../packages/sentry-client/package.json",
+        "../../packages/ui/src/**",
+        "../../packages/ui/package.json",
+        ".env*",
+        "!.env.example"
+      ],
       "env": [
         "CI",
         "NEXT_RUNTIME",
@@ -22,7 +34,13 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "api#build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/contracts/src/**",
+        "../../packages/contracts/package.json",
+        ".env*",
+        "!.env.example"
+      ],
       "env": [
         "NODE_CONFIG_TS_DIR",
         "PORT",
@@ -54,12 +72,28 @@
       "outputs": ["dist/**", "api/.app/**", "api/config/**"]
     },
     "docs#build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/ui/src/**",
+        "../../packages/ui/package.json",
+        ".env*",
+        "!.env.example"
+      ],
       "env": ["ALGOLIA_API_KEY", "ALGOLIA_APP_ID"],
       "outputs": ["build/**", ".docusaurus/**"]
     },
     "smashers#build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/playfab/src/**",
+        "../../packages/playfab/package.json",
+        "../../packages/sentry-client/src/**",
+        "../../packages/sentry-client/package.json",
+        "../../packages/ui/src/**",
+        "../../packages/ui/package.json",
+        ".env*",
+        "!.env.example"
+      ],
       "env": [
         "APPLE_CLIENT_ID",
         "APPLE_CLIENT_SECRET",
@@ -84,7 +118,15 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "web#build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env*", "!.env.example"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../packages/sentry-client/src/**",
+        "../../packages/sentry-client/package.json",
+        "../../packages/ui/src/**",
+        "../../packages/ui/package.json",
+        ".env*",
+        "!.env.example"
+      ],
       "env": [
         "CI",
         "EDGE_CONFIG",


### PR DESCRIPTION
Promote the current validated staging tree to the protected release branch.

This main-based promotion commit has the exact same Git tree as origin/staging, avoiding history-only merge conflicts while preserving the repository-required rebase promotion path.

The staged milestone is PR #870: shared Radix direct imports plus scoped Turbo inputs, with full local and hosted validation already green.