### PR TITLE
perf(web): keep static home sections on server

### DIFF
--- a/apps/web/src/app/(main)/page.test.tsx
+++ b/apps/web/src/app/(main)/page.test.tsx
@@ -71,11 +71,13 @@ describe('home page', () => {
     expect(document.getElementById('gaming-section')).not.toBeNull()
   })
 
-  it('defers below-the-fold section markup behind accessible loading boundaries', () => {
+  it('keeps interactive sections deferred while server-rendering static sections', () => {
     render(<Home />)
 
     expect(screen.queryByText('OWN YOUR AVATAR')).toBeNull()
     expect(screen.queryByText('COMMUNITY-GENERATED AVATARS')).toBeNull()
+    expect(screen.getByRole('heading', { name: 'DASHBOARDS' })).not.toBeNull()
+    expect(screen.getByRole('heading', { name: 'COMMUNITY' })).not.toBeNull()
     expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
   })
 

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -5,14 +5,14 @@ import OptimizedImage, { getOptimizedImageProps } from '@nl/ui/custom/optimized-
 import { DesktopOnlyImage, MobileOnlyImage } from '@nl/ui/custom/responsive-only-image'
 
 import {
-  DeferredHomeCommunity,
   DeferredHomeCompete,
-  DeferredHomeDashboard,
   DeferredHomeDegens,
-  DeferredHomeNiftyWorld,
-  DeferredHomeSponsors,
   DeferredHomeToken,
 } from '@/components/DeferredHomeSections'
+import HomeCommunitySection from '@/components/HomeSections/HomeCommunitySection'
+import HomeDashboardSection from '@/components/HomeSections/HomeDashboardSection'
+import HomeNiftyWorldSection from '@/components/HomeSections/HomeNiftyWorldSection'
+import HomeSponsorsSection from '@/components/HomeSections/HomeSponsorsSection'
 import MainLayout from '@/components/MainLayout'
 import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 import { DEGEN_COLLECTION_URL } from '@/constants/degen-assets'
@@ -246,11 +246,11 @@ const Home = () => {
 
       <DeferredHomeDegens />
       <DeferredHomeCompete />
-      <DeferredHomeNiftyWorld />
-      <DeferredHomeDashboard />
+      <HomeNiftyWorldSection />
+      <HomeDashboardSection />
       <DeferredHomeToken />
-      <DeferredHomeCommunity />
-      <DeferredHomeSponsors />
+      <HomeCommunitySection />
+      <HomeSponsorsSection />
     </MainLayout>
   )
 }

--- a/apps/web/src/components/DeferredHomeSections.tsx
+++ b/apps/web/src/components/DeferredHomeSections.tsx
@@ -4,11 +4,7 @@ import { DeferredSection } from '@nl/ui/custom/deferred-section'
 
 const loadHomeDegens = () => import('@/components/HomeSections/HomeDegensSection')
 const loadHomeCompete = () => import('@/components/HomeSections/HomeCompeteSection')
-const loadHomeNiftyWorld = () => import('@/components/HomeSections/HomeNiftyWorldSection')
-const loadHomeDashboard = () => import('@/components/HomeSections/HomeDashboardSection')
 const loadHomeToken = () => import('@/components/HomeSections/HomeTokenSection')
-const loadHomeCommunity = () => import('@/components/HomeSections/HomeCommunitySection')
-const loadHomeSponsors = () => import('@/components/HomeSections/HomeSponsorsSection')
 
 export function DeferredHomeDegens() {
   return (
@@ -30,52 +26,12 @@ export function DeferredHomeCompete() {
   )
 }
 
-export function DeferredHomeNiftyWorld() {
-  return (
-    <DeferredSection
-      label="NiftyWorld section"
-      load={loadHomeNiftyWorld}
-      minHeightClassName="min-h-[32rem]"
-    />
-  )
-}
-
-export function DeferredHomeDashboard() {
-  return (
-    <DeferredSection
-      label="dashboard section"
-      load={loadHomeDashboard}
-      minHeightClassName="min-h-[32rem]"
-    />
-  )
-}
-
 export function DeferredHomeToken() {
   return (
     <DeferredSection
       label="NFTL token section"
       load={loadHomeToken}
       minHeightClassName="min-h-[32rem]"
-    />
-  )
-}
-
-export function DeferredHomeCommunity() {
-  return (
-    <DeferredSection
-      label="community section"
-      load={loadHomeCommunity}
-      minHeightClassName="min-h-[32rem]"
-    />
-  )
-}
-
-export function DeferredHomeSponsors() {
-  return (
-    <DeferredSection
-      label="sponsors section"
-      load={loadHomeSponsors}
-      minHeightClassName="min-h-[28rem]"
     />
   )
 }

--- a/apps/web/src/components/HomeSections/HomeCommunitySection.tsx
+++ b/apps/web/src/components/HomeSections/HomeCommunitySection.tsx
@@ -1,11 +1,9 @@
-'use client'
-
 import OptimizedImage from '@nl/ui/custom/optimized-image'
 import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 
 export default function HomeCommunitySection() {
   return (
-    <section className="section container relative flex flex-row flex-wrap items-center">
+    <section className="home-static-section section container relative flex flex-row flex-wrap items-center">
       <div className="w-full md:w-1/2 flex justify-center md:justify-start">
         <div className="relative flex-grow transition-quick-pop home-community-image">
           <OptimizedImage

--- a/apps/web/src/components/HomeSections/HomeDashboardSection.tsx
+++ b/apps/web/src/components/HomeSections/HomeDashboardSection.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import OptimizedImage from '@nl/ui/custom/optimized-image'
 import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 
@@ -7,7 +5,7 @@ import { DEGEN_COLLECTION_URL } from '@/constants/degen-assets'
 
 export default function HomeDashboardSection() {
   return (
-    <section className="section w-screen relative">
+    <section className="home-static-section section w-screen relative">
       <div className="relative flex-grow transition-fade">
         <OptimizedImage
           src="/img/misc/dashboard.webp"

--- a/apps/web/src/components/HomeSections/HomeNiftyWorldSection.tsx
+++ b/apps/web/src/components/HomeSections/HomeNiftyWorldSection.tsx
@@ -1,11 +1,9 @@
-'use client'
-
 import OptimizedImage from '@nl/ui/custom/optimized-image'
 import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 
 export default function HomeNiftyWorldSection() {
   return (
-    <section className="container section relative flex flex-row flex-wrap items-center">
+    <section className="home-static-section container section relative flex flex-row flex-wrap items-center">
       <div className="w-full md:w-1/2">
         <div className="transition-fade">
           <OptimizedImage

--- a/apps/web/src/components/HomeSections/HomeSponsorsSection.tsx
+++ b/apps/web/src/components/HomeSections/HomeSponsorsSection.tsx
@@ -1,19 +1,12 @@
-'use client'
-
-import { DeferredSection } from '@nl/ui/custom/deferred-section'
 import { ThemeButtonGroup } from '@nl/ui/custom/theme-button-group'
 
-const loadSponsors = () => import('@/components/Sponsors')
-
-function DeferredSponsors() {
-  return <DeferredSection label="sponsors" load={loadSponsors} minHeightClassName="min-h-[22rem]" />
-}
+import Sponsors from '@/components/Sponsors'
 
 export default function HomeSponsorsSection() {
   return (
-    <section className="section w-screen relative text-center">
+    <section className="home-static-section section w-screen relative text-center">
       <h2 className="my-3 lg:my-5 section-heading transition-vertical-fade">PROUDLY BACKED BY</h2>
-      <DeferredSponsors />
+      <Sponsors />
       <ThemeButtonGroup
         primary={{ href: '/careers', title: 'JOIN THE TEAM' }}
         secondary={{

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -54,10 +54,10 @@
   position: relative;
 }
 
-/* Keep the long marketing page cheap to render before a deferred boundary is
- * close to the viewport. The boundary is a wrapper div, not the loaded
- * section itself, so containment remains active after the section hydrates. */
-.home-pg .deferred-section {
+/* Keep the long marketing page cheap to render before a deferred boundary or
+ * server-rendered static section is close to the viewport. */
+.home-pg .deferred-section,
+.home-pg .home-static-section {
   content-visibility: auto;
   contain-intrinsic-size: auto 800px;
 }

--- a/test/contract/route-surface.test.ts
+++ b/test/contract/route-surface.test.ts
@@ -1653,16 +1653,14 @@ describe('shared below-fold loading contract', () => {
     const pageSource = readFileSync(join(process.cwd(), webHomePage), 'utf8')
     const deferredSource = readFileSync(join(process.cwd(), webDeferredHomeSections), 'utf8')
     const sharedDeferredSource = readFileSync(join(process.cwd(), sharedDeferredSection), 'utf8')
-    const homeSectionNames = [
-      'HomeDegensSection',
-      'HomeCompeteSection',
+    const deferredHomeSectionNames = ['HomeDegensSection', 'HomeCompeteSection', 'HomeTokenSection']
+    const staticHomeSectionNames = [
       'HomeNiftyWorldSection',
       'HomeDashboardSection',
-      'HomeTokenSection',
       'HomeCommunitySection',
       'HomeSponsorsSection',
     ]
-    const homeSectionSources = homeSectionNames
+    const homeSectionSources = [...deferredHomeSectionNames, ...staticHomeSectionNames]
       .map((section) =>
         readFileSync(
           join(process.cwd(), `apps/web/src/components/HomeSections/${section}.tsx`),
@@ -1673,7 +1671,6 @@ describe('shared below-fold loading contract', () => {
     const homeStyles = readFileSync(join(process.cwd(), 'apps/web/src/styles/home.css'), 'utf8')
 
     expect(pageSource).toContain('DeferredHomeToken')
-    expect(pageSource).toContain('DeferredHomeSponsors')
     expect(pageSource).toContain('DeferredHomeDegens')
     expect(pageSource).not.toContain("import('@/components/MintOMatic')")
     expect(pageSource).not.toContain("import('@/components/Sponsors')")
@@ -1682,17 +1679,27 @@ describe('shared below-fold loading contract', () => {
     expect(deferredSource).not.toContain("import('@/components/HomeBelowFold')")
     expect(existsSync(join(process.cwd(), 'apps/web/src/components/HomeBelowFold.tsx'))).toBe(false)
     expect(sharedDeferredSource).toContain('className="deferred-section"')
-    for (const section of homeSectionNames) {
+    for (const section of deferredHomeSectionNames) {
       expect(deferredSource).toContain(`import('@/components/HomeSections/${section}')`)
     }
+    for (const section of staticHomeSectionNames) {
+      expect(deferredSource).not.toContain(`import('@/components/HomeSections/${section}')`)
+      expect(
+        readFileSync(
+          join(process.cwd(), `apps/web/src/components/HomeSections/${section}.tsx`),
+          'utf8'
+        )
+      ).not.toContain("'use client'")
+    }
     expect(homeSectionSources).toContain("import('@/components/MintOMatic')")
-    expect(homeSectionSources).toContain("import('@/components/Sponsors')")
+    expect(homeSectionSources).toContain("from '@/components/Sponsors'")
     expect(homeSectionSources).not.toContain("from '@/constants/sponsors'")
     expect(homeSectionSources).toContain("import('@/components/CommunityDegenCarousel')")
     expect(homeSectionSources).toContain("from '@nl/ui/custom/deferred-section'")
     expect(pageSource).not.toContain('home-below-fold')
     expect(homeStyles).not.toContain('.home-below-fold')
     expect(homeStyles).toContain('.home-pg .deferred-section')
+    expect(homeStyles).toContain('.home-pg .home-static-section')
     expect(homeStyles).toContain('content-visibility: auto')
     expect(homeStyles).toContain('contain-intrinsic-size: auto 800px')
   })


### PR DESCRIPTION
## Summary
- remove four non-interactive homepage sections from the client viewport-loader graph
- keep degen, compete, and NFTL interactive sections deferred
- preserve below-fold paint containment and add regression coverage for server/client boundaries

## Performance evidence
- homepage root client scripts: 590,886 bytes → 437,991 bytes locally (-25.9%)
- static home section chunks no longer appear in the browser chunk graph

## Validation
- web lint and type-check
- web unit suite
- route-surface contract suite
- web production build
- Prettier and diff checks

This is draft until the focused local evidence is reviewed; it will be marked ready before hosted validation.