### PR TITLE
refactor(app): remove stale leaderboard sorting

### DIFF
--- a/apps/app/src/types/leaderboard.ts
+++ b/apps/app/src/types/leaderboard.ts
@@ -54,8 +54,6 @@ export enum TimeFilter {
 
 export type LeaderboardGame = { key: string; display: Game; tables: TableType[] }
 
-export type Order = 'asc' | 'desc'
-
 export interface EnhancedTableProps {
   rows: TableRowType[]
   handleCheckYourRank: React.MouseEventHandler<HTMLSpanElement>

--- a/apps/app/src/utils/leaderboard.test.ts
+++ b/apps/app/src/utils/leaderboard.test.ts
@@ -9,8 +9,6 @@ let fetchRankByUserId: typeof import('./leaderboard').fetchRankByUserId
 let fetchClientScores: typeof import('./leaderboard').fetchScores
 let fetchScores: typeof import('./leaderboard-server').fetchScores
 let fetchUserNames: typeof import('./leaderboard-server').fetchUserNames
-let getComparator: typeof import('./leaderboard').getComparator
-let stableSort: typeof import('./leaderboard').stableSort
 
 beforeEach(async () => {
   mock.module('@/constants/leaderboards/data', () => {
@@ -44,8 +42,6 @@ beforeEach(async () => {
   fetchClientScores = leaderboard.fetchScores
   fetchScores = leaderboardServer.fetchScores
   fetchUserNames = leaderboardServer.fetchUserNames
-  getComparator = leaderboard.getComparator
-  stableSort = leaderboard.stableSort
 })
 
 afterEach(() => undefined)
@@ -121,26 +117,5 @@ describe('leaderboard data loaders', () => {
     const error = new Error('offline')
     stubGlobal('fetch', mock().mockRejectedValue(error))
     await expect(fetchRankByUserId('user-1', 'smashers', 'wins', 'week')).resolves.toBe(error)
-  })
-})
-
-describe('leaderboard ordering', () => {
-  const rows = [
-    { rank: 2, user_id: 'b', score: '2', stats: { score: '2', wins: '3' } },
-    { rank: 1, user_id: 'a', score: '2', stats: { score: '2', wins: '7' } },
-    { rank: 3, user_id: 'c', score: '1', stats: { score: '1', wins: '7' } },
-  ]
-
-  it('supports rank and statistic comparators in both directions', () => {
-    expect(
-      stableSort(rows as never, getComparator('asc', 'rank' as never)).map((row) => row.rank)
-    ).toEqual([1, 2, 3])
-    expect(
-      stableSort(rows as never, getComparator('desc', 'wins' as never)).map((row) => row.user_id)
-    ).toEqual(['a', 'c', 'b'])
-  })
-
-  it('preserves source order when the comparator reports a tie', () => {
-    expect(stableSort(rows, () => 0).map((row) => row.user_id)).toEqual(['b', 'a', 'c'])
   })
 })

--- a/apps/app/src/utils/leaderboard.ts
+++ b/apps/app/src/utils/leaderboard.ts
@@ -1,4 +1,4 @@
-import type { DataType, Order, ReturnDataType } from '@/types/leaderboard'
+import type { ReturnDataType } from '@/types/leaderboard'
 import { GET_RANK_BY_USER_ID_API } from '@/constants/url'
 
 export const fetchScores = async (
@@ -20,41 +20,6 @@ export const fetchScores = async (
   )
   if (!response.ok) throw new Error('Unable to load leaderboard')
   return response.json()
-}
-
-function descendingComparator(a: DataType, b: DataType, orderBy: keyof DataType['stats']) {
-  const [numberOfA, numberOfB] =
-    orderBy !== 'rank'
-      ? [parseFloat(a.stats[orderBy]), parseFloat(b.stats[orderBy])]
-      : [a.rank, b.rank]
-  if (numberOfB < numberOfA) {
-    return -1
-  }
-  if (numberOfB > numberOfA) {
-    return 1
-  }
-  return 0
-}
-
-export const getComparator = <Key extends keyof unknown>(
-  order: Order,
-  orderBy: Key
-): ((a: DataType, b: DataType) => number) => {
-  return order === 'desc'
-    ? (a, b) => descendingComparator(a, b, orderBy)
-    : (a, b) => -descendingComparator(a, b, orderBy)
-}
-
-export const stableSort = <T>(array: readonly T[], comparator: (a: T, b: T) => number): T[] => {
-  const stabilizedThis = array.map((el, index) => [el, index] as [T, number])
-  stabilizedThis.sort((a, b) => {
-    const order = comparator(a[0], b[0])
-    if (order !== 0) {
-      return order
-    }
-    return a[1] - b[1]
-  })
-  return stabilizedThis.map((el) => el[0])
 }
 
 export const fetchRankByUserId = async (


### PR DESCRIPTION
## Summary
- remove unused client-side leaderboard comparator and stable-sort helpers
- remove the now-unused Order type and obsolete ordering tests
- keep the active API loaders and rank lookup behavior unchanged

## Validation
- app focused leaderboard test
- app lint
- app type-check
- Prettier check

This PR is intentionally focused and draft until the broader release validation is complete.