### PR TITLE
perf(app): defer Blocknative notifications

### DIFF
--- a/apps/app/src/hooks/useNotify.test.ts
+++ b/apps/app/src/hooks/useNotify.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+let bncNotifyLoaded = false
+const sendTransactionMock = mock()
+const notifyFactory = mock(() => ({ hash: mock(() => ({ emitter: { on: mock() } })) }))
+
+mock.module('bnc-notify', () => {
+  bncNotifyLoaded = true
+  return { default: notifyFactory }
+})
+
+mock.module('@/utils/bnc-notify', () => ({
+  handleError: mock(),
+  handleLocalNotify: mock(),
+  sendTransaction: sendTransactionMock,
+}))
+
+mock.module('@/constants/networks', () => ({
+  TARGET_NETWORK: { blockExplorer: 'https://example.com', chainId: 1 },
+  VALID_NOTIFY_NETWORKS: [1],
+}))
+
+mock.module('@/constants/index', () => ({ DEBUG: false }))
+
+describe('useNotify', () => {
+  let useNotify: typeof import('./useNotify').default
+
+  beforeEach(async () => {
+    bncNotifyLoaded = false
+    sendTransactionMock.mockReset()
+    notifyFactory.mockClear()
+    useNotify = (await import('./useNotify')).default
+  })
+
+  it('does not load Blocknative until a transaction is submitted', () => {
+    renderHook(() => useNotify({} as never))
+
+    expect(bncNotifyLoaded).toBe(false)
+  })
+
+  it('loads Blocknative when a transaction is submitted', async () => {
+    const transaction = {
+      hash: '0xsubmitted',
+      wait: mock().mockResolvedValue(undefined),
+    }
+    sendTransactionMock.mockResolvedValue(transaction)
+    const { result } = renderHook(() => useNotify({} as never))
+
+    await act(async () => {
+      await result.current(Promise.resolve({}) as never)
+    })
+
+    expect(bncNotifyLoaded).toBe(true)
+    expect(sendTransactionMock).toHaveBeenCalled()
+  })
+})

--- a/apps/app/src/hooks/useNotify.ts
+++ b/apps/app/src/hooks/useNotify.ts
@@ -1,7 +1,7 @@
 'use client'
 /* eslint-disable no-console */
 import { useCallback } from 'react'
-import Notify, { API, InitOptions } from 'bnc-notify'
+import type { API, InitOptions } from 'bnc-notify'
 import type { JsonRpcSigner } from 'ethers'
 
 import { handleError, handleLocalNotify, sendTransaction } from '@/utils/bnc-notify'
@@ -16,38 +16,35 @@ const ETHERSCAN_TX_URL = `${TARGET_NETWORK.blockExplorer}/tx/`
 
 const callbacks: { [hash: string]: NotifyCallback } = {}
 
-const initializeNotify = (darkMode: boolean): API | null => {
-  let options: InitOptions
-  let notify: API | null = null
-  if (navigator.onLine) {
-    options = {
-      dappId: process.env.NEXT_PUBLIC_BLOCKNATIVE_DAPPID, // GET YOUR OWN KEY AT https://account.blocknative.com
-      system: 'ethereum',
-      networkId: TARGET_NETWORK.chainId,
-      darkMode,
-      transactionHandler: (txInformation) => {
-        const txData = (txInformation as TransactionEvent).transaction
-        if (DEBUG)
-          console.log(`HANDLE TX ${txData.status?.toString().toUpperCase()}`, txInformation)
-        const possibleFunction = txData.hash && callbacks[txData.hash]
-        if (typeof possibleFunction === 'function') possibleFunction(txData)
-      },
-      onerror: (e: NotifyError) => {
-        handleError(e)
-      },
-    }
-    notify = Notify(options)
+const initializeNotify = async (darkMode: boolean): Promise<API | null> => {
+  if (!navigator.onLine) return null
+
+  const { default: Notify } = await import('bnc-notify')
+  const options: InitOptions = {
+    dappId: process.env.NEXT_PUBLIC_BLOCKNATIVE_DAPPID, // GET YOUR OWN KEY AT https://account.blocknative.com
+    system: 'ethereum',
+    networkId: TARGET_NETWORK.chainId,
+    darkMode,
+    transactionHandler: (txInformation) => {
+      const txData = (txInformation as TransactionEvent).transaction
+      if (DEBUG) console.log(`HANDLE TX ${txData.status?.toString().toUpperCase()}`, txInformation)
+      const possibleFunction = txData.hash && callbacks[txData.hash]
+      if (typeof possibleFunction === 'function') possibleFunction(txData)
+    },
+    onerror: (e: NotifyError) => {
+      handleError(e)
+    },
   }
-  return notify
+
+  return Notify(options)
 }
 
 export default function useNotify(signer?: JsonRpcSigner, darkMode = true): Tx {
   return useCallback(
     async (tx, callback) => {
       if (typeof signer !== 'undefined') {
-        const notify = initializeNotify(darkMode)
-
         try {
+          const notify = await initializeNotify(darkMode)
           const result = await sendTransaction(signer, tx)
           if (callback) callbacks[result.hash] = callback
 


### PR DESCRIPTION
## Summary
- defer the `bnc-notify` browser dependency until a transaction is submitted
- keep existing transaction and fallback notification behavior unchanged
- add a regression test for the deferred load boundary and transaction activation

## Measured impact
- Before: `bnc-notify/dist/notify.js` was a synchronous dependency of `useNotify` and contributed about 124 KB of raw client source to the analyzed dashboard route.
- After: the same module is in an async dependency edge from `useNotify` and its 124 KB source is emitted in a separate client chunk (`0a_0zvevqwvkn.js`).
- This removes Blocknative from the initial synchronous graph; it still loads on the first submitted transaction.

## Validation
- `bun test --isolate --preload ../../test/happy-dom-setup.ts --preload ../../test/preload.ts --preload ../../test/setup.ts src/hooks/useNotify.test.ts`
- `bun run test` in `apps/app` — 226 passed, 0 failed
- `bun run build` in `apps/app` — passed, 21 routes generated; warm-cache wall time 13.73s
- `bun run format:check` — passed
- `bun run type-check` — 10/10 packages passed
- `bun run lint` — 10/10 packages passed with existing warnings only

The draft is intentionally cost-aware; I will mark it ready only after the focused milestone is complete.
