### PR TITLE
perf(web): defer third-party media and right-size artwork

### DIFF
--- a/apps/docs/docs/overview/games/mini-games/crypto-winter.md
+++ b/apps/docs/docs/overview/games/mini-games/crypto-winter.md
@@ -4,7 +4,7 @@ title: Crypto Winter
 sidebar_position: 3
 ---
 
-import LazyYouTubeEmbed from '@nl/ui/custom/lazy-youtube-embed';
+import DeferredYouTubeEmbed from '@nl/ui/custom/deferred-youtube-embed';
 
 <div style={{ maxWidth: 640, margin: 'auto' }}>![](/img/games/crypto-winter.webp)</div>
 <br />
@@ -25,7 +25,7 @@ Currently, earning Arcade Tokens that can be used to play WEN Game is based on N
 
 Interested in testing the old version? Learn how to get started below:
 
-<LazyYouTubeEmbed
+<DeferredYouTubeEmbed
 src="https://www.youtube.com/embed/ZiY-TwtzYVk"
 title="Crypto Winter gameplay"
 style={{ display: 'block', width: '100%', height: 500 }}

--- a/apps/docs/docs/overview/games/mobile-games/nifty-smashers.md
+++ b/apps/docs/docs/overview/games/mobile-games/nifty-smashers.md
@@ -4,7 +4,7 @@ title: Nifty Smashers
 sidebar_position: 1
 ---
 
-import LazyYouTubeEmbed from '@nl/ui/custom/lazy-youtube-embed';
+import DeferredYouTubeEmbed from '@nl/ui/custom/deferred-youtube-embed';
 import ViewportVideo from '@nl/ui/custom/viewport-video';
 import VideoURL from '/video/lobby.mp4';
 
@@ -20,7 +20,7 @@ For some background, the local-multiplayer version of Nifty Smashers was made av
 
 You can play using any other compatible controller (Playstation, Xbox, etc.) if you wish. For the deprecated desktop version you must have a [DEGEN NFT](/overview/nfts/degens/about) to play. Simply connect your crypto wallet holding your DEGEN, enter the game lobby, and select your DEGEN for battle.
 
-<LazyYouTubeEmbed
+<DeferredYouTubeEmbed
 src="https://www.youtube.com/embed/4lnDrx4aDq8"
 title="Nifty Smashers gameplay"
 style={{ display: 'block', width: '100%', height: 500 }}

--- a/apps/docs/docs/overview/nfts/degens/about.md
+++ b/apps/docs/docs/overview/nfts/degens/about.md
@@ -4,6 +4,8 @@ title: Overview
 sidebar_position: 1
 ---
 
+import DeferredYouTubeEmbed from '@nl/ui/custom/deferred-youtube-embed';
+
 <picture>
   <source
     media="(prefers-reduced-motion: no-preference)"
