### PR TITLE
perf(ui): lower priority for lazy artwork

### DIFF
--- a/packages/ui/src/components/custom/optimized-image/index.tsx
+++ b/packages/ui/src/components/custom/optimized-image/index.tsx
@@ -15,6 +15,12 @@ export function getOptimizedImageProps(props: OptimizedImageProps) {
     imgConf: imageConfig,
   }).props
 
+  // Keep below-the-fold artwork from competing with the route's LCP resource.
+  // Respect explicit priorities for hero and above-the-fold images.
+  if (imageProps.loading === 'lazy' && imageProps.fetchPriority === undefined) {
+    imageProps.fetchPriority = 'low'
+  }
+
   for (const [key, value] of Object.entries(imageProps)) {
     if (value === undefined) delete imageProps[key as keyof typeof imageProps]
   }

--- a/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
+++ b/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getOptimizedImageProps } from './index'
+
+describe('getOptimizedImageProps', () => {
+  const baseProps = {
+    alt: 'Artwork',
+    height: 200,
+    src: 'https://example.com/img/artwork.webp',
+    unoptimized: true,
+    width: 300,
+  } as const
+
+  it('gives lazy artwork a low network priority', () => {
+    const props = getOptimizedImageProps({ ...baseProps, loading: 'lazy' })
+
+    expect(props.loading).toBe('lazy')
+    expect(props.fetchPriority).toBe('low')
+  })
+
+  it('preserves explicit priority and eager image behavior', () => {
+    const highPriority = getOptimizedImageProps({
+      ...baseProps,
+      fetchPriority: 'high',
+      loading: 'lazy',
+    })
+    const eager = getOptimizedImageProps({ ...baseProps, loading: 'eager' })
+
+    expect(highPriority.fetchPriority).toBe('high')
+    expect(eager.fetchPriority).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- assigns fetchPriority="low" to lazy images from the shared OptimizedImage helper
- preserves explicit hero/high priorities and eager image behavior
- adds regression coverage for scheduling behavior

## Measured impact
- current web homepage build: 28 lazy images, all explicitly low priority
- hero remains high priority
- no route HTML, image dimensions, loader, or theme markup changes

## Validation
- UI full suite: 168 passed, 0 failed
- contract tests: 245 passed, 0 failed
- UI/web/app/Smashers type-check and lint passed
- web build: 16 routes passed
- app build: 21 routes passed
- Smashers build: 18 routes passed
- browser smoke on http://amf-mb-pro:3369/: meaningful page, no browser console errors/warnings, screenshot preserved hero/navbar; scroll preserved dark navbar transition
- git diff --check and Prettier passed

This remains a draft intentionally so hosted CI and Vercel stay gated until the milestone is ready.