### PR TITLE
perf(smashers): optimize party modes poster delivery

### DIFF
--- a/apps/smashers/src/components/GameSection/index.tsx
+++ b/apps/smashers/src/components/GameSection/index.tsx
@@ -53,7 +53,6 @@ const GameSection = () => {
           width={1350}
           height={566}
           className="w-full h-auto rounded-[40px]"
-          unoptimized
           loading="lazy"
           sizes="(max-width: 768px) 100vw, 1350px"
         />

--- a/test/contract/smashers-assets.test.ts
+++ b/test/contract/smashers-assets.test.ts
@@ -49,6 +49,7 @@ describe('Smashers asset delivery contracts', () => {
     expect(gameSection).toContain('party_modes-poster.webp')
     expect(gameSection).toContain('prefers-reduced-motion: no-preference')
     expect(gameSection).toContain('height={566}')
+    expect(gameSection).not.toContain('unoptimized')
     expect(gameSection).not.toContain('party_modes.gif')
   })
 


### PR DESCRIPTION
## Summary
- remove the stale `unoptimized` bypass from the below-fold party modes poster
- keep the existing responsive source, dimensions, lazy loading, and motion fallback unchanged
- add a contract guard against reintroducing the bypass

## Validation
- `bun test test/contract/smashers-assets.test.ts`
- `bun run test` (apps/smashers)
- `bun run type-check` (apps/smashers)
- `bun run lint` (apps/smashers)
- `env NEXTAUTH_SECRET=local-build-validation-secret-32-characters bun run build` (apps/smashers)
- `bunx prettier --check ...`

Draft until the next performance milestone is finalized.