### PR TITLE
promote: staging to main

### DIFF
--- a/apps/web/src/app/(main)/community/page.tsx
+++ b/apps/web/src/app/(main)/community/page.tsx
@@ -35,6 +35,7 @@ const Community: NextPage = () => {
                 alt="gradient background"
                 width={685}
                 height={685}
+                sizes="685px"
               />
             </div>
             <div className="purple-bg-orb orb-top-right" />

--- a/apps/web/src/app/(main)/lore/page.tsx
+++ b/apps/web/src/app/(main)/lore/page.tsx
@@ -106,6 +106,7 @@ const Lore: NextPage = () => {
               src="/img/hero/satoshi.webp"
               width={556}
               height={589}
+              sizes="100px"
               style={{ objectFit: 'cover', width: '100%', height: 'auto' }}
             />
           </div>
@@ -117,6 +118,7 @@ const Lore: NextPage = () => {
               src="/img/degens/community-characters.webp"
               width={1910}
               height={620}
+              sizes="300px"
               style={{ objectFit: 'cover', width: '100%', height: 'auto' }}
             />
           </div>

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -27,7 +27,7 @@ export default function ViewportVideoBoundary({
   return (
     <>
       <video {...props} ref={videoRef} preload={isNearViewport ? 'metadata' : 'none'}>
-        <source src={src} type="video/mp4" />
+        {hasEnteredViewport || isNearViewport ? <source src={src} type="video/mp4" /> : null}
       </video>
       {hasEnteredViewport || isNearViewport ? (
         <Suspense fallback={null}>

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -32,19 +32,31 @@ describe('ViewportVideo', () => {
     ViewportVideoEnhancer = (await import('./ViewportVideoEnhancer')).default
   })
 
-  it('keeps the video markup server-rendered before playback enhancement', async () => {
+  it('keeps the video shell server-rendered and adds media only near the viewport', async () => {
     state.nearViewport = false
-    const { container, unmount } = render(
+    const deferred = render(
       <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
     )
-    const video = container.querySelector('[data-testid="video"]') as HTMLVideoElement
+    const video = deferred.container.querySelector('[data-testid="video"]') as HTMLVideoElement
 
     expect(video.autoplay).toBe(false)
     expect(video.preload).toBe('none')
-    expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4')
+    expect(video.querySelector('source')).toBeNull()
 
     await waitFor(() => expect(state.observedRootMargin).toBe('0px'))
-    unmount()
+
+    deferred.unmount()
+    state.nearViewport = true
+    const nearViewport = render(
+      <ViewportVideo data-testid="video" src="/video/example.mp4" muted loop playsInline />
+    )
+
+    await waitFor(() =>
+      expect(
+        nearViewport.container.querySelector('[data-testid="video"] source')?.getAttribute('src')
+      ).toBe('/video/example.mp4')
+    )
+    nearViewport.unmount()
   })
 
   it('waits for the viewport by default while preserving explicit prefetch windows', async () => {


### PR DESCRIPTION
## Promotion
Promotes the validated `staging` tree to `main` through the repository release path. The promotion commit was created from `origin/main` and has the exact tree of `origin/staging`.

## Included milestone
- Defer offscreen `ViewportVideo` media sources until the shared viewport gate opens.
- Add fixed-layout `sizes` hints for web artwork to avoid image overfetching.

## Validation
- PR #877 into `staging` passed the ready-PR build, format, lint, type-check, unit, and aggregate gate checks.
- Local app-wide regression audit passed: web 22 tests/build, app 195 tests, Smashers 15 tests, docs 3 tests, UI 167 tests, root lint/type-check/format/build.
- Browser smoke passed for home and games with no console errors and verified deferred video sources after scrolling.

Merge method: rebase, per `.github/CONTRIBUTING.md`.