### PR TITLE
Promote staging -> main (2026-08-23)

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  ".": "1.2.25",
-  "apps/app": "1.1.11",
+  ".": "1.2.26",
+  "apps/app": "1.1.12",
   "apps/docs": "1.0.5",
   "apps/smashers": "1.0.8",
   "apps/template": "1.0.5",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.26](https://github.com/NiftyLeague/nifty-fe-monorepo/compare/nifty-fe-monorepo-v1.2.25...nifty-fe-monorepo-v1.2.26) (2026-08-23)
+
+
+### Performance
+
+* **app:** share lazy external image primitive ([3726a25](https://github.com/NiftyLeague/nifty-fe-monorepo/commit/3726a25027800b8b153cb48e33ee9a28e51ca489))
+
 ## [1.2.25](https://github.com/NiftyLeague/nifty-fe-monorepo/compare/nifty-fe-monorepo-v1.2.24...nifty-fe-monorepo-v1.2.25) (2026-08-23)
 
 

--- a/apps/app/CHANGELOG.md
+++ b/apps/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.12](https://github.com/NiftyLeague/nifty-fe-monorepo/compare/app-v1.1.11...app-v1.1.12) (2026-08-23)
+
+
+### Performance
+
+* **app:** share lazy external image primitive ([3726a25](https://github.com/NiftyLeague/nifty-fe-monorepo/commit/3726a25027800b8b153cb48e33ee9a28e51ca489))
+
 ## [1.1.11](https://github.com/NiftyLeague/nifty-fe-monorepo/compare/app-v1.1.10...app-v1.1.11) (2026-08-22)
 
 

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "type": "module",
   "private": true,
   "scripts": {

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.test.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.test.tsx
@@ -50,5 +50,6 @@ describe('DegenInternalImage', () => {
     const image = screen.getByRole('img', { name: 'Nifty Andy' })
     expect(image.getAttribute('src')).toBe('/media/avatar.webp')
     expect(image.getAttribute('loading')).toBe('lazy')
+    expect(image.getAttribute('fetchpriority')).toBe('low')
   })
 })

--- a/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.tsx
+++ b/apps/app/src/app/(private-routes)/dashboard/gamer-profile/_ImageProfile/DegenInternalImage.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import NativeImage from '@nl/ui/custom/native-image'
 import { ViewportVideo } from '@nl/ui/custom/viewport-video'
 import type { DashboardDegen } from '@/types/degens'
 
@@ -13,8 +14,7 @@ const DegenInternalImage = memo(({ degen }: { degen: DashboardDegen }) => {
   }
 
   // Profile media is API-provided and may come from a host that is not known at build time.
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={degen?.url} alt={alt} style={style} loading="lazy" decoding="async" />
+  return <NativeImage src={degen?.url} alt={alt} style={style} loading="lazy" />
 })
 
 DegenInternalImage.displayName = 'DegenInternalImage'

--- a/apps/app/src/components/cards/ImageCard.test.tsx
+++ b/apps/app/src/components/cards/ImageCard.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+mock.module('@/hooks/useImageOnLoad', () => ({
+  default: () => ({
+    handleImageOnLoad: () => undefined,
+    css: { thumbnail: {}, fullSize: {} },
+  }),
+}))
+
+let ImageCard: typeof import('./ImageCard').default
+
+beforeEach(async () => {
+  ImageCard = (await import('./ImageCard')).default
+})
+
+describe('ImageCard', () => {
+  it('keeps external marketplace media lazy through the shared image primitive', () => {
+    render(
+      <ImageCard
+        thumbnail="https://cdn.example.test/thumb.webp"
+        image="https://cdn.example.test/full.webp"
+        title="Marketplace item"
+        ratio={1}
+      />
+    )
+
+    const images = screen.getAllByRole('img')
+
+    expect(images).toHaveLength(2)
+    expect(images[0].getAttribute('alt')).toBe('thumbnail-Marketplace item')
+    expect(images[1].getAttribute('alt')).toBe('Marketplace item')
+
+    for (const image of images) {
+      expect(image.getAttribute('loading')).toBe('lazy')
+      expect(image.getAttribute('fetchpriority')).toBe('low')
+      expect(image.getAttribute('decoding')).toBe('async')
+    }
+  })
+})

--- a/apps/app/src/components/cards/ImageCard.tsx
+++ b/apps/app/src/components/cards/ImageCard.tsx
@@ -1,5 +1,6 @@
 import useImageOnLoad from '@/hooks/useImageOnLoad'
 import { AnimatedImage } from '@nl/ui/custom/animated-image'
+import NativeImage from '@nl/ui/custom/native-image'
 
 interface ImageCardProps {
   thumbnail?: string
@@ -22,10 +23,7 @@ const ImageCard = ({ image, imageWebp, thumbnail, title, ratio }: ImageCardProps
       style={{ ...styleImage.imageWrapper, paddingBottom: `${ratio * 100}%` }}
     >
       {thumbnail && (
-        // Marketplace media can be API-provided from arbitrary hosts, so it cannot use
-        // next/image until those hosts are explicitly configured.
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
+        <NativeImage
           onLoad={handleImageOnLoad}
           src={thumbnail}
           alt={`thumbnail-${title}`}
@@ -48,10 +46,7 @@ const ImageCard = ({ image, imageWebp, thumbnail, title, ratio }: ImageCardProps
             style={{ ...styleImage.imageCommon, ...css.fullSize }}
           />
         ) : (
-          // Marketplace media can be API-provided from arbitrary hosts, so it cannot use
-          // next/image until those hosts are explicitly configured.
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <NativeImage
             onLoad={handleImageOnLoad}
             src={image}
             alt={title}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nifty-fe-monorepo",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {

--- a/packages/ui/src/components/custom/optimized-image/index.tsx
+++ b/packages/ui/src/components/custom/optimized-image/index.tsx
@@ -10,10 +10,19 @@ export type OptimizedImageProps = ImageProps
 const imageConfig = process.env.__NEXT_IMAGE_OPTS as unknown as ImageConfigComplete
 
 export function getOptimizedImageProps(props: OptimizedImageProps) {
-  const imageProps = getImgProps(props, {
+  const { props: imageProps, meta } = getImgProps(props, {
     defaultLoader,
     imgConf: imageConfig,
-  }).props
+  })
+
+  // The native <img> renderer cannot consume Next's preload metadata. Carry
+  // its priority signal across as standard browser hints instead of silently
+  // dropping it when the shared primitive avoids the stateful next/image
+  // client component.
+  if (meta.preload) {
+    imageProps.loading ??= 'eager'
+    imageProps.fetchPriority ??= 'high'
+  }
 
   // Keep below-the-fold artwork from competing with the route's LCP resource.
   // Respect explicit priorities for hero and above-the-fold images.

--- a/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
+++ b/packages/ui/src/components/custom/optimized-image/optimized-image.test.tsx
@@ -29,4 +29,14 @@ describe('getOptimizedImageProps', () => {
     expect(highPriority.fetchPriority).toBe('high')
     expect(eager.fetchPriority).toBeUndefined()
   })
+
+  it('translates Next priority metadata to native image loading hints', () => {
+    const prioritized = getOptimizedImageProps({ ...baseProps, priority: true })
+    const preloaded = getOptimizedImageProps({ ...baseProps, preload: true })
+
+    expect(prioritized.loading).toBe('eager')
+    expect(prioritized.fetchPriority).toBe('high')
+    expect(preloaded.loading).toBe('eager')
+    expect(preloaded.fetchPriority).toBe('high')
+  })
 })


### PR DESCRIPTION
## Release promotion

Promotes the validated staging line to main.

Included focused change:
- preserve priority/preload image hints in the shared OptimizedImage primitive

Staging validation for the source PR passed format, lint, type-check, build, unit, aggregate gate, and Vercel review.

Merge policy: rebase into main after required checks pass.