### PR TITLE
promote: staging to main

### DIFF
--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -11,6 +11,10 @@ on:
       - 'style/*'
       - 'test/*'
       - 'codex/*'
+      # Promotion branches already have an explicit PR targeting main.
+      - '!codex/promote-*'
+      # Re-alignment creates and owns its own PR after its merge preview.
+      - '!chore/re-align-staging-*'
 
 permissions:
   contents: read

--- a/test/contract/ci-cost-policy.test.ts
+++ b/test/contract/ci-cost-policy.test.ts
@@ -26,6 +26,8 @@ describe('hosted validation cost policy', () => {
     const source = readWorkflow('draft-pr.yml')
 
     expect(source).toContain("      - 'codex/*'")
+    expect(source).toContain("      - '!codex/promote-*'")
+    expect(source).toContain("      - '!chore/re-align-staging-*'")
     expect(source).toContain('base: staging')
   })
 


### PR DESCRIPTION
Promote the exact staging tree to main after the draft-PR utility branch fix.

The staged tree contains only the draft automation exclusions and their contract assertions. Local focused validation passed; this promotion PR will be marked ready after the local promotion diff is confirmed.