### PR TITLE
chore(deps): prune unused build dependencies

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.2",
-    "@docusaurus/tsconfig": "^3.10.2",
     "@docusaurus/types": "^3.10.2",
     "@types/node": "^26.2.0",
     "@types/react": "19.2.18",

--- a/bun.lock
+++ b/bun.lock
@@ -8,13 +8,11 @@
         "@happy-dom/global-registrator": "^20.11.2",
         "@nl/eslint-config": "workspace:*",
         "@nl/typescript-config": "workspace:*",
-        "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.4",
         "@types/node": "^26.2.0",
         "eslint": "^10.8.1",
         "prettier": "^3.9.6",
-        "semver": "^7.8.5",
         "syncpack": "^15.3.3",
         "turbo": "^2.10.10",
         "typescript": "~6.0.3",
@@ -117,7 +115,6 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.2",
-        "@docusaurus/tsconfig": "^3.10.2",
         "@docusaurus/types": "^3.10.2",
         "@types/node": "^26.2.0",
         "@types/react": "19.2.18",
@@ -801,8 +798,6 @@
     "@docusaurus/theme-search-algolia": ["@docusaurus/theme-search-algolia@3.10.2", "", { "dependencies": { "@algolia/autocomplete-core": "^1.19.2", "@docsearch/react": "^3.9.0 || ^4.3.2", "@docusaurus/core": "3.10.2", "@docusaurus/logger": "3.10.2", "@docusaurus/plugin-content-docs": "3.10.2", "@docusaurus/theme-common": "3.10.2", "@docusaurus/theme-translations": "3.10.2", "@docusaurus/utils": "3.10.2", "@docusaurus/utils-validation": "3.10.2", "algoliasearch": "^5.37.0", "algoliasearch-helper": "^3.26.0", "clsx": "^2.0.0", "eta": "^2.2.0", "fs-extra": "^11.1.1", "lodash": "^4.17.21", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg=="],
 
     "@docusaurus/theme-translations": ["@docusaurus/theme-translations@3.10.2", "", { "dependencies": { "fs-extra": "^11.1.1", "tslib": "^2.6.0" } }, "sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA=="],
-
-    "@docusaurus/tsconfig": ["@docusaurus/tsconfig@3.10.2", "", {}, "sha512-5GiB7h/nFsMFPO9mCqcRNE1yA5TSXXNCshNIgHPL6fCPOjcTDixs6qjQBu8ddkgPcicwCvOA7n3jeK2rGdJk6g=="],
 
     "@docusaurus/types": ["@docusaurus/types@3.10.2", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/history": "^4.7.11", "@types/mdast": "^4.0.2", "@types/react": "*", "commander": "^5.1.0", "joi": "^17.9.2", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "utility-types": "^3.10.0", "webpack": "^5.95.0", "webpack-merge": "^5.9.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,13 +31,11 @@
     "@happy-dom/global-registrator": "^20.11.2",
     "@nl/eslint-config": "workspace:*",
     "@nl/typescript-config": "workspace:*",
-    "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.4",
     "@types/node": "^26.2.0",
     "eslint": "^10.8.1",
     "prettier": "^3.9.6",
-    "semver": "^7.8.5",
     "syncpack": "^15.3.3",
     "turbo": "^2.10.10",
     "typescript": "~6.0.3"


### PR DESCRIPTION
## Summary
- remove unused root build/dev dependencies
- remove the unused Docusaurus tsconfig package
- keep the lockfile aligned without changing runtime/config dependencies

## Validation
- `bun install --frozen-lockfile`
- `bun test --isolate test/contract/dependencies.test.ts`
- `bunx tsc --noEmit -p apps/docs/tsconfig.json`
- `bunx turbo run docs#build --force`
- `bunx prettier --check package.json apps/docs/package.json`
- `git diff --check`

Known unrelated local gate:
- `bunx syncpack lint` reports existing exact-version override/range mismatches in the root `overrides` block; this PR does not modify those entries.
