### PR TITLE
promote: staging to main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.11.2",
         "@nl/eslint-config": "workspace:*",
-        "@nl/prettier-config": "workspace:*",
         "@nl/typescript-config": "workspace:*",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.11.2",
     "@nl/eslint-config": "workspace:*",
-    "@nl/prettier-config": "workspace:*",
     "@nl/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
Promote the exact validated staging tree to main.

The original staging-head promotion PR was clean and fully validated, but GitHub rejected its rebase operation. This clean exact-tree branch contains only the remaining staging delta (the root formatter dependency removal), preserving the validated staging tree without force-pushing protected branches.

Local validation: format, lint, type-check, unit/integration/E2E/smoke, build, and browser route/state audit passed.