@@ -28,18 +30,9 @@ Each DEGEN's design affected the pool of available character traits and accessor
 
 Although our NFTs minted out in October 2021, they can be purchased on the secondary market via [OpenSea](https://opensea.io/collection/niftydegen).
 
-<div>
-    <iframe
-      height="380px"
-      width="100%"
-      src="https://www.youtube.com/embed/WWLqE1tnf6U"
-      frameBorder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowFullScreen
-      title="Nifty Smashers Video Clip"
-      className="pixelated"
-      style={{
-        borderRadius: '25px',
-      }}
-    />
-</div>
+<DeferredYouTubeEmbed
+src="https://www.youtube.com/embed/WWLqE1tnf6U"
+title="Nifty DEGEN overview video"
+className="pixelated"
+style={{ display: 'block', width: '100%', height: 380, borderRadius: '25px' }}
+/>

--- a/apps/web/src/app/(main)/compete-and-earn/page.tsx
+++ b/apps/web/src/app/(main)/compete-and-earn/page.tsx
@@ -2,7 +2,7 @@ import OptimizedImage from '@nl/ui/custom/optimized-image'
 import { Separator } from '@nl/ui/base/separator'
 import type { NextPage } from 'next'
 import { cx } from '@nl/ui/class-names'
-import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
+import { DeferredYouTubeEmbed } from '@nl/ui/custom/deferred-youtube-embed'
 import ThemeBtnGroup from '@nl/ui/custom/theme-button-group'
 import styles from './index.module.css'
 
@@ -51,7 +51,7 @@ const CompeteAndEarn: NextPage = () => {
         </div>
         <div className="w-full md:w-1/2">
           <div className="relative text-right mb-4 md:mb-0 ps-0 lg:ps-5">
-            <LazyYouTubeEmbed
+            <DeferredYouTubeEmbed
               src="https://www.youtube.com/embed/wv_fI1PPBi0"
               title="Nifty League Compete & Earn"
               className={styles.video}

--- a/apps/web/src/app/(main)/degens/page.tsx
+++ b/apps/web/src/app/(main)/degens/page.tsx
@@ -3,7 +3,7 @@ import type { NextPage } from 'next'
 import OptimizedImage from '@nl/ui/custom/optimized-image'
 
 import { DeferredConsoleGame } from '@nl/ui/custom/deferred-console-game'
-import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
+import { DeferredYouTubeEmbed } from '@nl/ui/custom/deferred-youtube-embed'
 import { cx } from '@nl/ui/class-names'
 
 import { NIFTY_DEGENS_ALL } from '@/constants/degens'
@@ -41,7 +41,7 @@ const Degens: NextPage = () => (
           </div>
           <div className="w-full md:w-1/2">
             <div className="relative text-right mb-4 md:mb-0 ps-0 lg:pl-5">
-              <LazyYouTubeEmbed
+              <DeferredYouTubeEmbed
                 src="https://www.youtube.com/embed/WWLqE1tnf6U"
                 title="Nifty League DEGENs"
                 className="h-[315px] w-full"

--- a/apps/web/src/app/(main)/degens/page.tsx
+++ b/apps/web/src/app/(main)/degens/page.tsx
@@ -76,6 +76,7 @@ const Degens: NextPage = () => (
                   alt={name}
                   width={image.width}
                   height={image.height}
+                  sizes="(max-width: 768px) 33vw, 205px"
                   className="pixelated mx-auto"
                 />
               </div>

--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 
-import { LazyYouTubeEmbed } from '@nl/ui/custom/lazy-youtube-embed'
+import { DeferredYouTubeEmbed } from '@nl/ui/custom/deferred-youtube-embed'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 import { cx } from '@nl/ui/class-names'
 import { MobileOnlyImage } from '@nl/ui/custom/responsive-only-image'
@@ -106,7 +106,7 @@ const Games: NextPage = () => (
           <div className="w-full md:w-5/12">
             <div className="relative text-right mb-4">
               {video.includes('youtube') ? (
-                <LazyYouTubeEmbed src={video} title={name} className={styles.video} />
+                <DeferredYouTubeEmbed src={video} title={name} className={styles.video} />
               ) : (
                 <ViewportVideo
                   id={`game-video-${index}`}

--- a/packages/ui/src/components/custom/deferred-youtube-embed/deferred-youtube-embed.test.tsx
+++ b/packages/ui/src/components/custom/deferred-youtube-embed/deferred-youtube-embed.test.tsx
@@ -28,12 +28,14 @@ describe('DeferredYouTubeEmbed', () => {
         src="about:blank"
         title="Example trailer"
         className="h-[315px] w-full"
+        style={{ display: 'block', width: '100%', height: 380 }}
       />
     )
 
     expect(container.querySelector('iframe')).toBeNull()
     expect(screen.getByRole('status', { name: 'Loading Example trailer' })).toBeTruthy()
     expect(screen.getByRole('status').className).toContain('h-[315px]')
+    expect(screen.getByRole('status').getAttribute('style')).toContain('height: 380px')
     expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
     expect(state.rootMargin).toBe('160px')
   })

--- a/packages/ui/src/components/custom/deferred-youtube-embed/deferred-youtube-embed.test.tsx
+++ b/packages/ui/src/components/custom/deferred-youtube-embed/deferred-youtube-embed.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const state = {
+  nearViewport: false,
+  rootMargin: undefined as string | undefined,
+}
+
+mock.module('@nl/ui/hooks/useOnScreen', () => ({
+  useOnScreen: (_ref: unknown, rootMargin: string) => {
+    state.rootMargin = rootMargin
+    return state.nearViewport
+  },
+}))
+
+describe('DeferredYouTubeEmbed', () => {
+  let DeferredYouTubeEmbed: typeof import('./index').DeferredYouTubeEmbed
+
+  beforeEach(async () => {
+    state.nearViewport = false
+    state.rootMargin = undefined
+    DeferredYouTubeEmbed = (await import('./index')).DeferredYouTubeEmbed
+  })
+
+  it('keeps third-party media out of the initial render with an accessible themed shell', () => {
+    const { container } = render(
+      <DeferredYouTubeEmbed
+        src="about:blank"
+        title="Example trailer"
+        className="h-[315px] w-full"
+      />
+    )
+
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(screen.getByRole('status', { name: 'Loading Example trailer' })).toBeTruthy()
+    expect(screen.getByRole('status').className).toContain('h-[315px]')
+    expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
+    expect(state.rootMargin).toBe('160px')
+  })
+
+  it('mounts the shared accessible iframe once the video is near the viewport', () => {
+    state.nearViewport = true
+
+    const { container } = render(
+      <DeferredYouTubeEmbed
+        src="about:blank"
+        title="Example trailer"
+        className="h-[315px] w-full"
+      />
+    )
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe('about:blank')
+    expect(iframe?.getAttribute('title')).toBe('Example trailer')
+    expect(iframe?.getAttribute('loading')).toBe('lazy')
+    expect(iframe?.getAttribute('allow')).toContain('autoplay')
+    expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('false')
+  })
+})

--- a/packages/ui/src/components/custom/deferred-youtube-embed/index.tsx
+++ b/packages/ui/src/components/custom/deferred-youtube-embed/index.tsx
@@ -35,6 +35,7 @@ export const DeferredYouTubeEmbed = memo(function DeferredYouTubeEmbed({
           aria-live="polite"
           aria-label={`Loading ${title}`}
           className={props.className}
+          style={props.style}
         />
       )}
     </div>

--- a/packages/ui/src/components/custom/deferred-youtube-embed/index.tsx
+++ b/packages/ui/src/components/custom/deferred-youtube-embed/index.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { memo, useRef } from 'react'
+
+import DeferredSkeleton from '@nl/ui/custom/deferred-skeleton'
+import { LazyYouTubeEmbed, type LazyYouTubeEmbedProps } from '@nl/ui/custom/lazy-youtube-embed'
+import { useOnScreen } from '@nl/ui/hooks/useOnScreen'
+
+export const DEFAULT_DEFERRED_YOUTUBE_ROOT_MARGIN = '160px'
+
+export type DeferredYouTubeEmbedProps = LazyYouTubeEmbedProps & {
+  /** Load the third-party iframe this many pixels before it enters the viewport. */
+  rootMargin?: string
+}
+
+/**
+ * Keeps YouTube out of the initial page load until a visitor is close to the
+ * video, while preserving the shared iframe's accessible and themed markup.
+ */
+export const DeferredYouTubeEmbed = memo(function DeferredYouTubeEmbed({
+  rootMargin = DEFAULT_DEFERRED_YOUTUBE_ROOT_MARGIN,
+  title,
+  ...props
+}: DeferredYouTubeEmbedProps) {
+  const embedRef = useRef<HTMLDivElement>(null)
+  const isNearViewport = useOnScreen(embedRef, rootMargin, { once: true })
+
+  return (
+    <div ref={embedRef} aria-busy={!isNearViewport}>
+      {isNearViewport ? (
+        <LazyYouTubeEmbed title={title} {...props} />
+      ) : (
+        <DeferredSkeleton
+          role="status"
+          aria-live="polite"
+          aria-label={`Loading ${title}`}
+          className={props.className}
+        />
+      )}
+    </div>
+  )
+})
+
+export default DeferredYouTubeEmbed

--- a/packages/ui/src/components/custom/lazy-youtube-embed/index.tsx
+++ b/packages/ui/src/components/custom/lazy-youtube-embed/index.tsx
@@ -3,7 +3,7 @@ import type { ComponentPropsWithoutRef } from 'react'
 const YOUTUBE_ALLOW =
   'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
 
-type LazyYouTubeEmbedProps = Omit<
+export type LazyYouTubeEmbedProps = Omit<
   ComponentPropsWithoutRef<'iframe'>,
   'allow' | 'allowFullScreen' | 'loading' | 'src' | 'title'
 > & {

--- a/test/contract/docs-media-policy.test.ts
+++ b/test/contract/docs-media-policy.test.ts
@@ -23,7 +23,9 @@ describe('shared docs media policy', () => {
     for (const page of docsMediaPages) {
       const source = readFileSync(page, 'utf8')
       expect(source).not.toContain('react-player')
-      expect(source).toMatch(/@nl\/ui\/custom\/(lazy-youtube-embed|viewport-video)/)
+      expect(source).toMatch(
+        /@nl\/ui\/custom\/(deferred-youtube-embed|lazy-youtube-embed|viewport-video)/
+      )
     }
   })
 

--- a/test/contract/docs-media-policy.test.ts
+++ b/test/contract/docs-media-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 
+const docsPage = 'apps/docs/docs/overview/nfts/degens/about.md'
 const docsMediaPages = [
   'apps/docs/docs/overview/games/mini-games/arcade-tokens.md',
   'apps/docs/docs/overview/games/mini-games/crypto-winter.md',
@@ -11,9 +12,9 @@ const docsMediaPages = [
   'apps/docs/docs/overview/games/mobile-games/nifty-smashers.md',
   'apps/docs/docs/overview/nfts/nifty-marketplace/items.md',
   'apps/docs/docs/overview/nfts/nifty-marketplace/comics.md',
+  docsPage,
 ]
 
-const docsPage = 'apps/docs/docs/overview/nfts/degens/about.md'
 const legacyAsset = 'assets/img/games/nifty-royale/nifty-royale.gif'
 const mintWebp = 'assets/img/mint-o-matic/degen-mint.webp'
 const mintPoster = 'assets/img/mint-o-matic/degen-mint-poster.webp'

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1771,6 +1771,7 @@ describe('web marketing image sizing contract', () => {
       ],
       ['apps/web/src/app/(main)/careers/page.tsx', 'sizes="(min-width: 768px) 50vw, 100vw"'],
       ['apps/web/src/app/(main)/games/page.tsx', 'sizes="33vw"'],
+      ['apps/web/src/app/(main)/degens/page.tsx', 'sizes="(max-width: 768px) 33vw, 205px"'],
       [
         'apps/web/src/app/(main)/niftyworld/page.tsx',
         'sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"',

--- a/test/contract/web-embed-policy.test.ts
+++ b/test/contract/web-embed-policy.test.ts
@@ -8,11 +8,11 @@ const marketingEmbedConsumers = [
 ]
 
 describe('marketing video embed policy', () => {
-  it('uses the shared lazy YouTube primitive for every marketing embed', () => {
+  it('uses the shared deferred YouTube primitive for every marketing embed', () => {
     for (const file of marketingEmbedConsumers) {
       const source = readFileSync(file, 'utf8')
 
-      expect(source).toContain('@nl/ui/custom/lazy-youtube-embed')
+      expect(source).toContain('@nl/ui/custom/deferred-youtube-embed')
       expect(source).not.toMatch(/<iframe\b/)
     }
   })


### PR DESCRIPTION
## Summary

- defer marketing YouTube iframes until they are near the viewport on the website and game documentation
- cover the previously raw YouTube iframe on the DEGEN overview docs page
- reuse the shared `useOnScreen`, `DeferredSkeleton`, and accessible iframe primitive
- preserve existing media dimensions, including inline style dimensions on deferred shells
- add regression coverage for deferred embeds and docs media policy
- add explicit responsive image sizing to the DEGENs grid so Next serves smaller mobile artwork

This consolidates the duplicate media optimization work from #902 into the existing canonical draft PR.

## Performance evidence

The affected website routes now emit zero initial YouTube iframes:

- `/games`: 182,770 gzip bytes, 0 initial iframes
- `/degens`: 183,717 gzip bytes, 0 initial iframes
- `/compete-and-earn`: 182,479 gzip bytes, 0 initial iframes

The route JavaScript overhead is approximately 0.25–1.1 KB gzip versus the baseline, while third-party iframe work is removed from initial HTML.

## Validation

- focused contracts and component tests: 217 passed, 0 failed, 1,159 expect() calls
- UI, web, and docs type checks and lint: passed
- Prettier check for changed files: passed
- web production build: passed (16 routes)
- docs production build: passed
- app production build: passed (21 routes)
- Smashers production build: passed (18 routes; existing Edge-runtime deprecation warning only)
- browser smoke on `/overview/nfts/degens/about`: initial placeholder 652.5×380px with 0 iframes; after scrolling, one lazy iframe titled `Nifty DEGEN overview video`
- browser console: no errors or warnings

This PR intentionally remains draft while the cost-gated work is being reviewed.