### PR TITLE
perf(web): defer roadmap catalog

### DIFF
--- a/apps/web/src/components/RoadmapTimeline/RoadmapTimelineCards.tsx
+++ b/apps/web/src/components/RoadmapTimeline/RoadmapTimelineCards.tsx
@@ -1,14 +1,37 @@
 'use client'
 
-import { ROADMAP_CARDS } from './constants'
+import { DeferredComponent } from '@nl/ui/custom/deferred-component'
+import { DeferredSectionLoading } from '@nl/ui/custom/deferred-section'
 import RoadmapCard from './roadmapCard'
+
+const loadRoadmapCardCatalog = async () => {
+  const { ROADMAP_CARDS } = await import('./constants')
+
+  return {
+    default: function RoadmapCardCatalog() {
+      return (
+        <>
+          {ROADMAP_CARDS.map((item) => (
+            <RoadmapCard key={item.title.toString()} {...item} />
+          ))}
+        </>
+      )
+    },
+  }
+}
 
 export default function RoadmapTimelineCards() {
   return (
-    <>
-      {ROADMAP_CARDS.slice(1).map((item) => (
-        <RoadmapCard key={item.title.toString()} {...item} />
-      ))}
-    </>
+    <DeferredComponent
+      label="Additional roadmap milestones"
+      load={loadRoadmapCardCatalog}
+      props={{}}
+      loadingFallback={
+        <DeferredSectionLoading
+          label="additional roadmap milestones"
+          minHeightClassName="min-h-[1200rem]"
+        />
+      }
+    />
   )
 }

--- a/apps/web/src/components/RoadmapTimeline/constants.tsx
+++ b/apps/web/src/components/RoadmapTimeline/constants.tsx
@@ -1,39 +1,9 @@
 import OptimizedImage from '@nl/ui/custom/optimized-image'
 import styles from './index.module.css'
-import { DEGEN_COLLECTION_URL } from '@/constants/degen-assets'
 
 const COMIC_THUMBNAIL_SIZES = '(max-width: 767px) 50vw, 250px'
 
 export const ROADMAP_CARDS = [
-  {
-    completed: true,
-    completionDate: 'Sept 24th - 30th, 2021',
-    image: {
-      height: 350,
-      src: '/img/mint-o-matic/creation.webp',
-      style: { top: '-90px' },
-      width: 661,
-    },
-    title: 'DEGEN Minting',
-    body: (
-      <p className="mb-0">
-        Nifty League{' '}
-        <strong>
-          <a href={DEGEN_COLLECTION_URL} target="_blank" rel="noreferrer">
-            DEGEN NFTs
-          </a>
-        </strong>{' '}
-        were brought to life by our community in Sept 2021. The minting process was a one-of-a-kind
-        spectacle that allowed minters the ability to design their own DEGEN using Satoshi&apos;s{' '}
-        <strong>
-          <a href="https://app.niftyleague.com/mint-o-matic" target="_blank" rel="noreferrer">
-            Mint-O-Matic
-          </a>
-        </strong>
-        !
-      </p>
-    ),
-  },
   {
     completed: true,
     completionDate: 'Sept 24th, 2021',

--- a/apps/web/src/components/RoadmapTimeline/first-card.tsx
+++ b/apps/web/src/components/RoadmapTimeline/first-card.tsx
@@ -1,0 +1,31 @@
+import { DEGEN_COLLECTION_URL } from '@/constants/degen-assets'
+
+export const FIRST_ROADMAP_CARD = {
+  completed: true,
+  completionDate: 'Sept 24th - 30th, 2021',
+  image: {
+    height: 350,
+    src: '/img/mint-o-matic/creation.webp',
+    style: { top: '-90px' },
+    width: 661,
+  },
+  title: 'DEGEN Minting',
+  body: (
+    <p className="mb-0">
+      Nifty League{' '}
+      <strong>
+        <a href={DEGEN_COLLECTION_URL} target="_blank" rel="noreferrer">
+          DEGEN NFTs
+        </a>
+      </strong>{' '}
+      were brought to life by our community in Sept 2021. The minting process was a one-of-a-kind
+      spectacle that allowed minters the ability to design their own DEGEN using Satoshi&apos;s{' '}
+      <strong>
+        <a href="https://app.niftyleague.com/mint-o-matic" target="_blank" rel="noreferrer">
+          Mint-O-Matic
+        </a>
+      </strong>
+      !
+    </p>
+  ),
+}

--- a/apps/web/src/components/RoadmapTimeline/index.tsx
+++ b/apps/web/src/components/RoadmapTimeline/index.tsx
@@ -1,14 +1,12 @@
 import RoadmapCard from './roadmapCard'
-import { ROADMAP_CARDS } from './constants'
 import DeferredRoadmapCards from './DeferredRoadmapCards'
+import { FIRST_ROADMAP_CARD } from './first-card'
 import styles from './index.module.css'
 
 const RoadmapTimeline = () => {
-  const firstCard = ROADMAP_CARDS[0]
-
   return (
     <section id={styles.cd_timeline} className={styles.cd_container}>
-      {firstCard ? <RoadmapCard key={firstCard.title.toString()} {...firstCard} /> : null}
+      <RoadmapCard key={FIRST_ROADMAP_CARD.title} {...FIRST_ROADMAP_CARD} />
       <DeferredRoadmapCards />
     </section>
   )

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1969,6 +1969,33 @@ describe('web marketing image sizing contract', () => {
     )
   })
 
+  it('keeps the first roadmap milestone separate from deferred catalog data', () => {
+    const timelineSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/RoadmapTimeline/index.tsx'),
+      'utf8'
+    )
+    const firstCardSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/RoadmapTimeline/first-card.tsx'),
+      'utf8'
+    )
+    const deferredCardsSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/RoadmapTimeline/RoadmapTimelineCards.tsx'),
+      'utf8'
+    )
+    const catalogSource = readFileSync(
+      join(process.cwd(), 'apps/web/src/components/RoadmapTimeline/constants.tsx'),
+      'utf8'
+    )
+
+    expect(timelineSource).toContain("from './first-card'")
+    expect(timelineSource).not.toContain("from './constants'")
+    expect(firstCardSource).toContain("title: 'DEGEN Minting'")
+    expect(catalogSource).not.toContain("from './first-card'")
+    expect(deferredCardsSource).toContain("import('./constants')")
+    expect(deferredCardsSource).toContain('ROADMAP_CARDS.map')
+    expect(deferredCardsSource).toContain('DeferredComponent')
+  })
+
   it('keeps the Community hero preload focused on its primary artwork', () => {
     const communitySource = readFileSync(join(process.cwd(), webCommunityPage), 'utf8')
 


### PR DESCRIPTION
## Summary
- keep the first roadmap milestone in the initial server-rendered path
- defer the remaining roadmap catalog until the existing viewport boundary is reached
- use the shared accessible deferred component/loading boundary
- add a contract guard for the split so the catalog cannot re-enter the initial route graph accidentally

## Validation
- `mise exec -- bun test test/contract`
- `mise exec -- bunx turbo run build --force --output-logs=errors-only`
- `mise exec -- bunx tsc --noEmit` (apps/web)
- `mise exec -- bunx eslint ... --max-warnings 0` (roadmap files)
- production smoke: `/` and `/roadmap` returned 200; initial `/roadmap` HTML contains the first card and not the deferred catalog
