### PR TITLE
perf(app): narrow generated contract type graph

### DIFF
--- a/apps/app/src/types/web3.ts
+++ b/apps/app/src/types/web3.ts
@@ -11,14 +11,12 @@ import type {
 import type { Abi } from 'viem'
 import type { Config } from 'wagmi'
 
-import type {
-  BalanceManagerDistributor,
-  NFTL,
-  NFTLToken,
-  NiftyBurningComicsL2,
-  NiftyDegen,
-  NiftyMarketplace,
-} from '@/types/typechain'
+import type { BalanceManagerDistributor } from '@/types/typechain/src/contracts/imx/BalanceManagerDistributor'
+import type { NFTL } from '@/types/typechain/src/contracts/imx/NFTL'
+import type { NiftyMarketplace } from '@/types/typechain/src/contracts/imx/NiftyMarketplace'
+import type { NiftyBurningComicsL2 } from '@/types/typechain/src/contracts/deprecated/NiftyBurningComicsL2'
+import type { NFTLToken } from '@/types/typechain/src/contracts/NFTLToken'
+import type { NiftyDegen } from '@/types/typechain/src/contracts/NiftyDegen'
 
 import {
   BALANCE_MANAGER_CONTRACT,

--- a/apps/app/src/utils/interchainTokenService.ts
+++ b/apps/app/src/utils/interchainTokenService.ts
@@ -17,7 +17,7 @@ import {
 } from '@/constants/contracts'
 import { SEPOLIA_ID, MAINNET_ID, IMX_TESTNET_ID, NETWORK_NAME } from '@/constants/networks'
 import { DEBUG } from '@/constants'
-import type { NFTLToken } from '@/types/typechain'
+import type { NFTLToken } from '@/types/typechain/src/contracts/NFTLToken'
 import type { Contracts } from '@/types/web3'
 
 type GasFeeResponse = {

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -6,5 +6,5 @@
     "plugins": [{ "name": "next" }]
   },
   "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", "next.config.ts", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "src/types/typechain/**"]
 }

--- a/test/contract/app-performance.test.ts
+++ b/test/contract/app-performance.test.ts
@@ -7,6 +7,9 @@ const appGasUtility = 'apps/app/src/utils/gas.ts'
 const retiredAxiosUtility = 'apps/app/src/utils/axios.ts'
 const appGraphQLUtility = 'apps/app/src/utils/graphql.ts'
 const appNextConfig = 'apps/app/next.config.ts'
+const appTsConfig = 'apps/app/tsconfig.json'
+const appWeb3Types = 'apps/app/src/types/web3.ts'
+const appInterchainService = 'apps/app/src/utils/interchainTokenService.ts'
 const deferredNicknameForm =
   'apps/app/src/app/(private-routes)/dashboard/rentals/ChangeNicknameDialog.tsx'
 const deferredProfileNameForm =
@@ -362,6 +365,20 @@ describe('app performance contracts', () => {
     for (const file of incrementalTypecheckConfigs) {
       expect(readFileSync(file, 'utf8')).toContain('"incremental": true')
     }
+  })
+
+  it('keeps generated contract types out of the default app program and avoids the barrel graph', () => {
+    const tsConfig = readFileSync(appTsConfig, 'utf8')
+    expect(tsConfig).toContain('src/types/typechain/**')
+
+    for (const file of [appWeb3Types, appInterchainService]) {
+      const source = readFileSync(file, 'utf8')
+      expect(source).not.toContain("from '@/types/typechain'")
+    }
+    expect(readFileSync(appWeb3Types, 'utf8')).toContain('@/types/typechain/src/contracts/imx/NFTL')
+    expect(readFileSync(appInterchainService, 'utf8')).toContain(
+      '@/types/typechain/src/contracts/NFTLToken'
+    )
   })
 
   it('keeps the app gas-price path on native fetch without a retired Axios wrapper', () => {


### PR DESCRIPTION
## Summary
- exclude generated TypeChain sources from the default app TypeScript program
- replace the TypeChain barrel imports with direct type-only imports
- add a performance contract preventing the barrel graph from returning

## Evidence
- app TypeScript program: 5,267 files / 408 TypeChain files -> 4,866 files / 7 reachable TypeChain files
- cold `app#build`: 33.5s baseline -> 18.8s on this branch
- focused contract tests, app lint, app type-check, and production build pass

## Validation
- `bun test test/contract/app-performance.test.ts test/contract/turbo-cache-scope.test.ts`
- `cd apps/app && bun run lint`
- `cd apps/app && bun run type-check`
- `bunx turbo run app#build --force`
- `bun run build`

The full app test command still has the repository's existing 63 duplicate-React failures under Bun/Testing Library; the failures are unrelated to this type-only graph change.
