### PR TITLE
perf(web): defer Games lobby video loading

### DIFF
--- a/apps/web/src/app/(main)/games/page.tsx
+++ b/apps/web/src/app/(main)/games/page.tsx
@@ -26,6 +26,8 @@ const Games: NextPage = () => {
               playsInline
               data-keepplaying
               className="hidden md:block"
+              deferLoad
+              poster="/img/games/smashers/lobby.webp"
               src="/video/lobby.mp4"
             />
             <div className="block md:hidden">

--- a/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
+++ b/packages/ui/src/components/custom/viewport-video/ViewportVideoBoundary.tsx
@@ -11,7 +11,29 @@ const ViewportVideoEnhancer = lazy<ComponentType<ViewportVideoEnhancerProps>>(
   () => import('./ViewportVideoEnhancer')
 )
 
+const DEFERRED_VIDEO_LOAD_DELAY_MS = 750
+
+function scheduleDeferredLoad(callback: () => void): () => void {
+  let idleCallbackId: number | undefined
+  const delayId = window.setTimeout(() => {
+    if ('requestIdleCallback' in window) {
+      idleCallbackId = window.requestIdleCallback(callback, { timeout: 1500 })
+      return
+    }
+
+    callback()
+  }, DEFERRED_VIDEO_LOAD_DELAY_MS)
+
+  return () => {
+    window.clearTimeout(delayId)
+    if (idleCallbackId !== undefined && 'cancelIdleCallback' in window) {
+      window.cancelIdleCallback(idleCallbackId)
+    }
+  }
+}
+
 export default function ViewportVideoBoundary({
+  deferLoad = false,
   playOnViewport = true,
   rootMargin = DEFAULT_VIEWPORT_VIDEO_ROOT_MARGIN,
   src,
@@ -20,17 +42,28 @@ export default function ViewportVideoBoundary({
   const videoRef = useRef<HTMLVideoElement>(null)
   const [hasEnteredViewport, setHasEnteredViewport] = useState(false)
   const isNearViewport = useOnScreen(videoRef, rootMargin)
+  const shouldRenderMedia = hasEnteredViewport || (isNearViewport && !deferLoad)
 
   useEffect(() => {
-    if (isNearViewport) setHasEnteredViewport(true)
-  }, [isNearViewport])
+    if (!isNearViewport || hasEnteredViewport) return
+    if (!deferLoad) {
+      setHasEnteredViewport(true)
+      return
+    }
+
+    return scheduleDeferredLoad(() => setHasEnteredViewport(true))
+  }, [deferLoad, hasEnteredViewport, isNearViewport])
 
   return (
     <>
-      <video {...props} ref={videoRef} preload={isNearViewport ? 'metadata' : 'none'}>
-        {hasEnteredViewport || isNearViewport ? <source src={src} type="video/mp4" /> : null}
+      <video
+        {...props}
+        ref={videoRef}
+        preload={shouldRenderMedia && isNearViewport ? 'metadata' : 'none'}
+      >
+        {shouldRenderMedia ? <source src={src} type="video/mp4" /> : null}
       </video>
-      {hasEnteredViewport || isNearViewport ? (
+      {shouldRenderMedia ? (
         <Suspense fallback={null}>
           <ViewportVideoEnhancer
             isNearViewport={isNearViewport}

--- a/packages/ui/src/components/custom/viewport-video/index.tsx
+++ b/packages/ui/src/components/custom/viewport-video/index.tsx
@@ -9,6 +9,8 @@ export type ViewportVideoProps = Omit<
 > & {
   /** Automatically play while the video is near the viewport. */
   playOnViewport?: boolean
+  /** Defer loading a visible video until the browser has had idle time. */
+  deferLoad?: boolean
   rootMargin?: string
   src: string
 }
@@ -16,6 +18,7 @@ export type ViewportVideoProps = Omit<
 export { DEFAULT_VIEWPORT_VIDEO_ROOT_MARGIN }
 
 export const ViewportVideo = memo(function ViewportVideo({
+  deferLoad = false,
   playOnViewport = true,
   rootMargin = DEFAULT_VIEWPORT_VIDEO_ROOT_MARGIN,
   src,
@@ -23,6 +26,7 @@ export const ViewportVideo = memo(function ViewportVideo({
 }: ViewportVideoProps) {
   return (
     <ViewportVideoBoundary
+      deferLoad={deferLoad}
       playOnViewport={playOnViewport}
       rootMargin={rootMargin}
       src={src}

--- a/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
+++ b/packages/ui/src/components/custom/viewport-video/viewport-video.test.tsx
@@ -69,6 +69,28 @@ describe('ViewportVideo', () => {
     await waitFor(() => expect(state.observedRootMargin).toBe('300px'))
   })
 
+  it('can defer an above-the-fold video until the browser is idle', async () => {
+    const deferred = render(
+      <ViewportVideo
+        data-testid="video"
+        deferLoad
+        poster="/img/video-poster.webp"
+        src="/video/example.mp4"
+      />
+    )
+    const video = deferred.container.querySelector('[data-testid="video"]') as HTMLVideoElement
+
+    expect(video.getAttribute('deferload')).toBeNull()
+    expect(video.getAttribute('poster')).toBe('/img/video-poster.webp')
+    expect(video.querySelector('source')).toBeNull()
+
+    await waitFor(
+      () => expect(video.querySelector('source')?.getAttribute('src')).toBe('/video/example.mp4'),
+      { timeout: 2000 }
+    )
+    deferred.unmount()
+  })
+
   it('only enables playback and metadata loading near the viewport', async () => {
     function PlaybackHarness() {
       const videoRef = useRef<HTMLVideoElement>(null)

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -2151,8 +2151,12 @@ describe('public route dependency contract', () => {
     expect(constants).toContain("DEFAULT_VIEWPORT_VIDEO_ROOT_MARGIN = '0px 0px -25% 0px'")
     expect(boundary).toContain('lazy<ComponentType<ViewportVideoEnhancerProps>>(')
     expect(boundary).toContain('rootMargin = DEFAULT_VIEWPORT_VIDEO_ROOT_MARGIN')
-    expect(boundary).toContain("preload={isNearViewport ? 'metadata' : 'none'}")
-    expect(boundary).toContain('hasEnteredViewport || isNearViewport')
+    expect(boundary).toContain(
+      "preload={shouldRenderMedia && isNearViewport ? 'metadata' : 'none'}"
+    )
+    expect(boundary).toContain(
+      'const shouldRenderMedia = hasEnteredViewport || (isNearViewport && !deferLoad)'
+    )
     expect(enhancer).not.toContain("from '@nl/ui/hooks/useOnScreen'")
     expect(enhancer).toContain('isNearViewport: boolean')
     expect(enhancer).toContain("from '@nl/ui/hooks/useMediaQuery'")


### PR DESCRIPTION
## Summary
- add an opt-in idle-load path to the shared ViewportVideo primitive
- use a poster and deferred loading for the Games lobby video
- preserve default viewport playback behavior for existing callers

## Validation
- shared UI test suite: 174 passed
- website test suite: 45 passed
- website type-check: passed
- website production build: passed
- browser verification: poster loaded before the lobby video; video request began around 910ms after navigation

## Cost control
This PR is intentionally focused and draft-first; hosted validation should only start after it is marked ready.