### PR TITLE
perf(ui): preserve priority image hints

### DIFF
--- a/packages/ui/src/components/custom/optimized-image/index.tsx
+++ b/packages/ui/src/components/custom/optimized-image/index.tsx
@@ -10,10 +10,19 @@ export type OptimizedImageProps = ImageProps
 const imageConfig = process.env.__NEXT_IMAGE_OPTS as unknown as ImageConfigComplete
 
 export function getOptimizedImageProps(props: OptimizedImageProps) {
-  const imageProps = getImgProps(props, {
+  const { props: imageProps, meta } = getImgProps(props, {
     defaultLoader,
     imgConf: imageConfig,
-  }).props
+  })
+
+  // The native <img> renderer cannot consume Next's preload metadata. Carry
+  // its priority signal across as standard browser hints instead of silently
+  // dropping it when the shared primitive avoids the stateful next/image
+  // client component.
+  if (meta.preload) {
+    imageProps.loading ??= 'eager'
+    imageProps.fetchPriority ??= 'high'
+  }
 
   // Keep below-the-fold artwork from competing with the route's LCP resource.
   // Respect explicit priorities for hero and above-the-fold images.

--- a/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
+++ b/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
@@ -29,4 +29,14 @@ describe('getOptimizedImageProps', () => {
     expect(highPriority.fetchPriority).toBe('high')
     expect(eager.fetchPriority).toBeUndefined()
   })
+
+  it('translates Next priority metadata to native image loading hints', () => {
+    const prioritized = getOptimizedImageProps({ ...baseProps, priority: true })
+    const preloaded = getOptimizedImageProps({ ...baseProps, preload: true })
+
+    expect(prioritized.loading).toBe('eager')
+    expect(prioritized.fetchPriority).toBe('high')
+    expect(preloaded.loading).toBe('eager')
+    expect(preloaded.fetchPriority).toBe('high')
+  })
 })


### PR DESCRIPTION
## Summary
- preserve Next priority/preload metadata when shared OptimizedImage renders a native img
- emit explicit eager/high browser hints for above-the-fold hero images
- add regression coverage for both priority and preload paths

## Validation
- focused OptimizedImage test: passed
- 255 performance/route contract tests: passed
- app, web, smashers, and docs production builds: passed
- production browser probe: passed
- full shared UI suite remains blocked by the repository's pre-existing duplicate-React test-environment failures; changed test passes

Target: staging; keep this PR draft until hosted validation is green.