### PR TITLE
Promote staging -> main (2026-08-23)

### DIFF
--- a/apps/web/src/components/HomeBelowFold.tsx
+++ b/apps/web/src/components/HomeBelowFold.tsx
@@ -1,9 +1,0 @@
-'use client'
-
-export { default as HomeCommunitySection } from './HomeSections/HomeCommunitySection'
-export { default as HomeCompeteSection } from './HomeSections/HomeCompeteSection'
-export { default as HomeDashboardSection } from './HomeSections/HomeDashboardSection'
-export { default as HomeDegensSection } from './HomeSections/HomeDegensSection'
-export { default as HomeNiftyWorldSection } from './HomeSections/HomeNiftyWorldSection'
-export { default as HomeSponsorsSection } from './HomeSections/HomeSponsorsSection'
-export { default as HomeTokenSection } from './HomeSections/HomeTokenSection'

--- a/apps/web/src/components/HomeSections/HomeDegensSection.test.tsx
+++ b/apps/web/src/components/HomeSections/HomeDegensSection.test.tsx
@@ -25,9 +25,9 @@ mock.module('@/components/BouncingNFTL', () => ({
   default: () => null,
 }))
 
-describe('HomeBelowFold', () => {
+describe('HomeDegensSection', () => {
   it('preserves responsive labels inside the deferred DEGEN section', async () => {
-    const { HomeDegensSection } = await import('./HomeBelowFold')
+    const { default: HomeDegensSection } = await import('./HomeDegensSection')
 
     render(<HomeDegensSection />)
 

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -54,10 +54,10 @@
   position: relative;
 }
 
-/* Keep the long marketing page cheap to render before a section is close to
- * the viewport. The intrinsic size preserves scroll position and the existing
- * IntersectionObserver-driven sections still hydrate as they approach. */
-.home-pg > section:not(#gaming-section) {
+/* Keep the long marketing page cheap to render before a deferred boundary is
+ * close to the viewport. The boundary is a wrapper div, not the loaded
+ * section itself, so containment remains active after the section hydrates. */
+.home-pg .deferred-section {
   content-visibility: auto;
   contain-intrinsic-size: auto 800px;
 }

--- a/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
+++ b/packages/ui/src/components/custom/deferred-section/deferred-section.test.tsx
@@ -18,6 +18,7 @@ describe('DeferredSection', () => {
 
     expect(screen.getByRole('status', { name: 'Loading Game details' })).toBeTruthy()
     expect(container.firstElementChild?.getAttribute('aria-busy')).toBe('true')
+    expect(container.firstElementChild?.classList.contains('deferred-section')).toBe(true)
     expect(screen.getAllByRole('status').length).toBe(1)
     expect(useOnScreen).toHaveBeenCalledWith(expect.anything(), '160px', { once: true })
   })

--- a/packages/ui/src/components/custom/deferred-section/index.tsx
+++ b/packages/ui/src/components/custom/deferred-section/index.tsx
@@ -55,7 +55,7 @@ export const DeferredSection = memo(function DeferredSection({
   } = useDeferredComponent(load, isNearViewport)
 
   return (
-    <div ref={sectionRef} aria-busy={!LoadedSection && !loadError}>
+    <div ref={sectionRef} className="deferred-section" aria-busy={!LoadedSection && !loadError}>
       {loadError ? (
         <div
           className={`flex ${minHeightClassName ?? 'min-h-48'} flex-col items-center justify-center gap-3`}

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1652,10 +1652,7 @@ describe('shared below-fold loading contract', () => {
   it('defers below-fold marketing interaction without clipping visual effects', () => {
     const pageSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
     const deferredSource = readFileSync(join(process.cwd(), webDeferredHomeSections), 'utf8')
-    const homeBelowFoldSource = readFileSync(
-      join(process.cwd(), 'apps/web/src/components/HomeBelowFold.tsx'),
-      'utf8'
-    )
+    const sharedDeferredSource = readFileSync(join(process.cwd(), sharedDeferredSection), 'utf8')
     const homeSectionNames = [
       'HomeDegensSection',
       'HomeCompeteSection',
@@ -1683,10 +1680,11 @@ describe('shared below-fold loading contract', () => {
     expect(pageSource).not.toContain("from '@/components/Carousel'")
     expect(pageSource).not.toContain("from '@/components/Carousel/DegenCardItem'")
     expect(deferredSource).not.toContain("import('@/components/HomeBelowFold')")
+    expect(existsSync(join(process.cwd(), 'apps/web/src/components/HomeBelowFold.tsx'))).toBe(false)
+    expect(sharedDeferredSource).toContain('className="deferred-section"')
     for (const section of homeSectionNames) {
       expect(deferredSource).toContain(`import('@/components/HomeSections/${section}')`)
     }
-    expect(homeBelowFoldSource).toContain('export { default as HomeDegensSection }')
     expect(homeSectionSources).toContain("import('@/components/MintOMatic')")
     expect(homeSectionSources).toContain("import('@/components/Sponsors')")
     expect(homeSectionSources).not.toContain("from '@/constants/sponsors'")
@@ -1694,6 +1692,7 @@ describe('shared below-fold loading contract', () => {
     expect(homeSectionSources).toContain("from '@nl/ui/custom/deferred-section'")
     expect(pageSource).not.toContain('home-below-fold')
     expect(homeStyles).not.toContain('.home-below-fold')
+    expect(homeStyles).toContain('.home-pg .deferred-section')
     expect(homeStyles).toContain('content-visibility: auto')
     expect(homeStyles).toContain('contain-intrinsic-size: auto 800px')
   })


### PR DESCRIPTION
## Environment promotion

Promote the validated `staging` environment into `main`. This is a deployment-promotion PR, not the version-release PR.

- **Source:** `staging`
- **Target:** `main`
- **Changes:** 1 focused performance change
- **Commit:** `f6910e20` (`perf(web): restore deferred below-fold containment`)

### Validation

- Local contract suite: 472 passed
- Affected web/app production builds passed
- Web/app TypeScript checks and lint passed
- Production smoke passed for `/`, `/games`, `/degens`, `/roadmap`, `/overview`, `/niftyworld`, and `/gltf/1`
- Required PR format, lint, type-check, build, unit, gate, and Vercel review checks passed on PR #1050
- The automated release-PR creator failed separately with a `Bad credentials` error, so this promotion PR was created manually after verifying the exact branch diff.

Merge this promotion using the repository-configured **rebase** method. After merge, Release Please should open the separate versioned release PR.